### PR TITLE
jf/dataPrefetcherfromWSH

### DIFF
--- a/Common/src/Injection/ServiceCollectionExt.cs
+++ b/Common/src/Injection/ServiceCollectionExt.cs
@@ -87,7 +87,7 @@ public static class ServiceCollectionExt
               .AddOption<Components>(configuration,
                                      Components.SettingSection)
               .AddSingletonWithHealthCheck<GrpcChannelProvider>(nameof(GrpcChannelProvider))
-              .AddSingletonWithHealthCheck<IWorkerStreamHandler, WorkerStreamHandler>(nameof(WorkerStreamHandler));
+              .AddSingleton<IWorkerStreamHandler, WorkerStreamHandler>();
     }
 
     return services;

--- a/Common/src/Injection/ServiceCollectionExt.cs
+++ b/Common/src/Injection/ServiceCollectionExt.cs
@@ -86,7 +86,7 @@ public static class ServiceCollectionExt
               .AddSingleton(computePlanOptions.GrpcChannel)
               .AddOption<Components>(configuration,
                                      Components.SettingSection)
-              .AddSingletonWithHealthCheck<GrpcChannelProvider>(nameof(GrpcChannelProvider))
+              .AddSingletonWithHealthCheck<IGrpcChannelProvider,GrpcChannelProvider>(nameof(GrpcChannelProvider))
               .AddSingleton<IWorkerStreamHandler, WorkerStreamHandler>();
     }
 

--- a/Common/src/Pollster/DataPrefetcher.cs
+++ b/Common/src/Pollster/DataPrefetcher.cs
@@ -79,7 +79,11 @@ public class DataPrefetcher : IInitializable
 
     activity?.AddEvent(new ActivityEvent("Load payload"));
 
