### PR TITLE
Modified pipeline to merge arm images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -421,15 +421,11 @@ jobs:
           -f ${{ matrix.path }} . \
           --push
 
-    - name: Get manifest
-      run: |
-        docker manifest inspect --verbose ${{ matrix.img }}:${VERSION}-arm | jq '.Descriptor' > descr.json
-        cat descr.json
+    - name: Create multi-arch manifest
+      run: docker create manifest ${{ matrix.img }}:$VERSION -a ${{ matrix.img }}:$VERSION -a ${{ matrix.img }}:$VERSION-arm
 
-    - name: Tag
-      continue-on-error: true
-      run: |
-        docker buildx imagetools create ${{ matrix.img }}:$VERSION -t ${{ matrix.img }}:$VERSION --append -f descr.json
+    - name: Push multi-arch manifest
+      run: docker manifest push ${{ matrix.img }}:$VERSION
 
   testStreamDC:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -422,10 +422,10 @@ jobs:
           --push
 
     - name: Create multi-arch manifest
-      run: docker create manifest ${{ matrix.img }}:$VERSION -a ${{ matrix.img }}:$VERSION -a ${{ matrix.img }}:$VERSION-arm
+      run: docker manifest create ${{ matrix.img }}:${VERSION} -a ${{ matrix.img }}:${VERSION} -a ${{ matrix.img }}:${VERSION}-arm
 
     - name: Push multi-arch manifest
-      run: docker manifest push ${{ matrix.img }}:$VERSION
+      run: docker manifest push ${{ matrix.img }}:${VERSION}
 
   testStreamDC:
     needs:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -58,12 +58,10 @@ jobs:
     - name: ReTag
       run: |
         set -xe
-        CONTENT_TYPE="application/vnd.docker.distribution.manifest.v2+json"
-        # CONTENT_TYPE="application/vnd.docker.distribution.manifest.list.v2+json" # we need a list when there is multiple tags for multi arch images
-        TOKEN="$(curl -fsSL -u dhaneo1:${{ secrets.DOCKER_HUB_TOKEN }} "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${{ matrix.image }}:pull,push" | jq --raw-output .token)"
-        curl -fsSL -H "Accept: ${CONTENT_TYPE}" -H "Authorization: Bearer ${TOKEN}" "https://index.docker.io/v2/${{ matrix.image }}/manifests/${VERSION}" > manifest.json
-        curl -fsSL -X PUT -H "Content-Type: ${CONTENT_TYPE}" -H "Authorization: Bearer ${TOKEN}" -d @manifest.json "https://index.docker.io/v2/${{ matrix.image }}/manifests/${RELEASE}"
-        curl -fsSL -X PUT -H "Content-Type: ${CONTENT_TYPE}" -H "Authorization: Bearer ${TOKEN}" -d @manifest.json "https://index.docker.io/v2/${{ matrix.image }}/manifests/latest"
+        docker manifest inspect ${{ matrix.image }}:$VERSION | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:${RELEASE} -a 
+        docker manifest inspect ${{ matrix.image }}:$VERSION | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:latest -a 
+        docker manifest push ${{ matrix.image }}:${RELEASE}
+        docker manifest push ${{ matrix.image }}:latest
 
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -58,8 +58,8 @@ jobs:
     - name: ReTag
       run: |
         set -xe
-        docker manifest inspect ${{ matrix.image }}:$VERSION | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:${RELEASE} -a 
-        docker manifest inspect ${{ matrix.image }}:$VERSION | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:latest -a 
+        docker manifest inspect ${{ matrix.image }}:${VERSION} | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:${RELEASE} -a 
+        docker manifest inspect ${{ matrix.image }}:${VERSION} | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:latest -a 
         docker manifest push ${{ matrix.image }}:${RELEASE}
         docker manifest push ${{ matrix.image }}:latest
 


### PR DESCRIPTION
At some point the previous way to merge docker images as the same tag with different plateforms (x86, arm) stopped working. Therefore, the ARM variant of the docker images was not available anymore in our regular tags.

This PR fixes this issue.
fix https://github.com/aneoconsulting/ArmoniK/issues/625