### PR TITLE
fix for 636 - Mark the pollster as failed when worker is unavailable

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -320,7 +320,6 @@ public class Pollster : IInitializable
             catch (RpcException e) when (e.StatusCode == StatusCode.Unavailable)
             {
               // This exception should stop pollster
-              RecordError(e);
               throw;
             }
             catch (Exception e)
@@ -336,6 +335,9 @@ public class Pollster : IInitializable
         catch (RpcException e) when (e.StatusCode == StatusCode.Unavailable)
         {
           // This exception should stop pollster
+          healthCheckFailedResult_ = HealthCheckResult.Unhealthy("Worker unavailable",
+                                                                 e);
+          cts.Cancel();
           throw;
         }
         catch (TooManyException)

--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -37,6 +37,8 @@ using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Stream.Worker;
 using ArmoniK.Core.Common.Utils;
 
+using Grpc.Core;
+
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -315,6 +317,12 @@ public class Pollster : IInitializable
                 }
               }
             }
+            catch (RpcException e) when (e.StatusCode == StatusCode.Unavailable)
+            {
+              // This exception should stop pollster
+              RecordError(e);
+              throw;
+            }
             catch (Exception e)
             {
               RecordError(e);
@@ -324,6 +332,11 @@ public class Pollster : IInitializable
               TaskProcessing = string.Empty;
             }
           }
+        }
+        catch (RpcException e) when (e.StatusCode == StatusCode.Unavailable)
+        {
+          // This exception should stop pollster
+          throw;
         }
         catch (TooManyException)
         {

--- a/Common/tests/Helpers/TestUnavailableRpcException.cs
+++ b/Common/tests/Helpers/TestUnavailableRpcException.cs
@@ -1,0 +1,59 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using Grpc.Core;
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+public class TestUnavailableRpcException : RpcException
+{
+  public TestUnavailableRpcException()
+    : base(new Status(StatusCode.Unavailable,
+                      ""))
+  {
+  }
+
+  public TestUnavailableRpcException(string message)
+    : base(new Status(StatusCode.Unavailable,
+                      ""),
+           message)
+  {
+  }
+
+  public TestUnavailableRpcException(Metadata trailers)
+    : base(new Status(StatusCode.Unavailable,
+                      ""),
+           trailers)
+  {
+  }
+
+  public TestUnavailableRpcException(Metadata trailers,
+                                     string   message)
+    : base(new Status(StatusCode.Unavailable,
+                      ""),
+           trailers,
+           message)
+  {
+  }
+}

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -924,6 +924,12 @@ public class TaskHandlerTest
                                                                                       .SetArgDisplayNames("ExceptionTaskCancellation");
       yield return new TestCaseData(new ExceptionWorkerStreamHandler<TestRpcException>(3000)).Returns(TaskStatus.Submitted)
                                                                                              .SetArgDisplayNames("RpcExceptionTaskCancellation");
+
+      // Worker unavailable and therefore should be considered as cancelled task and resend into queue
+      yield return new TestCaseData(new ExceptionWorkerStreamHandler<TestUnavailableRpcException>(0)).Returns(TaskStatus.Submitted)
+                                                                                                     .SetArgDisplayNames("UnavailableBeforeCancellation");
+      yield return new TestCaseData(new ExceptionWorkerStreamHandler<TestUnavailableRpcException>(3000)).Returns(TaskStatus.Submitted)
+                                                                                                        .SetArgDisplayNames("UnavailableAfterCancellation");
     }
   }
 


### PR DESCRIPTION
cherry pick jg/fix636 for 0.6.7 release