### PR TITLE
Add more doc

### DIFF
--- a/Common/src/Pollster/ComputeRequestQueue.cs
+++ b/Common/src/Pollster/ComputeRequestQueue.cs
@@ -36,8 +36,8 @@ using Microsoft.Extensions.Logging;
 namespace ArmoniK.Core.Common.Pollster;
 
 /// <summary>
-///   Queue for converting data to their corresponding <see cref="ProcessRequest.Types.ComputeRequest" /> while verifying
-///   their consistency through state machines
+///   Queue to identify input data with a <see cref="ProcessRequest.Types.ComputeRequest" /> while verifying
+///   the request ordering with state machines
 /// </summary>
 public class ComputeRequestQueue
 {
@@ -118,7 +118,7 @@ public class ComputeRequestQueue
   }
 
   /// <summary>
-  ///   Add request representing the end of the payload in the queue
+  ///   Add a request representing the end of the payload in the queue
   /// </summary>
   /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void CompletePayload()
@@ -134,7 +134,7 @@ public class ComputeRequestQueue
   }
 
   /// <summary>
-  ///   Add request representing the start of a data dependency in the queue
+  ///   Add a request representing the start of a data dependency in the queue
   /// </summary>
   /// <param name="key">The identifier of the data dependency</param>
   /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
@@ -151,7 +151,7 @@ public class ComputeRequestQueue
   }
 
   /// <summary>
-  ///   Add request containing the given data chunk for the data dependency in the queue
+  ///   Add a request containing the given data chunk for the data dependency in the queue
   /// </summary>
   /// <param name="chunk">Data chunk</param>
   /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
@@ -168,7 +168,7 @@ public class ComputeRequestQueue
   }
 
   /// <summary>
-  ///   Add request representing the end of the data dependency in the queue
+  ///   Add a request representing the end of the data dependency in the queue
   /// </summary>
   /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void CompleteDataDependency()

--- a/Common/src/Pollster/ComputeRequestQueue.cs
+++ b/Common/src/Pollster/ComputeRequestQueue.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -22,6 +22,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1;
@@ -34,6 +35,10 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Common.Pollster;
 
+/// <summary>
+///   Queue for converting data to their corresponding <see cref="ProcessRequest.Types.ComputeRequest" /> while verifying
+///   their consistency through state machines
+/// </summary>
 public class ComputeRequestQueue
 {
   private readonly Queue<ProcessRequest.Types.ComputeRequest> computeRequests_;
@@ -41,6 +46,10 @@ public class ComputeRequestQueue
   private readonly ILogger                    logger_;
   private readonly ComputeRequestStateMachine machine_;
 
+  /// <summary>
+  ///   Initializes a queue that stores <see cref="ProcessRequest.Types.ComputeRequest" />
+  /// </summary>
+  /// <param name="logger"></param>
   public ComputeRequestQueue(ILogger logger)
   {
     logger_          = logger;
@@ -48,6 +57,16 @@ public class ComputeRequestQueue
     machine_         = new ComputeRequestStateMachine(logger_);
   }
 
+  /// <summary>
+  ///   Create the init computation request with the given parameters
+  /// </summary>
+  /// <param name="dataChunkMaxSize">The maximum size of a data chunk</param>
+  /// <param name="sessionId">The session identifier</param>
+  /// <param name="taskId">The task identifier</param>
+  /// <param name="taskOptions">The options of the task</param>
+  /// <param name="payload">The input data of the task</param>
+  /// <param name="expectedOutputKeys">Collection of data ids for the expected outputs of the task</param>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void Init(int           dataChunkMaxSize,
                    string        sessionId,
                    string        taskId,
@@ -81,6 +100,11 @@ public class ComputeRequestQueue
                              });
   }
 
+  /// <summary>
+  ///   Add the given payload chunk to the request queue
+  /// </summary>
+  /// <param name="chunk">Data chunk</param>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void AddPayloadChunk(ByteString chunk)
   {
     machine_.AddPayloadChunk();
@@ -93,6 +117,10 @@ public class ComputeRequestQueue
                              });
   }
 
+  /// <summary>
+  ///   Add request representing the end of the payload in the queue
+  /// </summary>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void CompletePayload()
   {
     machine_.CompletePayload();
@@ -105,6 +133,11 @@ public class ComputeRequestQueue
                              });
   }
 
