### PR TITLE
Remove not helping log

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -317,9 +317,6 @@ public class Pollster : IInitializable
             }
             catch (Exception e)
             {
-              logger_.LogError(e,
-                               "Error with messageHandler {messageId}",
-                               message.MessageId);
               RecordError(e);
             }
             finally


### PR DESCRIPTION
The Pollster was having a log that is not necessary anymore because there is a log of the same error in the HandleError in the TaskHandler. This PR remove this log.

fix https://github.com/aneoconsulting/ArmoniK/issues/605