### PR TITLE
Add missing doc

### DIFF
--- a/Common/src/Exceptions/ArmoniKException.cs
+++ b/Common/src/Exceptions/ArmoniKException.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -27,18 +27,33 @@ using System.Runtime.Serialization;
 
 namespace ArmoniK.Core.Common.Exceptions;
 
+/// <summary>
+///   Base exception for exceptions in ArmoniK core
+/// </summary>
 [Serializable]
 public class ArmoniKException : Exception
 {
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ArmoniKException" />
+  /// </summary>
   public ArmoniKException()
   {
   }
 
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ArmoniKException" /> with the specified error message
+  /// </summary>
+  /// <param name="message">The error message</param>
   public ArmoniKException(string message)
     : base(message)
   {
   }
 
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ArmoniKException" /> with the specified error message and an exception
+  /// </summary>
+  /// <param name="message">The error message</param>
+  /// <param name="innerException">The inner exception that triggered this exception</param>
   public ArmoniKException(string    message,
                           Exception innerException)
     : base(message,
@@ -46,6 +61,11 @@ public class ArmoniKException : Exception
   {
   }
 
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ArmoniKException" /> with serialized data
+  /// </summary>
+  /// <param name="info">Information for the perform the serialization</param>
+  /// <param name="context">Context passed to the Stream</param>
   protected ArmoniKException(SerializationInfo info,
                              StreamingContext  context)
     : base(info,

--- a/Common/src/HealthCheck.cs
+++ b/Common/src/HealthCheck.cs
@@ -32,12 +32,21 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace ArmoniK.Core.Common;
 
+/// <summary>
+///   Implementation of <see cref="IHealthCheck" /> that manages FailureStatus and simplifies the implementation of Health
+///   Checks
+/// </summary>
 [PublicAPI]
 public class HealthCheck : IHealthCheck
 {
   private readonly IHealthCheckProvider healthCheckProvider_;
   private readonly HealthCheckTag       tag_;
 
+  /// <summary>
+  ///   Constructor that creates a HealthCheck from a <see cref="IHealthCheckProvider" />
+  /// </summary>
+  /// <param name="healthCheckProvider">Interface for classes that exposes a simplified Health Check</param>
+  /// <param name="tag">Tag to filter which health check is executed</param>
   public HealthCheck(IHealthCheckProvider healthCheckProvider,
                      HealthCheckTag       tag)
   {

--- a/Common/src/HealthCheckTag.cs
+++ b/Common/src/HealthCheckTag.cs
@@ -30,17 +30,17 @@ namespace ArmoniK.Core.Common;
 public enum HealthCheckTag
 {
   /// <summary>
-  ///   For health check that determines the status of a class exposing health check during its initialization.
+  ///   For a health check that determines the status of a class exposing health check during its initialization.
   /// </summary>
   Startup,
 
   /// <summary>
-  ///   For health check that determines the status of a class exposing health check during its execution.
+  ///   For a health check that determines the status of a class exposing health check during its execution.
   /// </summary>
   Liveness,
 
   /// <summary>
-  ///   For health check that determines if a class exposing health check can accept workload.
+  ///   For a health check that determines if a class exposing health check can accept workload.
   /// </summary>
   Readiness,
 }

--- a/Common/src/HealthCheckTag.cs
+++ b/Common/src/HealthCheckTag.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -24,9 +24,23 @@
 
 namespace ArmoniK.Core.Common;
 
+/// <summary>
+///   Tags to filter the kind of health check
+/// </summary>
 public enum HealthCheckTag
 {
+  /// <summary>
+  ///   For health check that determines the status of a class exposing health check during its initialization.
+  /// </summary>
   Startup,
+
+  /// <summary>
+  ///   For health check that determines the status of a class exposing health check during its execution.
+  /// </summary>
   Liveness,
+
+  /// <summary>
+  ///   For health check that determines if a class exposing health check can accept workload.
+  /// </summary>
   Readiness,
 }

--- a/Common/src/IHealthCheckProvider.cs
+++ b/Common/src/IHealthCheckProvider.cs
@@ -30,8 +30,18 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace ArmoniK.Core.Common;
 
+/// <summary>
+///   Represents a simpler health check than <see cref="IHealthCheck" />.
+/// </summary>
 [PublicAPI]
 public interface IHealthCheckProvider
 {
+  /// <summary>
+  ///   Checks the status of a class for the given health check type.
+  /// </summary>
+  /// <param name="tag">Health check for which the class has to answer.</param>
+  /// <returns>
+  ///   The result of the check containing the status of the class for the health check type.
+  /// </returns>
   Task<HealthCheckResult> Check(HealthCheckTag tag);
 }

--- a/Common/src/IInitializable.cs
+++ b/Common/src/IInitializable.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -27,7 +27,17 @@ using System.Threading.Tasks;
 
 namespace ArmoniK.Core.Common;
 
+/// <summary>
+///   Represents a class initializable through the given method and exposes a health check.
+/// </summary>
 public interface IInitializable : IHealthCheckProvider
 {
+  /// <summary>
+  ///   Executes an initialization process for the class
+  /// </summary>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Task representing the asynchronous execution of the method
+  /// </returns>
   Task Init(CancellationToken cancellationToken);
 }

--- a/Common/src/Injection/Options/Components.cs
+++ b/Common/src/Injection/Options/Components.cs
@@ -26,14 +26,34 @@ using JetBrains.Annotations;
 
 namespace ArmoniK.Core.Common.Injection.Options;
 
+/// <summary>
+///   Configuration used to choose which adapter for storage is used
+/// </summary>
 [PublicAPI]
 public class Components
 {
+  /// <summary>
+  ///   Path to the section containing the values in the configuration object
+  /// </summary>
   public const string SettingSection = nameof(Components);
 
-  public string? TableStorage          { get; set; }
-  public string? QueueStorage          { get; set; }
-  public string? LeaseProvider         { get; set; }
-  public string? ObjectStorage         { get; set; }
+  /// <summary>
+  ///   Represents which database is used for tasks metadata
+  /// </summary>
+  public string? TableStorage { get; set; }
+
+  /// <summary>
+  ///   Represents which queue implementation is used to store messages
+  /// </summary>
+  public string? QueueStorage { get; set; }
+
+  /// <summary>
+  ///   Represents which object storage is used to store data for tasks
+  /// </summary>
+  public string? ObjectStorage { get; set; }
+
+  /// <summary>
+  ///   Represents which database is used for authentication
+  /// </summary>
   public string? AuthenticationStorage { get; set; }
 }

--- a/Common/src/Injection/Options/InitWorker.cs
+++ b/Common/src/Injection/Options/InitWorker.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -26,8 +26,14 @@ using System;
 
 namespace ArmoniK.Core.Common.Injection.Options;
 
+/// <summary>
+///   Configuration for <see cref="Stream.Worker.WorkerStreamHandler" />
+/// </summary>
 public class InitWorker
 {
+  /// <summary>
+  ///   Path to the section containing the values in the configuration object
+  /// </summary>
   public const string SettingSection = nameof(InitWorker);
 
   public int      WorkerCheckRetries { get; set; } = 10;

--- a/Common/src/Injection/Options/Pollster.cs
+++ b/Common/src/Injection/Options/Pollster.cs
@@ -27,7 +27,7 @@ using System;
 namespace ArmoniK.Core.Common.Injection.Options;
 
 /// <summary>
-///   Configuration for Pollster
+///   Configuration for <see cref="Common.Pollster.Pollster" />
 /// </summary>
 public class Pollster
 {

--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -24,9 +24,18 @@
 
 namespace ArmoniK.Core.Common.Injection.Options;
 
+/// <summary>
+///   Configuration for <see cref="gRPC.Services.Submitter" />.
+/// </summary>
 public class Submitter
 {
+  /// <summary>
+  ///   Path to the section containing the values in the configuration object
+  /// </summary>
   public const string SettingSection = nameof(Submitter);
 
+  /// <summary>
+  ///   Name of the default partition in which submit tasks
+  /// </summary>
   public string DefaultPartition { get; set; } = string.Empty;
 }

--- a/Common/src/Injection/ProviderBase.cs
+++ b/Common/src/Injection/ProviderBase.cs
@@ -29,12 +29,20 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace ArmoniK.Core.Common.Injection;
 
+/// <summary>
+///   Implement a mechanism to initialize a class during its first access
+/// </summary>
+/// <typeparam name="T">Type of the class to initialize</typeparam>
 public abstract class ProviderBase<T> : IHealthCheckProvider
 {
   private readonly Func<Task<T>> builder_;
   private readonly object        lockObj_ = new();
   private          T?            object_;
 
+  /// <summary>
+  ///   Constructor of the provider with a method to initialize the class that will be provided.
+  /// </summary>
+  /// <param name="builder">Method to initialize the class that will be provided</param>
   protected ProviderBase(Func<Task<T>> builder)
     => builder_ = builder;
 
@@ -44,6 +52,14 @@ public abstract class ProviderBase<T> : IHealthCheckProvider
                          ? HealthCheckResult.Healthy()
                          : HealthCheckResult.Unhealthy());
 
+  /// <summary>
+  ///   Getter for the class to initialize.
+  ///   If the class is initialized, returns the class.
+  ///   If not, initializes the class then returns it.
+  /// </summary>
+  /// <returns>
+  ///   The initialized class
+  /// </returns>
   public T Get()
   {
     // Double null check to avoid the lock once initialization is finished

--- a/Common/src/Injection/ServiceCollectionExt.cs
+++ b/Common/src/Injection/ServiceCollectionExt.cs
@@ -40,13 +40,36 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace ArmoniK.Core.Common.Injection;
 
+/// <summary>
+///   Extends the functionality of the <see cref="IConfiguration" />
+/// </summary>
 public static class ConfigurationExt
 {
+  /// <summary>
+  ///   Configure an object with the given configuration.
+  /// </summary>
+  /// <typeparam name="T">Type of the options class</typeparam>
+  /// <param name="configuration">Configurations used to fill the class</param>
+  /// <param name="key">Path to the Object in the configuration</param>
+  /// <returns>
+  ///   The initialized object
+  /// </returns>
+  /// <exception cref="InvalidOperationException">the <paramref name="key" /> is not found in the configurations.</exception>
   public static T GetRequiredValue<T>(this IConfiguration configuration,
                                       string              key)
     => configuration.GetRequiredSection(key)
                     .Get<T>();
 
+  /// <summary>
+  ///   Configure an object with the given configuration.
+  ///   If the object is not found in the configuration, a new object in returned.
+  /// </summary>
+  /// <typeparam name="T">Type of the options class</typeparam>
+  /// <param name="configuration">Configurations used to fill the class</param>
+  /// <param name="key">Path to the Object in the configuration</param>
+  /// <returns>
+  ///   The initialized object
+  /// </returns>
   public static T GetInitializedValue<T>(this IConfiguration configuration,
                                          string              key)
     where T : new()
@@ -54,6 +77,9 @@ public static class ConfigurationExt
                     .Get<T>() ?? new T();
 }
 
+/// <summary>
+///   Extends the functionality of the <see cref="IServiceCollection" />
+/// </summary>
 public static class ServiceCollectionExt
 {
   /// <summary>
@@ -73,6 +99,16 @@ public static class ServiceCollectionExt
     where T : class, new()
     => services.AddSingleton(configuration.GetInitializedValue<T>(key));
 
+  /// <summary>
+  ///   Fills in an option class and add it in the service collection
+  /// </summary>
+  /// <typeparam name="T">Type of option class to add</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="configuration">Collection of configuration used to configure the option class</param>
+  /// <param name="key">Key to find the option to fill</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddOption<T>(this IServiceCollection services,
                                                 IConfiguration          configuration,
@@ -80,7 +116,17 @@ public static class ServiceCollectionExt
     where T : class
     => services.AddSingleton(configuration.GetRequiredValue<T>(key));
 
-
+  /// <summary>
+  ///   Fills in an option class, add it in the service collection and return the initialized class
+  /// </summary>
+  /// <typeparam name="T">Type of option class to add</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="configuration">Collection of configuration used to configure the option class</param>
+  /// <param name="key">Key to find the option to fill</param>
+  /// <param name="option">Represents the filled option class</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddOption<T>(this IServiceCollection services,
                                                 IConfiguration          configuration,
@@ -92,6 +138,14 @@ public static class ServiceCollectionExt
     return services.AddSingleton(option);
   }
 
+  /// <summary>
+  ///   Add the services to create connection to the worker
+  /// </summary>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="configuration">Collection of configuration used to configure the added services</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddArmoniKWorkerConnection(this IServiceCollection services,
                                                               IConfiguration          configuration)
@@ -116,6 +170,15 @@ public static class ServiceCollectionExt
     return services;
   }
 
+  /// <summary>
+  ///   Add a singleton service of the type specified with health check capabilities
+  /// </summary>
+  /// <typeparam name="T">Type of the service (interface)</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="checkName">Name for the health check</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddSingletonWithHealthCheck<T>(this IServiceCollection services,
                                                                   string                  checkName)
@@ -151,6 +214,16 @@ public static class ServiceCollectionExt
     return services;
   }
 
+  /// <summary>
+  ///   Add a singleton service of the type specified with health check capabilities
+  /// </summary>
+  /// <typeparam name="TService">Type of the service (interface)</typeparam>
+  /// <typeparam name="TImplementation">Implementation class of the service</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="checkName">Name for the health check</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddSingletonWithHealthCheck<TService, TImplementation>(this IServiceCollection services,
                                                                                           string                  checkName)
@@ -187,6 +260,15 @@ public static class ServiceCollectionExt
     return services;
   }
 
+  /// <summary>
+  ///   Add a transient service of the type specified with health check capabilities
+  /// </summary>
+  /// <typeparam name="T">Type of the service (interface)</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="checkName">Name for the health check</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddTransientWithHealthCheck<T>(this IServiceCollection services,
                                                                   string                  checkName)
@@ -222,6 +304,16 @@ public static class ServiceCollectionExt
     return services;
   }
 