+  /// <summary>
+  ///   Add request representing the start of a data dependency in the queue
+  /// </summary>
+  /// <param name="key">The identifier of the data dependency</param>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void InitDataDependency(string key)
   {
     machine_.InitDataDependency();
@@ -117,7 +150,11 @@ public class ComputeRequestQueue
                              });
   }
 
-
+  /// <summary>
+  ///   Add request containing the given data chunk for the data dependency in the queue
+  /// </summary>
+  /// <param name="chunk">Data chunk</param>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void AddDataDependencyChunk(ByteString chunk)
   {
     machine_.AddDataDependencyChunk();
@@ -130,6 +167,10 @@ public class ComputeRequestQueue
                              });
   }
 
+  /// <summary>
+  ///   Add request representing the end of the data dependency in the queue
+  /// </summary>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public void CompleteDataDependency()
   {
     machine_.CompleteDataDependency();
@@ -142,6 +183,13 @@ public class ComputeRequestQueue
                              });
   }
 
+  /// <summary>
+  ///   Get the queue with the complete compute request
+  /// </summary>
+  /// <returns>
+  ///   The queue with the complete compute request
+  /// </returns>
+  /// <exception cref="InvalidOperationException">Invalid request according to the state machine</exception>
   public Queue<ProcessRequest.Types.ComputeRequest> GetQueue()
   {
     machine_.CompleteRequest();

--- a/Common/src/Pollster/IAgentHandler.cs
+++ b/Common/src/Pollster/IAgentHandler.cs
@@ -46,9 +46,9 @@ public interface IAgentHandler
   /// </summary>
   /// <param name="token">Token that can be used to differentiate running tasks</param>
   /// <param name="logger">Logger that may be injected into the handler that embed preconfigured scopes</param>
-  /// <param name="taskId"></param>
+  /// <param name="sessionData">Session metadata</param>
+  /// <param name="taskData">Task metadata</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
-  /// <param name="sessionId"></param>
   /// <returns>
   ///   Task representing the asynchronous execution of the method
   /// </returns>

--- a/Common/src/StateMachines/UmlMermaidGraphStyle.cs
+++ b/Common/src/StateMachines/UmlMermaidGraphStyle.cs
@@ -30,6 +30,7 @@ using Stateless.Graph;
 
 namespace ArmoniK.Core.Common.StateMachines;
 
+/// <inheritdoc />
 public class UmlMermaidGraphStyle : GraphStyleBase
 {
   /// <inheritdoc />

--- a/Common/src/Storage/IPullQueueStorage.cs
+++ b/Common/src/Storage/IPullQueueStorage.cs
@@ -38,7 +38,7 @@ public interface IPullQueueStorage : IQueueStorage
   /// <param name="nbMessages">Number of messages to retrieve</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
-  ///   Async Enumerable of queue messages
+  ///   Enumerator allowing async iteration over the message queue
   /// </returns>
   IAsyncEnumerable<IQueueMessageHandler> PullMessagesAsync(int               nbMessages,
                                                            CancellationToken cancellationToken = default);

--- a/Common/src/Storage/IPullQueueStorage.cs
+++ b/Common/src/Storage/IPullQueueStorage.cs
@@ -27,8 +27,19 @@ using System.Threading;
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Interface to retrieve messages from the queue
+/// </summary>
 public interface IPullQueueStorage : IQueueStorage
 {
+  /// <summary>
+  ///   Gets messages from the queue
+  /// </summary>
+  /// <param name="nbMessages">Number of messages to retrieve</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Async Enumerable of queue messages
+  /// </returns>
   IAsyncEnumerable<IQueueMessageHandler> PullMessagesAsync(int               nbMessages,
                                                            CancellationToken cancellationToken = default);
 }

--- a/Common/src/Storage/IPushQueueStorage.cs
+++ b/Common/src/Storage/IPushQueueStorage.cs
@@ -28,8 +28,21 @@ using System.Threading.Tasks;
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Interface to insert messages into the queue
+/// </summary>
 public interface IPushQueueStorage : IQueueStorage
 {
+  /// <summary>
+  ///   Puts messages into the queue
+  /// </summary>
+  /// <param name="messages">Collection of messages</param>
+  /// <param name="partitionId">Id of the partition</param>
+  /// <param name="priority">Priority of the tasks associated to the messages</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Task representing the asynchronous execution of the method
+  /// </returns>
   public Task PushMessagesAsync(IEnumerable<string> messages,
                                 string              partitionId,
                                 int                 priority          = 1,

--- a/Common/src/Storage/IQueueStorage.cs
+++ b/Common/src/Storage/IQueueStorage.cs
@@ -24,7 +24,13 @@
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Interface representing a queue
+/// </summary>
 public interface IQueueStorage : IInitializable
 {
+  /// <summary>
+  ///   Max priority supported by the queue
+  /// </summary>
   public int MaxPriority { get; }
 }

--- a/Common/src/Storage/Output.cs
+++ b/Common/src/Storage/Output.cs
@@ -28,7 +28,7 @@ using ArmoniK.Api.gRPC.V1.Tasks;
 namespace ArmoniK.Core.Common.Storage;
 
 /// <summary>
-///   Represents the output of a task
+///   Record encoding if a task successfully produced an output
 /// </summary>
 /// <param name="Success">xWhether the task is successful</param>
 /// <param name="Error">Error message if task is not successful</param>

--- a/Common/src/Storage/Output.cs
+++ b/Common/src/Storage/Output.cs
@@ -27,9 +27,18 @@ using ArmoniK.Api.gRPC.V1.Tasks;
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Represents the output of a task
+/// </summary>
+/// <param name="Success">xWhether the task is successful</param>
+/// <param name="Error">Error message if task is not successful</param>
 public record Output(bool   Success,
                      string Error)
 {
+  /// <summary>
+  ///   Convert the <see cref="Output" /> to <see cref=" Api.gRPC.V1.Output" />
+  /// </summary>
+  /// <param name="output">The object to convert</param>
   public static implicit operator Api.gRPC.V1.Output(Output output)
   {
     if (output.Success)
@@ -49,6 +58,10 @@ public record Output(bool   Success,
            };
   }
 
+  /// <summary>
+  ///   Convert the <see cref=" Api.gRPC.V1.Output" /> to <see cref="Output" />
+  /// </summary>
+  /// <param name="output">The object to convert</param>
   public static implicit operator Output(Api.gRPC.V1.Output output)
     => output.TypeCase switch
        {
@@ -58,6 +71,10 @@ public record Output(bool   Success,
                          output.Error.Details),
        };
 
+  /// <summary>
+  ///   Convert the <see cref="Output" /> to <see cref="TaskRaw.Types.Output" />
+  /// </summary>
+  /// <param name="output">The object to convert</param>
   public static implicit operator TaskRaw.Types.Output(Output output)
     => new()
        {
@@ -65,6 +82,10 @@ public record Output(bool   Success,
          Success = output.Success,
        };
 
+  /// <summary>
+  ///   Convert the <see cref="TaskRaw.Types.Output" /> to <see cref="Output" />
+  /// </summary>
+  /// <param name="output">The object to convert</param>
   public static implicit operator Output(TaskRaw.Types.Output output)
     => new(output.Success,
            output.Error);

--- a/Common/src/Storage/PartitionTaskStatusCount.cs
+++ b/Common/src/Storage/PartitionTaskStatusCount.cs
@@ -26,6 +26,12 @@ using ArmoniK.Api.gRPC.V1;
 
 namespace ArmoniK.Core.Common.Storage;
 
+/// <summary>
+///   Data structure to hold the count of tasks given their status and partition id
+/// </summary>
+/// <param name="PartitionId">Partition identifier</param>
+/// <param name="Status">Task status</param>
+/// <param name="Count">Number of task with the corresponding status and partition id</param>
 public record PartitionTaskStatusCount(string     PartitionId,
                                        TaskStatus Status,
                                        int        Count);


### PR DESCRIPTION
Improves the documentation of public items. It reduces the number of warnings that comes from the addition of `<GenerateDocumentationFile>true</GenerateDocumentationFile>` in the `.csproj` file of the Common project. One of our goals is to eliminate all the warning due to this option by populating all the missing documentation fields.

fix https://github.com/aneoconsulting/ArmoniK/issues/577