-    var payloadChunks = await payloadStorage.GetValuesAsync(taskData.TaskId,
+    var taskId = taskData.RetryOfIds.Count > 0
+                   ? taskData.RetryOfIds.First()
+                   : taskData.TaskId;
+
+    var payloadChunks = await payloadStorage.GetValuesAsync(taskId,
                                                             cancellationToken)
                                             .Select(bytes => UnsafeByteOperations.UnsafeWrap(bytes))
                                             .ToListAsync(cancellationToken)

--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -144,11 +144,6 @@ public class Pollster
             {
               var taskData = precondition;
 
-              logger_.LogDebug("Start prefetch data");
-              var computeRequestStream = await dataPrefetcher_.PrefetchDataAsync(taskData,
-                                                                                 cancellationToken)
-                                                              .ConfigureAwait(false);
-
               logger_.LogDebug("Start a new Task to process the messageHandler");
               using var requestProcessor = new RequestProcessor(workerStreamHandler_,
                                                                 objectStorageFactory_,
@@ -159,7 +154,6 @@ public class Pollster
 
               var processResult = await requestProcessor.ProcessAsync(message,
                                                                       taskData,
-                                                                      computeRequestStream,
                                                                       cancellationToken)
                                                         .ConfigureAwait(false);
 

--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -92,6 +92,8 @@ public class Pollster
                          .ConfigureAwait(false);
     await preconditionChecker_.Init(cancellationToken)
                               .ConfigureAwait(false);
+    await workerStreamHandler_.Init(cancellationToken)
+                              .ConfigureAwait(false);
   }
 
   public async Task MainLoop(CancellationToken cancellationToken)

--- a/Common/src/Pollster/RequestProcessor.cs
+++ b/Common/src/Pollster/RequestProcessor.cs
@@ -82,11 +82,13 @@ public class RequestProcessor : IDisposable
 
   public async Task<List<Task>> ProcessAsync(IQueueMessageHandler  messageHandler,
                                              TaskData              taskData,
-                                             Queue<ComputeRequest> computeRequests,
                                              CancellationToken     cancellationToken)
   {
     try
     {
+      var computeRequests = await workerStreamHandler_.StartTaskPrefetching(taskData,
+                                                       cancellationToken).ConfigureAwait(false);
+
       taskToFinalize_.Clear();
       var result = await ProcessInternalsAsync(taskData, computeRequests,
                                                cancellationToken)

--- a/Common/src/Stream/Worker/IWorkerStreamHandler.cs
+++ b/Common/src/Stream/Worker/IWorkerStreamHandler.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Core.Common.Storage;
@@ -40,7 +41,8 @@ namespace ArmoniK.Core.Common.Stream.Worker;
 [PublicAPI]
 public interface IWorkerStreamHandler : IInitializable, IDisposable
 {
-  public Queue<ComputeRequest> WorkerReturn();
+  public Task<Queue<ComputeRequest>> StartTaskPrefetching(TaskData          taskData,
+                                                          CancellationToken cancellationToken);
 
   public void StartTaskProcessing(TaskData          taskData,
                                   CancellationToken cancellationToken);

--- a/Common/src/Stream/Worker/WorkerStreamHandler.cs
+++ b/Common/src/Stream/Worker/WorkerStreamHandler.cs
@@ -49,7 +49,7 @@ public class WorkerStreamHandler : IWorkerStreamHandler
 
   public WorkerStreamHandler(IGrpcChannelProvider channelProvider, DataPrefetcher dataPrefetcher)
   {
-    ChannelBase channel;
+    ChannelBase? channel;
     try
     {
       channel = channelProvider.Get();
@@ -58,8 +58,12 @@ public class WorkerStreamHandler : IWorkerStreamHandler
     {
       throw new ArmoniKException("Could not get grpc channel");
     }
-
-    workerClient_ = new WorkerClient(channel);
+    if (channel is null)
+    {
+      throw new NullReferenceException();
+    }
+    workerClient_   = new WorkerClient(channel);
+    dataPrefetcher_ = dataPrefetcher;
   }
 
   public async Task<Queue<ComputeRequest>> StartTaskPrefetching(TaskData          taskData,

--- a/Common/src/Stream/Worker/WorkerStreamHandler.cs
+++ b/Common/src/Stream/Worker/WorkerStreamHandler.cs
@@ -30,6 +30,7 @@ using System.Threading.Tasks;
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC;
+using ArmoniK.Core.Common.gRPC.Validators;
 using ArmoniK.Core.Common.Pollster;
 using ArmoniK.Core.Common.Storage;
 
@@ -70,8 +71,11 @@ public class WorkerStreamHandler : IWorkerStreamHandler
 
   public void StartTaskProcessing(TaskData taskData, CancellationToken cancellationToken)
   {
-    Stream = workerClient_.Process(deadline: DateTime.UtcNow + taskData.Options.MaxDuration,
-                                   cancellationToken: cancellationToken);
+    var taskValidator = new TaskOptionsValidator();
+
+    if (taskValidator.Validate(taskData.Options).IsValid)
+      Stream = workerClient_.Process(deadline: DateTime.UtcNow + taskData.Options.MaxDuration,
+                                     cancellationToken: cancellationToken);
     WorkerRequestStream = Stream is not null ?
                             Stream.RequestStream
                             : throw new ArmoniKException($"Failed to recuperate Stream for {taskData.TaskId}");

--- a/Common/src/gRPC/GrpcChannelProvider.cs
+++ b/Common/src/gRPC/GrpcChannelProvider.cs
@@ -42,7 +42,7 @@ using GrpcChannel = ArmoniK.Core.Common.Injection.Options.GrpcChannel;
 namespace ArmoniK.Core.Common.gRPC;
 
 [UsedImplicitly]
-public class GrpcChannelProvider : ProviderBase<ChannelBase>
+public class GrpcChannelProvider : ProviderBase<ChannelBase>, IGrpcChannelProvider
 {
   private readonly bool isInitialized_;
 

--- a/Common/src/gRPC/IGrpcChannelProvider.cs
+++ b/Common/src/gRPC/IGrpcChannelProvider.cs
@@ -1,0 +1,35 @@
+﻿// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2022. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Threading.Tasks;
+
+using Grpc.Core;
+
+namespace ArmoniK.Core.Common.gRPC;
+
+public interface IGrpcChannelProvider
+{
+  ValueTask<bool> Check(HealthCheckTag tag);
+  ChannelBase? Get();
+}

--- a/Common/tests/Helpers/TestHelperClientStreamWritter.cs
+++ b/Common/tests/Helpers/TestHelperClientStreamWritter.cs
@@ -1,0 +1,52 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2022. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using Grpc.Core;
+
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+internal class TestHelperClientStreamWriter<T> : IClientStreamWriter<T>
+{
+  private readonly List<T> messages_ = new();
+
+  public IList<T> Messages
+    => messages_;
+
+  public Task WriteAsync(T message)
+  {
+    messages_.Add(message);
+    return Task.CompletedTask;
+  }
+
+  public Task CompleteAsync()
+  {
+    return Task.CompletedTask;
+  }
+
+  public WriteOptions WriteOptions { get; set; }
+}

--- a/Common/tests/Pollster/RequestProcessorTests.cs
+++ b/Common/tests/Pollster/RequestProcessorTests.cs
@@ -396,7 +396,7 @@ public class RequestProcessorTest
   }
 
   [TestCaseSource(nameof(ReplyTestData))]
-  public async Task ProcessInternalsAsyncShouldSucceed(List<ProcessReply> computeReplies)
+  public async Task IntegrationProcessInternalsAsyncTest(List<ProcessReply> computeReplies)
   {
     var taskData = await taskTable_.ReadTaskAsync(Task1,
                                                   CancellationToken.None)

--- a/Common/tests/Pollster/RequestProcessorTests.cs
+++ b/Common/tests/Pollster/RequestProcessorTests.cs
@@ -492,19 +492,7 @@ public class RequestProcessorTest
                                                   CancellationToken.None)
                                    .ConfigureAwait(false);
 
-    var dataPrefetcher = new DataPrefetcher(mockObjectStorageFactory_.Object,
-                                            activitySource_,
-                                            loggerFactory_.CreateLogger<DataPrefetcher>());
-
-    var requests = await dataPrefetcher.PrefetchDataAsync(taskData,
-                                                          CancellationToken.None)
-                                       .ConfigureAwait(false);
-
-    Console.WriteLine("Requests:");
-    foreach (var cr in requests)
-    {
-      Console.WriteLine(cr.ToString());
-    }
+    var requests = new Queue<ProcessRequest.Types.ComputeRequest>();
 
     Console.WriteLine("Replies:");
     foreach (var reps in computeReplies)
@@ -598,19 +586,7 @@ public class RequestProcessorTest
                                                   CancellationToken.None)
                                    .ConfigureAwait(false);
 
-    var dataPrefetcher = new DataPrefetcher(mockObjectStorageFactory_.Object,
-                                            activitySource_,
-                                            loggerFactory_.CreateLogger<DataPrefetcher>());
-
-    var requests = await dataPrefetcher.PrefetchDataAsync(taskData,
-                                                          CancellationToken.None)
-                                       .ConfigureAwait(false);
-
-    Console.WriteLine("Requests:");
-    foreach (var cr in requests)
-    {
-      Console.WriteLine(cr.ToString());
-    }
+    var requests = new Queue<ProcessRequest.Types.ComputeRequest>();
 
     Console.WriteLine("Replies:");
     foreach (var reps in computeReplies)
@@ -640,14 +616,7 @@ public class RequestProcessorTest
                                                   CancellationToken.None)
                                    .ConfigureAwait(false);
 
-    var dataPrefetcher = new DataPrefetcher(mockObjectStorageFactory_.Object,
-                                            activitySource_,
-                                            loggerFactory_.CreateLogger<DataPrefetcher>());
-
-    var requests = await dataPrefetcher.PrefetchDataAsync(taskData,
-                                                          CancellationToken.None)
-                                       .ConfigureAwait(false);
-
+    var requests = new Queue<ProcessRequest.Types.ComputeRequest>();
 
     mockWorkerStreamHandler_.Setup(s => s.WorkerResponseStream)
                             .Throws(() => new ArmoniKException());
@@ -671,13 +640,7 @@ public class RequestProcessorTest
                                                   CancellationToken.None)
                                    .ConfigureAwait(false);
 
-    var dataPrefetcher = new DataPrefetcher(mockObjectStorageFactory_.Object,
-                                            activitySource_,
-                                            loggerFactory_.CreateLogger<DataPrefetcher>());
-
-    var requests = await dataPrefetcher.PrefetchDataAsync(taskData,
-                                                          CancellationToken.None)
-                                       .ConfigureAwait(false);
+    var requests = new Queue<ProcessRequest.Types.ComputeRequest>();
 
     var computeReplies = new List<ProcessReply>
                          {

--- a/Common/tests/Pollster/WorkerStreamHandlerTests.cs
+++ b/Common/tests/Pollster/WorkerStreamHandlerTests.cs
@@ -1,0 +1,213 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2022. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Common.Exceptions;
+using ArmoniK.Core.Common.gRPC;
+using ArmoniK.Core.Common.gRPC.Services;
+using ArmoniK.Core.Common.Pollster;
+using ArmoniK.Core.Common.Storage;
+using ArmoniK.Core.Common.Stream.Worker;
+using ArmoniK.Core.Common.Tests.Helpers;
+
+using Microsoft.Extensions.Logging;
+
+using Moq;
+
+using NUnit.Framework;
+
+using Output = ArmoniK.Core.Common.Storage.Output;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
+using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
+
+namespace ArmoniK.Core.Common.Tests.Pollster;
+
+[TestFixture]
+public class WorkerStreamHandlerTests
+{
+  private GrpcSubmitterServiceHelper helper_;
+  private WorkerStreamHandler        workerStreamHandler_;
+  private ActivitySource             activitySource_;
+
+  [SetUp]
+  public async Task SetUp()
+  {
+    activitySource_ = new ActivitySource(nameof(WorkerStreamHandlerTests));
+
+    var mockSubmitter       = new Mock<ISubmitter>();
+    var mockChannelProvider = new Mock<IGrpcChannelProvider>();
+
+    helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object);
+
+    var channel = await helper_.CreateChannel()
+                               .ConfigureAwait(false);
+
+    var mockObjectStorageFactory = new Mock<IObjectStorageFactory>();
+    var mockObjectStorage        = new Mock<IObjectStorage>();
+    mockObjectStorage.Setup(x => x.GetValuesAsync(It.IsAny<string>(),
+                                                  CancellationToken.None))
+                     .Returns((string            key,
+                               CancellationToken token) => new List<byte[]>().ToAsyncEnumerable());
+
+    var mockResultStorage = new Mock<IObjectStorage>();
+    mockResultStorage.Setup(x => x.GetValuesAsync(It.IsAny<string>(),
+                                                  CancellationToken.None))
+                     .Returns((string            key,
+                               CancellationToken token) => new List<byte[]>
+                                                           {
+                                                             Convert.FromBase64String("1111"),
+                                                           }.ToAsyncEnumerable());
+
+    mockObjectStorageFactory.Setup(x => x.CreateObjectStorage(It.IsAny<string>()))
+                            .Returns((string objname) =>
+                                     {
+                                       if (objname.StartsWith("results"))
+                                       {
+                                         return mockResultStorage.Object;
+                                       }
+
+                                       if (objname.StartsWith("payloads"))
+                                       {
+                                         return mockObjectStorage.Object;
+                                       }
+
+                                       return null;
+                                     });
+
+    mockChannelProvider.Setup(cp => cp.Get())
+                       .Returns(() => channel);
+
+    var loggerFactory = new LoggerFactory();
+
+    var dataPrefetcher = new DataPrefetcher(mockObjectStorageFactory.Object,
+                                            activitySource_,
+                                            loggerFactory.CreateLogger<DataPrefetcher>());
+
+    workerStreamHandler_ = new WorkerStreamHandler(mockChannelProvider.Object,
+                                                   dataPrefetcher);
+  }
+
+
+  [TearDown]
+  public async Task TearDown()
+  {
+    await helper_.StopServer()
+                 .ConfigureAwait(false);
+    helper_.Dispose();
+  }
+
+  [Test]
+  public void IntegrationNotInitializedStreamsShouldBeNull()
+  {
+    Assert.IsNull(workerStreamHandler_.Stream);
+    Assert.IsNull(workerStreamHandler_.WorkerRequestStream);
+    Assert.IsNull(workerStreamHandler_.WorkerResponseStream);
+  }
+
+  [Test]
+  public void IntegrationStartTaskProcessingFailsOnInvalidTaskOptions()
+  {
+    var taskData = new TaskData("SessionId",
+                                "TaskId",
+                                "PodId",
+                                new[]
+                                {
+                                  "ParentTaskId"
+                                },
+                                new[]
+                                {
+                                  "Dependency",
+                                },
+                                new[]
+                                {
+                                  "Output",
+                                },
+                                Array.Empty<string>(),
+                                TaskStatus.Creating,
+                                "",
+                                new TaskOptions(new Dictionary<string, string>(),
+                                                TimeSpan.FromSeconds(100),
+                                                5,
+                                                0), // Zero priority is not a valid option
+                                DateTime.Now,
+                                DateTime.MinValue,
+                                DateTime.MinValue,
+                                DateTime.Now,
+                                DateTime.Now,
+                                new Output(false,
+                                           ""));
+
+    Assert.Throws<ArmoniKException>(() =>
+                                    {
+                                      workerStreamHandler_.StartTaskProcessing(taskData,
+                                                                               CancellationToken.None);
+                                    });
+  }
+
+  [Test]
+  public void IntegrationStartTaskProcessingSucceeds()
+  {
+    var taskData = new TaskData("SessionId",
+                                "TaskId",
+                                "PodId",
+                                new[]
+                                {
+                                  "ParentTaskId",
+                                },
+                                new[]
+                                {
+                                  "Dependency",
+                                },
+                                new[]
+                                {
+                                  "Output",
+                                },
+                                Array.Empty<string>(),
+                                TaskStatus.Creating,
+                                "",
+                                new TaskOptions(new Dictionary<string, string>(),
+                                                TimeSpan.FromSeconds(100),
+                                                5,
+                                                1), 
+                                DateTime.Now,
+                                DateTime.MinValue,
+                                DateTime.MinValue,
+                                DateTime.Now,
+                                DateTime.Now,
+                                new Output(false,
+                                           ""));
+
+    workerStreamHandler_.StartTaskProcessing(taskData, CancellationToken.None);
+
+    Assert.IsNotNull(workerStreamHandler_.Stream);
+    Assert.IsNotNull(workerStreamHandler_.WorkerRequestStream);
+    Assert.IsNotNull(workerStreamHandler_.WorkerResponseStream);
+  }
+}


### PR DESCRIPTION
- Move call of DataPrefetcher to WorkerStreamHandler
- Add simple integration tests for WorkerStreamHandler
- Purge unnecessary code from RequestProcessorTests