+  /// <summary>
+  ///   Add a transient service of the type specified with health check capabilities
+  /// </summary>
+  /// <typeparam name="TService">Type of the service (interface)</typeparam>
+  /// <typeparam name="TImplementation">Implementation class of the service</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="checkName">Name for the health check</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection AddTransientWithHealthCheck<TService, TImplementation>(this IServiceCollection services,
                                                                                           string                  checkName)
@@ -258,6 +350,16 @@ public static class ServiceCollectionExt
     return services;
   }
 
+  /// <summary>
+  ///   Add a transient service of the type specified with health check capabilities
+  /// </summary>
+  /// <typeparam name="TService">Type of the service</typeparam>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="implementationFactory">Factory to create service</param>
+  /// <param name="checkName">Name for the health check</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   public static IServiceCollection AddTransientWithHealthCheck<TService>(this IServiceCollection          services,
                                                                          Func<IServiceProvider, TService> implementationFactory,
                                                                          string                           checkName)
@@ -293,6 +395,13 @@ public static class ServiceCollectionExt
     return services;
   }
 
+  /// <summary>
+  ///   Add validation services for gRPC Requests
+  /// </summary>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
   [PublicAPI]
   public static IServiceCollection ValidateGrpcRequests(this IServiceCollection services)
     => services.AddGrpc(options =>

--- a/Common/src/Injection/ServiceCollectionExt.cs
+++ b/Common/src/Injection/ServiceCollectionExt.cs
@@ -49,7 +49,7 @@ public static class ConfigurationExt
   ///   Configure an object with the given configuration.
   /// </summary>
   /// <typeparam name="T">Type of the options class</typeparam>
-  /// <param name="configuration">Configurations used to fill the class</param>
+  /// <param name="configuration">Configurations used to populate the class</param>
   /// <param name="key">Path to the Object in the configuration</param>
   /// <returns>
   ///   The initialized object
@@ -65,7 +65,7 @@ public static class ConfigurationExt
   ///   If the object is not found in the configuration, a new object in returned.
   /// </summary>
   /// <typeparam name="T">Type of the options class</typeparam>
-  /// <param name="configuration">Configurations used to fill the class</param>
+  /// <param name="configuration">Configurations used to populate the class</param>
   /// <param name="key">Path to the Object in the configuration</param>
   /// <returns>
   ///   The initialized object
@@ -87,7 +87,7 @@ public static class ServiceCollectionExt
   /// </summary>
   /// <typeparam name="T">Class to fill</typeparam>
   /// <param name="services">Collection of services</param>
-  /// <param name="configuration">Configurations used to fill the class</param>
+  /// <param name="configuration">Configurations used to populate the class</param>
   /// <param name="key">Path to the Object in the configuration</param>
   /// <returns>
   ///   Input collection of services to chain usages
@@ -100,7 +100,7 @@ public static class ServiceCollectionExt
     => services.AddSingleton(configuration.GetInitializedValue<T>(key));
 
   /// <summary>
-  ///   Fills in an option class and add it in the service collection
+  ///   Fills in an option class and add it to the service collection
   /// </summary>
   /// <typeparam name="T">Type of option class to add</typeparam>
   /// <param name="services">Collection of service descriptors</param>
@@ -171,7 +171,7 @@ public static class ServiceCollectionExt
   }
 
   /// <summary>
