### PR TITLE
Specialize mongo getresult

### DIFF
--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -94,9 +94,9 @@ public class ResultTable : IResultTable
     }
   }
 
-  async Task<Core.Common.Storage.Result> IResultTable.GetResult(string              sessionId,
-                                                                 string key,
-                                                                 CancellationToken   cancellationToken)
+  async Task<Core.Common.Storage.Result> IResultTable.GetResult(string            sessionId,
+                                                                string            key,
+                                                                CancellationToken cancellationToken)
   {
     using var activity = activitySource_.StartActivity($"{nameof(IResultTable.GetResult)}");
     activity?.SetTag($"{nameof(IResultTable.GetResult)}_sessionId",
@@ -116,7 +116,6 @@ public class ResultTable : IResultTable
       throw new ResultNotFoundException($"Key '{key}' not found");
     }
   }
-  
 
 
   public IAsyncEnumerable<Core.Common.Storage.Result> GetResults(string              sessionId,

--- a/Common/tests/IResultTableTests.cs
+++ b/Common/tests/IResultTableTests.cs
@@ -343,7 +343,9 @@ public class ResultTableTestBase
     {
       var n = 2000;
       var ids = Enumerable.Range(0,
-                                 n).Select(i => $"ResultIsAvailable#{i}").ToArray();
+                                 n)
+                          .Select(i => $"ResultIsAvailable#{i}")
+                          .ToArray();
       await ResultTable!.Create(ids.Select(id => new Result("SessionId",
                                                             id,
                                                             "OwnerId",
@@ -357,10 +359,12 @@ public class ResultTableTestBase
                                       .ToListAsync()
                                       .ConfigureAwait(false);
 
-      Assert.AreEqual(n, results.Count);
+      Assert.AreEqual(n,
+                      results.Count);
       foreach (var result in results)
       {
-        Assert.AreEqual(ResultStatus.Completed, result.Status);
+        Assert.AreEqual(ResultStatus.Completed,
+                        result.Status);
       }
     }
   }
@@ -387,8 +391,8 @@ public class ResultTableTestBase
       foreach (var id in ids)
       {
         results.Add(await ResultTable.GetResult("SessionId",
-                                                 id)
-                                      .ConfigureAwait(false));
+                                                id)
+                                     .ConfigureAwait(false));
       }
 
       Assert.AreEqual(n,


### PR DESCRIPTION
The factorization of GetResult and GetResults resulted in a very big slow down of Extension Csharp.
This PR specializes GetResult for MongoDB in order to have a faster DB request.

GetResult 17 times faster