### PR TITLE
Reduce errors in polling agent

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -156,15 +156,15 @@ public class Pollster
 
             if (precondition)
             {
-              await taskHandler.PreProcessing(cancellationToken)
+              await taskHandler.PreProcessing(combinedCts.Token)
                                .ConfigureAwait(false);
 
-              await taskHandler.ExecuteTask(cancellationToken)
+              await taskHandler.ExecuteTask(combinedCts.Token)
                                .ConfigureAwait(false);
 
               logger_.LogDebug("CompleteProcessing task processing");
 
-              await taskHandler.PostProcessing(cancellationToken)
+              await taskHandler.PostProcessing(combinedCts.Token)
                                .ConfigureAwait(false);
 
               logger_.LogDebug("Task returned");
@@ -175,7 +175,7 @@ public class Pollster
             logger_.LogWarning(e,
                                "Error with messageHandler {messageId}",
                                message.MessageId);
-            throw;
+            combinedCts.Cancel();
           }
         }
       }


### PR DESCRIPTION
en enlevant le throw, l'erreur est effectivement interceptée et le pollster est capable de prendre une nouvelle tache. Si on laisse ce thow, chaque erreur ici va déclencher une global cancellation et crash le polling agent