-  ///   Add a singleton service of the type specified with health check capabilities
+  ///   Add a singleton service of the specified type with health check capabilities
   /// </summary>
   /// <typeparam name="T">Type of the service (interface)</typeparam>
   /// <param name="services">Collection of service descriptors</param>
@@ -215,7 +215,7 @@ public static class ServiceCollectionExt
   }
 
   /// <summary>
-  ///   Add a singleton service of the type specified with health check capabilities
+  ///   Add a singleton service of the specified type with health check capabilities
   /// </summary>
   /// <typeparam name="TService">Type of the service (interface)</typeparam>
   /// <typeparam name="TImplementation">Implementation class of the service</typeparam>
@@ -261,7 +261,7 @@ public static class ServiceCollectionExt
   }
 
   /// <summary>
-  ///   Add a transient service of the type specified with health check capabilities
+  ///   Add a transient service of the specified type with health check capabilities
   /// </summary>
   /// <typeparam name="T">Type of the service (interface)</typeparam>
   /// <param name="services">Collection of service descriptors</param>
@@ -305,7 +305,7 @@ public static class ServiceCollectionExt
   }
 
   /// <summary>
-  ///   Add a transient service of the type specified with health check capabilities
+  ///   Add a transient service of the specified type with health check capabilities
   /// </summary>
   /// <typeparam name="TService">Type of the service (interface)</typeparam>
   /// <typeparam name="TImplementation">Implementation class of the service</typeparam>
@@ -351,7 +351,7 @@ public static class ServiceCollectionExt
   }
 
   /// <summary>
-  ///   Add a transient service of the type specified with health check capabilities
+  ///   Add a transient service of the specified type with health check capabilities
   /// </summary>
   /// <typeparam name="TService">Type of the service</typeparam>
   /// <param name="services">Collection of service descriptors</param>

--- a/Common/src/Pollster/AgentHandler.cs
+++ b/Common/src/Pollster/AgentHandler.cs
@@ -121,6 +121,7 @@ public class AgentHandler : IAgentHandler, IAsyncDisposable
     }
   }
 
+  /// <inheritdoc />
   public async Task<IAgent> Start(string            token,
                                   ILogger           logger,
                                   SessionData       sessionData,
@@ -149,6 +150,7 @@ public class AgentHandler : IAgentHandler, IAsyncDisposable
     }
   }
 
+  /// <inheritdoc />
   public async Task Stop(CancellationToken cancellationToken)
   {
     try
@@ -164,6 +166,7 @@ public class AgentHandler : IAgentHandler, IAsyncDisposable
     }
   }
 
+  /// <inheritdoc />
   public async ValueTask DisposeAsync()
   {
     await app_.DisposeAsync()

--- a/Common/src/StateMachines/ComputeRequestStateMachine.cs
+++ b/Common/src/StateMachines/ComputeRequestStateMachine.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Text;
 
 using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Worker;
 
 using Microsoft.Extensions.Logging;
 
@@ -45,13 +46,44 @@ public class ComputeRequestStateMachine
   /// </summary>
   public enum State
   {
+    /// <summary>
+    ///   Initial state of the Final State Machine.
+    /// </summary>
     Init,
+
+    /// <summary>
+    ///   State after receiving <see cref="Triggers.InitRequest" />.
+    /// </summary>
     InitRequest,
+
+    /// <summary>
+    ///   State when receiving payload chunk.
+    /// </summary>
     PayloadData,
+
+    /// <summary>
+    ///   State after reception of the last payload chunk.
+    /// </summary>
     PayloadComplete,
+
+    /// <summary>
+    ///   State for initiating the reception of the data for a data dependency.
+    /// </summary>
     DataInit,
+
+    /// <summary>
+    ///   State when receiving the last data chunk of the given data dependency.
+    /// </summary>
     DataComplete,
+
+    /// <summary>
+    ///   State when receiving a data chunk.
+    /// </summary>
     Data,
+
+    /// <summary>
+    ///   State when receiving the last data dependency.
+    /// </summary>
     DataLast,
   }
 

--- a/Common/src/StateMachines/ProcessReplyCreateLargeTaskStateMachine.cs
+++ b/Common/src/StateMachines/ProcessReplyCreateLargeTaskStateMachine.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -27,6 +27,7 @@ using System.Linq;
 using System.Text;
 
 using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Submitter;
 
 using Microsoft.Extensions.Logging;
 
@@ -36,7 +37,7 @@ using Stateless.Graph;
 namespace ArmoniK.Core.Common.StateMachines;
 
 /// <summary>
-///   Utility class for the Final State Machine from <see cref="ProcessReply.Types.CreateLargeTaskRequest" />
+///   Utility class for the Final State Machine from <see cref="CreateLargeTaskRequest" />
 /// </summary>
 public class ProcessReplyCreateLargeTaskStateMachine
 {
@@ -82,7 +83,7 @@ public class ProcessReplyCreateLargeTaskStateMachine
   public enum Triggers
   {
     /// <summary>
-    ///   Correspond to receive request <see cref="ProcessReply.Types.CreateLargeTaskRequest.TypeOneofCase.InitRequest" />
+    ///   Correspond to receive request <see cref="CreateLargeTaskRequest.TypeOneofCase.InitRequest" />
     /// </summary>
     InitRequest,
 

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -32,6 +32,33 @@ using static Google.Protobuf.WellKnownTypes.Timestamp;
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Task metadata stored in database
+/// </summary>
+/// <param name="SessionId">Unique identifier of the session in which the task belongs</param>
+/// <param name="TaskId">Unique identifier of the task</param>
+/// <param name="OwnerPodId">Identifier of the polling agent running the task</param>
+/// <param name="PayloadId">Unique identifier of the payload in input of the task</param>
+/// <param name="ParentTaskIds">
+///   Unique identifiers of the tasks that submitted the current task up to the session id which
+///   represents a submission from the client
+/// </param>
+/// <param name="DataDependencies">Unique identifiers of the results the task depends on</param>
+/// <param name="ExpectedOutputIds">
+///   Identifiers of the outputs the task should produce or should transmit the
+///   responsibility to produce
+/// </param>
+/// <param name="InitialTaskId">Task id before retry</param>
+/// <param name="RetryOfIds">List of previous tasks ids before the current retry</param>
+/// <param name="Status">Current status of the task</param>
+/// <param name="StatusMessage">Message associated to the status</param>
+/// <param name="Options">Task options</param>
+/// <param name="CreationDate">Date when the task is created</param>
+/// <param name="SubmittedDate">Date when the task is submitted</param>
+/// <param name="StartDate">Date when the task execution begins</param>
+/// <param name="EndDate">Date when the task ends</param>
+/// <param name="PodTtl">Task Time To Live on the current pod</param>
+/// <param name="Output">Output of the task after its successful completion</param>
 public record TaskData(string        SessionId,
                        string        TaskId,
                        string        OwnerPodId,
@@ -51,6 +78,26 @@ public record TaskData(string        SessionId,
                        DateTime?     PodTtl,
                        Output        Output)
 {
+  /// <summary>
+  ///   Initializes task metadata with specified fields
+  /// </summary>
+  /// <param name="sessionId">Unique identifier of the session in which the task belongs</param>
+  /// <param name="taskId">Unique identifier of the task</param>
+  /// <param name="ownerPodId">Identifier of the polling agent running the task</param>
+  /// <param name="payloadId">Unique identifier of the payload in input of the task</param>
+  /// <param name="parentTaskIds">
+  ///   Unique identifiers of the tasks that submitted the current task up to the session id which
+  ///   represents a submission from the client
+  /// </param>
+  /// <param name="dataDependencies">Unique identifiers of the results the task depends on</param>
+  /// <param name="expectedOutputIds">
+  ///   Identifiers of the outputs the task should produce or should transmit the
+  ///   responsibility to produce
+  /// </param>
+  /// <param name="retryOfIds">List of previous tasks ids before the current retry</param>
+  /// <param name="status">Current status of the task</param>
+  /// <param name="options">Task options</param>
+  /// <param name="output">Output of the task after its successful completion</param>
   public TaskData(string        sessionId,
                   string        taskId,
                   string        ownerPodId,
@@ -83,6 +130,14 @@ public record TaskData(string        SessionId,
   {
   }
 
+
+  /// <summary>
+  ///   Conversion operator from <see cref="TaskData" /> to <see cref="TaskRaw" />
+  /// </summary>
+  /// <param name="taskData">The input task data</param>
+  /// <returns>
+  ///   The converted task data
+  /// </returns>
   public static implicit operator TaskRaw(TaskData taskData)
     => new()
        {
@@ -124,6 +179,13 @@ public record TaskData(string        SessionId,
                          : null,
        };
 
+  /// <summary>
+  ///   Conversion operator from <see cref="TaskData" /> to <see cref="Task" />
+  /// </summary>
+  /// <param name="taskData">The input task data</param>
+  /// <returns>
+  ///   The converted task data
+  /// </returns>
   public static implicit operator Task(TaskData taskData)
     => new()
        {

--- a/Common/src/Storage/TaskStatusCount.cs
+++ b/Common/src/Storage/TaskStatusCount.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -26,5 +26,10 @@ using ArmoniK.Api.gRPC.V1;
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Relation between a task status and the number of tasks with this status
+/// </summary>
+/// <param name="Status">Status of the task</param>
+/// <param name="Count">Number of tasks with the associated status</param>
 public record TaskStatusCount(TaskStatus Status,
                               int        Count);

--- a/Common/src/Utils/LocalIPv4.cs
+++ b/Common/src/Utils/LocalIPv4.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -27,16 +27,30 @@ using System.Net.Sockets;
 
 using ArmoniK.Core.Common.Exceptions;
 
+using JetBrains.Annotations;
+
 namespace ArmoniK.Core.Common.Utils;
 
+/// <summary>
+///   Helper to get local IP address.
+/// </summary>
+[PublicAPI]
 public class LocalIPv4
 {
-  public static string GetLocalIPv4(NetworkInterfaceType _type)
+  /// <summary>
+  ///   Get local IP from a network interface.
+  /// </summary>
+  /// <param name="type">Interface type from which to get the IP.</param>
+  /// <returns>
+  ///   <see cref="string" /> representing the IP.
+  /// </returns>
+  /// <exception cref="ArmoniKException"></exception>
+  public static string GetLocalIPv4(NetworkInterfaceType type)
   {
     var output = "";
     foreach (var item in NetworkInterface.GetAllNetworkInterfaces())
     {
-      if (item.NetworkInterfaceType == _type && item.OperationalStatus == OperationalStatus.Up)
+      if (item.NetworkInterfaceType == type && item.OperationalStatus == OperationalStatus.Up)
       {
         foreach (var ip in item.GetIPProperties()
                                .UnicastAddresses)
@@ -57,6 +71,12 @@ public class LocalIPv4
     return output;
   }
 
+  /// <summary>
+  ///   Get local IP from Ethernet network interface.
+  /// </summary>
+  /// <returns>
+  ///   <see cref="string" /> representing the IP.
+  /// </returns>
   public static string GetLocalIPv4Ethernet()
     => GetLocalIPv4(NetworkInterfaceType.Ethernet);
 }

--- a/Common/src/gRPC/Services/Agent.cs
+++ b/Common/src/gRPC/Services/Agent.cs
@@ -84,6 +84,8 @@ public class Agent : IAgent
     token_            = token;
   }
 
+  /// <inheritdoc />
+  /// <exception cref="ArmoniKException"></exception>
   public async Task FinalizeTaskCreation(CancellationToken cancellationToken)
   {
     using var _ = logger_.BeginNamedScope(nameof(FinalizeTaskCreation),
@@ -108,6 +110,7 @@ public class Agent : IAgent
     }
   }
 
+  /// <inheritdoc />
   public async Task<CreateTaskReply> CreateTask(IAsyncStreamReader<CreateTaskRequest> requestStream,
                                                 CancellationToken                     cancellationToken)
   {
@@ -272,6 +275,7 @@ public class Agent : IAgent
     return new CreateTaskReply();
   }
 
+  /// <inheritdoc />
   public async Task GetCommonData(DataRequest                    request,
                                   IServerStreamWriter<DataReply> responseStream,
                                   CancellationToken              cancellationToken)
@@ -311,6 +315,7 @@ public class Agent : IAgent
                         .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public async Task GetDirectData(DataRequest                    request,
                                   IServerStreamWriter<DataReply> responseStream,
                                   CancellationToken              cancellationToken)
@@ -351,6 +356,7 @@ public class Agent : IAgent
                         .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public async Task GetResourceData(DataRequest                    request,
                                     IServerStreamWriter<DataReply> responseStream,
                                     CancellationToken              cancellationToken)
@@ -448,6 +454,7 @@ public class Agent : IAgent
                         .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public async Task<ResultReply> SendResult(IAsyncStreamReader<Result> requestStream,
                                             CancellationToken          cancellationToken)
   {
@@ -559,6 +566,7 @@ public class Agent : IAgent
     return new ResultReply();
   }
 
+  /// <inheritdoc />
   public void Dispose()
   {
   }

--- a/Common/src/gRPC/Validators/CreateSessionRequestValidator.cs
+++ b/Common/src/gRPC/Validators/CreateSessionRequestValidator.cs
@@ -26,13 +26,16 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 
 using FluentValidation;
 
-using JetBrains.Annotations;
-
 namespace ArmoniK.Core.Common.gRPC.Validators;
 
-[UsedImplicitly]
+/// <summary>
+///   Validator for <see cref="CreateSessionRequest" />
+/// </summary>
 public class CreateSessionRequestValidator : AbstractValidator<CreateSessionRequest>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="CreateSessionRequest" />
+  /// </summary>
   public CreateSessionRequestValidator()
     => RuleFor(request => request.DefaultTaskOption)
        .SetValidator(new TaskOptionsValidator())

--- a/Common/src/gRPC/Validators/CreateTaskRequestValidator.cs
+++ b/Common/src/gRPC/Validators/CreateTaskRequestValidator.cs
@@ -29,8 +29,14 @@ using FluentValidation;
 
 namespace ArmoniK.Core.Common.gRPC.Validators;
 
+/// <summary>
+///   Validator for <see cref="CreateSmallTaskRequest" />
+/// </summary>
 public class CreateSmallTaskRequestValidator : AbstractValidator<CreateSmallTaskRequest>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="CreateSmallTaskRequest" />
+  /// </summary>
   public CreateSmallTaskRequestValidator()
   {
     RuleFor(r => r.SessionId)
@@ -46,8 +52,14 @@ public class CreateSmallTaskRequestValidator : AbstractValidator<CreateSmallTask
   }
 
 
+  /// <summary>
+  ///   Validator for <see cref="TaskRequest" />
+  /// </summary>
   public class TaskRequestValidator : AbstractValidator<TaskRequest>
   {
+    /// <summary>
+    ///   Initializes a validator for <see cref="TaskRequest" />
+    /// </summary>
     public TaskRequestValidator()
     {
       RuleFor(r => r.DataDependencies)
@@ -62,8 +74,14 @@ public class CreateSmallTaskRequestValidator : AbstractValidator<CreateSmallTask
   }
 }
 
+/// <summary>
+///   Validator for <see cref="CreateLargeTaskRequest" />
+/// </summary>
 public class CreateLargeTaskRequestValidator : AbstractValidator<CreateLargeTaskRequest>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="CreateLargeTaskRequest" />
+  /// </summary>
   public CreateLargeTaskRequestValidator()
   {
     RuleFor(r => r.TypeCase)

--- a/Common/src/gRPC/Validators/ListSessionsRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListSessionsRequestValidator.cs
@@ -26,13 +26,16 @@ using ArmoniK.Api.gRPC.V1.Sessions;
 
 using FluentValidation;
 
-using JetBrains.Annotations;
-
 namespace ArmoniK.Core.Common.gRPC.Validators;
 
-[UsedImplicitly]
+/// <summary>
+///   Validator for <see cref="ListSessionsRequest" />
+/// </summary>
 public class ListSessionsRequestValidator : AbstractValidator<ListSessionsRequest>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="ListSessionsRequest" />
+  /// </summary>
   public ListSessionsRequestValidator()
   {
     RuleFor(request => request.Page)

--- a/Common/src/gRPC/Validators/ListTasksRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListTasksRequestValidator.cs
@@ -26,13 +26,16 @@ using ArmoniK.Api.gRPC.V1.Tasks;
 
 using FluentValidation;
 
-using JetBrains.Annotations;
-
 namespace ArmoniK.Core.Common.gRPC.Validators;
 
-[UsedImplicitly]
+/// <summary>
+///   Validator for <see cref="ListTasksRequest" />
+/// </summary>
 public class ListTasksRequestValidator : AbstractValidator<ListTasksRequest>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="ListTasksRequest" />
+  /// </summary>
   public ListTasksRequestValidator()
   {
     RuleFor(request => request.Page)

--- a/Common/src/gRPC/Validators/SessionFilterValidator.cs
+++ b/Common/src/gRPC/Validators/SessionFilterValidator.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -26,13 +26,16 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 
 using FluentValidation;
 
-using JetBrains.Annotations;
-
 namespace ArmoniK.Core.Common.gRPC.Validators;
 
-[UsedImplicitly]
+/// <summary>
+///   Validator for <see cref="SessionFilter" />
+/// </summary>
 public class SessionFilterValidator : AbstractValidator<SessionFilter>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="SessionFilter" />
+  /// </summary>
   public SessionFilterValidator()
   {
     RuleFor(filter => filter.Included)

--- a/Common/src/gRPC/Validators/TaskFilterValidator.cs
+++ b/Common/src/gRPC/Validators/TaskFilterValidator.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -37,6 +37,7 @@ namespace ArmoniK.Core.Common.gRPC.Validators;
 public class TaskFilterValidator : AbstractValidator<TaskFilter>
 {
   /// <summary>
+  ///   Initializes a validator for <see cref="TaskFilter" />
   ///   Either filter on task id or session id.
   ///   The one selected should not be empty
   ///   Filter on Status is not mandatory but the one selected has to have at least one element

--- a/Common/src/gRPC/Validators/TaskOptionsValidator.cs
+++ b/Common/src/gRPC/Validators/TaskOptionsValidator.cs
@@ -28,8 +28,14 @@ using FluentValidation;
 
 namespace ArmoniK.Core.Common.gRPC.Validators;
 
+/// <summary>
+///   Validator for <see cref="TaskOptions" />
+/// </summary>
 public class TaskOptionsValidator : AbstractValidator<TaskOptions>
 {
+  /// <summary>
+  ///   Initializes a validator for <see cref="TaskOptions" />
+  /// </summary>
   public TaskOptionsValidator()
   {
     RuleFor(o => o.MaxRetries)


### PR DESCRIPTION
Improves the documentation of public items. It reduces the number of warnings that comes from the addition of `<GenerateDocumentationFile>true</GenerateDocumentationFile>` in the `.csproj` file of the Common project. One of our goals is to eliminate all the warning due to this option by populating all the missing documentation fields.

fix https://github.com/aneoconsulting/ArmoniK/issues/577