### PR TITLE
Add podname, acquisition date and reception date in TaskData

### DIFF
--- a/Adaptors/Amqp/src/QueueMessageHandler.cs
+++ b/Adaptors/Amqp/src/QueueMessageHandler.cs
@@ -56,6 +56,7 @@ public class QueueMessageHandler : IQueueMessageHandler
     logger_           = logger;
     TaskId            = taskId;
     CancellationToken = cancellationToken;
+    ReceptionDateTime = DateTime.UtcNow;
   }
 
   /// <inheritdoc />
@@ -70,6 +71,9 @@ public class QueueMessageHandler : IQueueMessageHandler
 
   /// <inheritdoc />
   public QueueMessageStatus Status { get; set; }
+
+  /// <inheritdoc />
+  public DateTime ReceptionDateTime { get; init; }
 
   /// <inheritdoc />
   public async ValueTask DisposeAsync()

--- a/Adaptors/Memory/src/PushQueueStorage.cs
+++ b/Adaptors/Memory/src/PushQueueStorage.cs
@@ -206,6 +206,9 @@ public class PushQueueStorage : IPushQueueStorage
 
     /// <inheritdoc />
     public QueueMessageStatus Status { get; set; }
+
+    /// <inheritdoc />
+    public DateTime ReceptionDateTime { get; init; }
   }
 
   private class MessageComparer : IComparer<MessageHandler>

--- a/Adaptors/Memory/src/QueueStorage.cs
+++ b/Adaptors/Memory/src/QueueStorage.cs
@@ -258,6 +258,9 @@ public class QueueStorage : IQueueStorage
 
     /// <inheritdoc />
     public QueueMessageStatus Status { get; set; } = 0;
+
+    /// <inheritdoc />
+    public DateTime ReceptionDateTime { get; init; }
   }
 
   private class MessageComparer : IComparer<MessageHandler>

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -497,6 +497,8 @@ public class TaskTable : ITaskTable
   /// <inheritdoc />
   public Task<TaskData> AcquireTask(string            taskId,
                                     string            ownerPodId,
+                                    string            ownerPodName,
+                                    DateTime          receptionDate,
                                     CancellationToken cancellationToken = default)
     => Task.FromResult(taskId2TaskData_.AddOrUpdate(taskId,
                                                     _ => throw new InvalidOperationException("The task does not exist."),
@@ -511,6 +513,9 @@ public class TaskTable : ITaskTable
                                                       return data with
                                                              {
                                                                OwnerPodId = ownerPodId,
+                                                               OwnerPodName = ownerPodName,
+                                                               ReceptionDate = receptionDate,
+                                                               AcquisitionDate = DateTime.UtcNow,
                                                              };
                                                     }));
 
@@ -532,6 +537,9 @@ public class TaskTable : ITaskTable
                                                       return data with
                                                              {
                                                                OwnerPodId = "",
+                                                               OwnerPodName = "",
+                                                               AcquisitionDate = null,
+                                                               ReceptionDate = null,
                                                              };
                                                     }));
 
@@ -576,6 +584,7 @@ public class TaskTable : ITaskTable
     var newTaskData = new TaskData(taskData.SessionId,
                                    newTaskId,
                                    "",
+                                   "",
                                    taskData.PayloadId,
                                    taskData.ParentTaskIds,
                                    taskData.DataDependencies,
@@ -586,6 +595,8 @@ public class TaskTable : ITaskTable
                                    "",
                                    taskData.Options,
                                    DateTime.UtcNow,
+                                   null,
+                                   null,
                                    null,
                                    null,
                                    null,

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -47,6 +47,8 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                                                   .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.OwnerPodId))
                                                   .SetIsRequired(true);
+                                                cm.MapProperty(nameof(TaskData.OwnerPodName))
+                                                  .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.PayloadId))
                                                   .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.ParentTaskIds))
@@ -74,6 +76,10 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                                                   .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.EndDate))
                                                   .SetIsRequired(true);
+                                                cm.MapProperty(nameof(TaskData.ReceptionDate))
+                                                  .SetIsRequired(true);
+                                                cm.MapProperty(nameof(TaskData.AcquisitionDate))
+                                                  .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.PodTtl))
                                                   .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.Output))
@@ -82,6 +88,7 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                                                 cm.MapCreator(model => new TaskData(model.SessionId,
                                                                                     model.TaskId,
                                                                                     model.OwnerPodId,
+                                                                                    model.OwnerPodName,
                                                                                     model.PayloadId,
                                                                                     model.ParentTaskIds,
                                                                                     model.DataDependencies,
@@ -95,6 +102,8 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                                                                                     model.SubmittedDate,
                                                                                     model.StartDate,
                                                                                     model.EndDate,
+                                                                                    model.ReceptionDate,
+                                                                                    model.AcquisitionDate,
                                                                                     model.PodTtl,
                                                                                     model.Output));
                                               });

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -601,6 +601,8 @@ public class TaskTable : ITaskTable
   /// <inheritdoc />
   public async Task<TaskData> AcquireTask(string            taskId,
                                           string            ownerPodId,
+                                          string            ownerPodName,
+                                          DateTime          receptionDate,
                                           CancellationToken cancellationToken = default)
   {
     using var activity       = activitySource_.StartActivity($"{nameof(AcquireTask)}");
@@ -608,6 +610,12 @@ public class TaskTable : ITaskTable
 
     var updateDefinition = new UpdateDefinitionBuilder<TaskData>().Set(tdm => tdm.OwnerPodId,
                                                                        ownerPodId)
+                                                                  .Set(tdm => tdm.OwnerPodName,
+                                                                       ownerPodName)
+                                                                  .Set(tdm => tdm.ReceptionDate,
+                                                                       receptionDate)
+                                                                  .Set(tdm => tdm.AcquisitionDate,
+                                                                       DateTime.UtcNow)
                                                                   .Set(tdm => tdm.Status,
                                                                        TaskStatus.Dispatched);
 
@@ -640,6 +648,12 @@ public class TaskTable : ITaskTable
 
     var updateDefinition = new UpdateDefinitionBuilder<TaskData>().Set(tdm => tdm.OwnerPodId,
                                                                        "")
+                                                                  .Set(tdm => tdm.OwnerPodName,
+                                                                       "")
+                                                                  .Set(tdm => tdm.AcquisitionDate,
+                                                                       null)
+                                                                  .Set(tdm => tdm.ReceptionDate,
+                                                                       null)
                                                                   .Set(tdm => tdm.Status,
                                                                        TaskStatus.Submitted);
 
@@ -772,6 +786,7 @@ public class TaskTable : ITaskTable
     var newTaskData = new TaskData(taskData.SessionId,
                                    newTaskId,
                                    "",
+                                   "",
                                    taskData.PayloadId,
                                    taskData.ParentTaskIds,
                                    taskData.DataDependencies,
@@ -782,6 +797,8 @@ public class TaskTable : ITaskTable
                                    "",
                                    taskData.Options,
                                    DateTime.UtcNow,
+                                   null,
+                                   null,
                                    null,
                                    null,
                                    null,

--- a/Adaptors/MongoDB/tests/BsonSerializerTest.cs
+++ b/Adaptors/MongoDB/tests/BsonSerializerTest.cs
@@ -122,6 +122,7 @@ internal class BsonSerializerTest
     var tdm = new TaskData("SessionId",
                            "TaskCompletedId",
                            "OwnerPodId",
+                           "OwnerPodName",
                            "PayloadId",
                            new[]
                            {

--- a/Adaptors/MongoDB/tests/ExpressionsBuildersFieldFilterExpressionTests.cs
+++ b/Adaptors/MongoDB/tests/ExpressionsBuildersFieldFilterExpressionTests.cs
@@ -64,6 +64,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("Session",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -99,6 +100,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -135,6 +137,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("Session",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -171,6 +174,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -207,6 +211,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -243,6 +248,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -279,6 +285,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -316,6 +323,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -351,6 +359,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -387,6 +396,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -423,6 +433,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -460,6 +471,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -495,6 +507,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -531,6 +544,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -567,6 +581,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -604,6 +619,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -639,6 +655,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "OtherTask",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -675,6 +692,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "OtherTask",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -711,6 +729,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "OtherTask",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -748,6 +767,7 @@ internal class ExpressionsBuildersFieldFilterExpressionTests
     var model = new TaskData("OtherSession",
                              "OtherTask",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {

--- a/Adaptors/MongoDB/tests/TaskFilterExtTests.cs
+++ b/Adaptors/MongoDB/tests/TaskFilterExtTests.cs
@@ -69,6 +69,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("Session",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -109,6 +110,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("OtherSession",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -157,6 +159,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -204,6 +207,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -252,6 +256,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -300,6 +305,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -347,6 +353,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -394,6 +401,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -442,6 +450,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -490,6 +499,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -531,6 +541,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -573,6 +584,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "Task",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -614,6 +626,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {
@@ -656,6 +669,7 @@ internal class TaskFilterExtTests
     var model = new TaskData("SessionId",
                              "TaskCompletedId",
                              "OwnerPodId",
+                             "OwnerPodName",
                              "PayloadId",
                              new[]
                              {

--- a/Adaptors/RabbitMQ/src/QueueMessageHandler.cs
+++ b/Adaptors/RabbitMQ/src/QueueMessageHandler.cs
@@ -53,6 +53,7 @@ public class QueueMessageHandler : IQueueMessageHandler
     deliverEvent_     = deliverEvent;
     CancellationToken = cancellationToken;
     channel_          = channel;
+    ReceptionDateTime = DateTime.UtcNow;
   }
 
   /// <inheritdoc />
@@ -67,6 +68,9 @@ public class QueueMessageHandler : IQueueMessageHandler
 
   /// <inheritdoc />
   public QueueMessageStatus Status { get; set; }
+
+  /// <inheritdoc />
+  public DateTime ReceptionDateTime { get; init; }
 
   public ValueTask DisposeAsync()
   {

--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -26,7 +26,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Core" Version="3.2.0-SNAPSHOT.4.d624710" />
+    <PackageReference Include="ArmoniK.Api.Core" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.2.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.49.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.1.0" />

--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Net;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -55,6 +56,7 @@ public class Pollster : IInitializable
   private readonly int                        messageBatchSize_;
   private readonly IObjectStorageFactory      objectStorageFactory_;
   private readonly string                     ownerPodId_;
+  private readonly string                     ownerPodName_;
   private readonly Injection.Options.Pollster pollsterOptions_;
   private readonly IPullQueueStorage          pullQueueStorage_;
   private readonly IResultTable               resultTable_;
@@ -106,6 +108,7 @@ public class Pollster : IInitializable
     agentHandler_          = agentHandler;
     TaskProcessing         = "";
     ownerPodId_            = LocalIPv4.GetLocalIPv4Ethernet();
+    ownerPodName_          = Dns.GetHostName();
     Failed                 = false;
   }
 
@@ -284,6 +287,7 @@ public class Pollster : IInitializable
                                                             message,
                                                             taskProcessingChecker_,
                                                             ownerPodId_,
+                                                            ownerPodName_,
                                                             activitySource_,
                                                             agentHandler_,
                                                             logger_,

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -56,6 +56,7 @@ public class TaskHandler : IAsyncDisposable
   private readonly ILogger                                     logger_;
   private readonly IQueueMessageHandler                        messageHandler_;
   private readonly string                                      ownerPodId_;
+  private readonly string                                      ownerPodName_;
   private readonly CancellationTokenRegistration               reg1_;
   private readonly IResultTable                                resultTable_;
   private readonly ISessionTable                               sessionTable_;
@@ -79,6 +80,7 @@ public class TaskHandler : IAsyncDisposable
                      IQueueMessageHandler       messageHandler,
                      ITaskProcessingChecker     taskProcessingChecker,
                      string                     ownerPodId,
+                     string                     ownerPodName,
                      ActivitySource             activitySource,
                      IAgentHandler              agentHandler,
                      ILogger                    logger,
@@ -98,6 +100,7 @@ public class TaskHandler : IAsyncDisposable
     logger_                  = logger;
     cancellationTokenSource_ = cancellationTokenSource;
     ownerPodId_              = ownerPodId;
+    ownerPodName_            = ownerPodName;
     taskData_                = null;
     sessionData_             = null;
     token_ = Guid.NewGuid()
@@ -311,6 +314,8 @@ public class TaskHandler : IAsyncDisposable
       logger_.LogDebug("Trying to acquire task");
       taskData_ = await taskTable_.AcquireTask(messageHandler_.TaskId,
                                                ownerPodId_,
+                                               ownerPodName_,
+                                               messageHandler_.ReceptionDateTime,
                                                CancellationToken.None)
                                   .ConfigureAwait(false);
 

--- a/Common/src/Storage/IQueueMessageHandler.cs
+++ b/Common/src/Storage/IQueueMessageHandler.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -47,4 +47,6 @@ public interface IQueueMessageHandler : IAsyncDisposable
   string TaskId { get; }
 
   QueueMessageStatus Status { get; set; }
+
+  DateTime ReceptionDateTime { get; init; }
 }

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -298,12 +298,16 @@ public interface ITaskTable : IInitializable
   /// </summary>
   /// <param name="taskId">Id of the task to acquire</param>
   /// <param name="ownerPodId">Identifier (Ip) that will be used to reach the pod if another pod tries to acquire the task</param>
+  /// <param name="ownerPodName">Hostname of the pollster</param>
+  /// <param name="receptionDate">Date when the message from the queue storage is received</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
   ///   Metadata of the task we try to acquire
   /// </returns>
   Task<TaskData> AcquireTask(string            taskId,
                              string            ownerPodId,
+                             string            ownerPodName,
+                             DateTime          receptionDate,
                              CancellationToken cancellationToken = default);
 
   /// <summary>

--- a/Common/src/Storage/QueueMessageHandler.cs
+++ b/Common/src/Storage/QueueMessageHandler.cs
@@ -48,6 +48,7 @@ public class QueueMessageHandler : IQueueMessageHandler
     MessageId         = messageId;
     TaskId            = taskId;
     CancellationToken = cancellationToken;
+    ReceptionDateTime = DateTime.UtcNow;
   }
 
   public string MessageId { get; init; }
@@ -56,6 +57,10 @@ public class QueueMessageHandler : IQueueMessageHandler
   /// <inheritdoc />
   public QueueMessageStatus Status { get; set; }
 
+  /// <inheritdoc />
+  public DateTime ReceptionDateTime { get; init; }
+
+  /// <inheritdoc />
   public CancellationToken CancellationToken { get; set; }
 
   /// <inheritdoc />

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -57,11 +57,14 @@ namespace ArmoniK.Core.Common.Storage;
 /// <param name="SubmittedDate">Date when the task is submitted</param>
 /// <param name="StartDate">Date when the task execution begins</param>
 /// <param name="EndDate">Date when the task ends</param>
+/// <param name="ReceptionDate">Date when the task is received by the polling agent</param>
+/// <param name="AcquisitionDate">Date when the task is acquired by the pollster</param>
 /// <param name="PodTtl">Task Time To Live on the current pod</param>
 /// <param name="Output">Output of the task after its successful completion</param>
 public record TaskData(string        SessionId,
                        string        TaskId,
                        string        OwnerPodId,
+                       string        OwnerPodName,
                        string        PayloadId,
                        IList<string> ParentTaskIds,
                        IList<string> DataDependencies,
@@ -75,6 +78,8 @@ public record TaskData(string        SessionId,
                        DateTime?     SubmittedDate,
                        DateTime?     StartDate,
                        DateTime?     EndDate,
+                       DateTime?     ReceptionDate,
+                       DateTime?     AcquisitionDate,
                        DateTime?     PodTtl,
                        Output        Output)
 {
@@ -84,6 +89,7 @@ public record TaskData(string        SessionId,
   /// <param name="sessionId">Unique identifier of the session in which the task belongs</param>
   /// <param name="taskId">Unique identifier of the task</param>
   /// <param name="ownerPodId">Identifier of the polling agent running the task</param>
+  /// <param name="ownerPodName">Hostname of the polling agent running the task</param>
   /// <param name="payloadId">Unique identifier of the payload in input of the task</param>
   /// <param name="parentTaskIds">
   ///   Unique identifiers of the tasks that submitted the current task up to the session id which
@@ -101,6 +107,7 @@ public record TaskData(string        SessionId,
   public TaskData(string        sessionId,
                   string        taskId,
                   string        ownerPodId,
+                  string        ownerPodName,
                   string        payloadId,
                   IList<string> parentTaskIds,
                   IList<string> dataDependencies,
@@ -112,6 +119,7 @@ public record TaskData(string        SessionId,
     : this(sessionId,
            taskId,
            ownerPodId,
+           ownerPodName,
            payloadId,
            parentTaskIds,
            dataDependencies,
@@ -122,6 +130,8 @@ public record TaskData(string        SessionId,
            "",
            options,
            DateTime.UtcNow,
+           null,
+           null,
            null,
            null,
            null,
@@ -177,6 +187,13 @@ public record TaskData(string        SessionId,
          SubmittedAt = taskData.SubmittedDate is not null
                          ? FromDateTime(taskData.SubmittedDate.Value)
                          : null,
+         AcquiredAt = taskData.AcquisitionDate is not null
+                        ? FromDateTime(taskData.AcquisitionDate.Value)
+                        : null,
+         ReceivedAt = taskData.ReceptionDate is not null
+                        ? FromDateTime(taskData.ReceptionDate.Value)
+                        : null,
+         PodHostname = taskData.OwnerPodName,
        };
 
   /// <summary>
@@ -201,6 +218,9 @@ public record TaskData(string        SessionId,
          StartedAt = taskData.StartDate is not null
                        ? FromDateTime(taskData.StartDate.Value)
                        : null,
+         Error = taskData.Status == TaskStatus.Error
+                   ? taskData.Output.Error
+                   : "",
        };
 
   /// <summary>

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -734,6 +734,7 @@ public class Submitter : ISubmitter
     await taskTable_.CreateTasks(requests.Select(request => new TaskData(sessionData.SessionId,
                                                                          request.Id,
                                                                          "",
+                                                                         "",
                                                                          request.Id,
                                                                          parentTaskIds,
                                                                          request.DataDependencies.ToList(),

--- a/Common/tests/Helpers/SimpleQueueMessageHandler.cs
+++ b/Common/tests/Helpers/SimpleQueueMessageHandler.cs
@@ -17,6 +17,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -33,4 +34,5 @@ public class SimpleQueueMessageHandler : IQueueMessageHandler
   public string             MessageId         { get; init; } = "";
   public string             TaskId            { get; set; }  = "";
   public QueueMessageStatus Status            { get; set; }
+  public DateTime           ReceptionDateTime { get; init; } = DateTime.UtcNow;
 }

--- a/Common/tests/ListApplicationsRequestExt/ToApplicationFieldTest.cs
+++ b/Common/tests/ListApplicationsRequestExt/ToApplicationFieldTest.cs
@@ -60,6 +60,7 @@ public class ToApplicationFieldTest
   private readonly TaskData taskData_ = new("SessionId",
                                             "TaskCompletedId",
                                             "OwnerPodId",
+                                            "OwnerPodName",
                                             "PayloadId",
                                             new[]
                                             {

--- a/Common/tests/ListApplicationsRequestExt/ToApplicationFilterTest.cs
+++ b/Common/tests/ListApplicationsRequestExt/ToApplicationFilterTest.cs
@@ -59,6 +59,7 @@ public class ToApplicationFilterTest
   private readonly TaskData taskData_ = new("SessionId",
                                             "TaskCompletedId",
                                             "OwnerPodId",
+                                            "OwnerPodName",
                                             "PayloadId",
                                             new[]
                                             {

--- a/Common/tests/ListTasksRequestExt/ToTaskDataFieldTest.cs
+++ b/Common/tests/ListTasksRequestExt/ToTaskDataFieldTest.cs
@@ -54,6 +54,7 @@ public class ToTaskDataFieldTest
   private readonly TaskData taskData_ = new("SessionId",
                                             "TaskCompletedId",
                                             "OwnerPodId",
+                                            "OwnerPodName",
                                             "PayloadId",
                                             new[]
                                             {

--- a/Common/tests/ListTasksRequestExt/ToTaskDataFilterTest.cs
+++ b/Common/tests/ListTasksRequestExt/ToTaskDataFilterTest.cs
@@ -56,6 +56,7 @@ public class ToTaskDataFilterTest
   private readonly TaskData taskData_ = new("SessionId",
                                             "TaskCompletedId",
                                             "OwnerPodId",
+                                            "OwnerPodName",
                                             "PayloadId",
                                             new[]
                                             {

--- a/Common/tests/Pollster/DataPrefetcherTest.cs
+++ b/Common/tests/Pollster/DataPrefetcherTest.cs
@@ -112,10 +112,12 @@ public class DataPrefetcherTest
     const string output1      = "Output1";
     const string dependency1  = "Dependency1";
     const string podId        = "PodId";
+    const string podName      = "PodName";
     const string payloadId    = "PayloadId";
     var res = await dataPrefetcher.PrefetchDataAsync(new TaskData(sessionId,
                                                                   taskId,
                                                                   podId,
+                                                                  podName,
                                                                   payloadId,
                                                                   new[]
                                                                   {
@@ -271,11 +273,13 @@ public class DataPrefetcherTest
     const string taskId       = "TaskId";
     const string output1      = "Output1";
     const string dependency1  = "Dependency1";
+    const string podName      = "PodName";
     const string podId        = "PodId";
     const string payloadId    = "PayloadId";
     var res = await dataPrefetcher.PrefetchDataAsync(new TaskData(sessionId,
                                                                   taskId,
                                                                   podId,
+                                                                  podName,
                                                                   payloadId,
                                                                   new[]
                                                                   {
@@ -365,10 +369,12 @@ public class DataPrefetcherTest
     const string output1      = "Output1";
     const string dependency1  = "Dependency1";
     const string podId        = "PodId";
+    const string podName      = "PodName";
     const string payloadId    = "PayloadId";
     var res = await dataPrefetcher.PrefetchDataAsync(new TaskData(sessionId,
                                                                   taskId,
                                                                   podId,
+                                                                  podName,
                                                                   payloadId,
                                                                   new[]
                                                                   {
@@ -458,10 +464,12 @@ public class DataPrefetcherTest
     const string output1      = "Output1";
     const string dependency1  = "Dependency1";
     const string podId        = "PodId";
+    const string podName      = "PodName";
     const string payloadId    = "PayloadId";
     var res = await dataPrefetcher.PrefetchDataAsync(new TaskData(sessionId,
                                                                   taskId,
                                                                   podId,
+                                                                  podName,
                                                                   payloadId,
                                                                   new[]
                                                                   {
@@ -546,10 +554,12 @@ public class DataPrefetcherTest
     const string dependency1  = "Dependency1";
     const string dependency2  = "Dependency2";
     const string podId        = "PodId";
+    const string podName      = "PodName";
     const string payloadId    = "PayloadId";
     var res = await dataPrefetcher.PrefetchDataAsync(new TaskData(sessionId,
                                                                   taskId,
                                                                   podId,
+                                                                  podName,
                                                                   payloadId,
                                                                   new[]
                                                                   {
@@ -635,10 +645,12 @@ public class DataPrefetcherTest
     const string dependency1  = "Dependency1";
     const string dependency2  = "Dependency2";
     const string podId        = "PodId";
+    const string podName      = "PodName";
     const string payloadId    = "PayloadId";
     var res = await dataPrefetcher.PrefetchDataAsync(new TaskData(sessionId,
                                                                   taskId,
                                                                   podId,
+                                                                  podName,
                                                                   payloadId,
                                                                   new[]
                                                                   {

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -355,6 +355,7 @@ public class TaskHandlerTest
                                 Guid.NewGuid()
                                     .ToString(),
                                 "ownerpodid",
+                                "ownerpodname",
                                 "payload",
                                 new List<string>(),
                                 new List<string>(),
@@ -374,6 +375,8 @@ public class TaskHandlerTest
                                                 "",
                                                 ""),
                                 DateTime.Now,
+                                null,
+                                null,
                                 null,
                                 null,
                                 null,
@@ -442,7 +445,8 @@ public class TaskHandlerTest
 
       return new TaskData("SessionId",
                           "taskId",
-                          "owner",
+                          "ownerpodid",
+                          "ownerpodname",
                           "payload",
                           new List<string>(),
                           new List<string>(),
@@ -461,6 +465,8 @@ public class TaskHandlerTest
                                           "",
                                           "",
                                           ""),
+                          DateTime.Now,
+                          DateTime.Now,
                           DateTime.Now,
                           DateTime.Now,
                           DateTime.Now,
@@ -550,6 +556,8 @@ public class TaskHandlerTest
 
     public async Task<TaskData> AcquireTask(string            taskId,
                                             string            ownerPodId,
+                                            string            ownerPodName,
+                                            DateTime          receptionDate,
                                             CancellationToken cancellationToken = default)
     {
       if (waitMethod_ == WaitMethod.Acquire)
@@ -561,6 +569,7 @@ public class TaskHandlerTest
       return new TaskData("SessionId",
                           taskId,
                           ownerPodId,
+                          ownerPodName,
                           "payload",
                           new List<string>(),
                           new List<string>(),
@@ -583,6 +592,8 @@ public class TaskHandlerTest
                           DateTime.Now,
                           DateTime.Now,
                           DateTime.Now,
+                          receptionDate,
+                          DateTime.Now,
                           DateTime.Now,
                           new Output(false,
                                      ""));
@@ -593,6 +604,7 @@ public class TaskHandlerTest
                                       CancellationToken cancellationToken = default)
       => Task.FromResult(new TaskData("SessionId",
                                       taskId,
+                                      ownerPodId,
                                       ownerPodId,
                                       "payload",
                                       new List<string>(),
@@ -612,6 +624,8 @@ public class TaskHandlerTest
                                                       "",
                                                       "",
                                                       ""),
+                                      DateTime.Now,
+                                      DateTime.Now,
                                       DateTime.Now,
                                       DateTime.Now,
                                       DateTime.Now,

--- a/Common/tests/Submitter/SubmitterTests.cs
+++ b/Common/tests/Submitter/SubmitterTests.cs
@@ -308,6 +308,7 @@ public class SubmitterTests
     var taskData = new TaskData(sessionId,
                                 taskCompletedId,
                                 "OwnerPodId",
+                                "OwnerPodName",
                                 "PayloadId",
                                 new List<string>(),
                                 new List<string>(),

--- a/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
+++ b/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.0.4" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />

--- a/Tests/Bench/Client/src/ExecutionStats.cs
+++ b/Tests/Bench/Client/src/ExecutionStats.cs
@@ -37,7 +37,7 @@ namespace ArmoniK.Samples.Bench.Client;
 /// <param name="TotalTasks">Total number of tasks executed in the application</param>
 /// <param name="ErrorTasks">Number of tasks in error in the application</param>
 /// <param name="CompletedTasks">Number of tasks completed in the application</param>
-/// <param name="CanceledTasks">Number of tasks canceled in the application</param>
+/// <param name="CancelledTasks">Number of tasks canceled in the application</param>
 public record ExecutionStats(TimeSpan ElapsedTime          = default,
                              TimeSpan SubmissionTime       = default,
                              TimeSpan TasksExecutionTime   = default,
@@ -46,4 +46,4 @@ public record ExecutionStats(TimeSpan ElapsedTime          = default,
                              int      TotalTasks           = default,
                              int      ErrorTasks           = default,
                              int      CompletedTasks       = default,
-                             int      CanceledTasks        = default);
+                             int      CancelledTasks       = default);

--- a/Tests/Bench/Client/src/Program.cs
+++ b/Tests/Bench/Client/src/Program.cs
@@ -234,8 +234,8 @@ internal static class Program
                                            .Sum(count => count.Count),
                   ErrorTasks = countAll.Values.Where(count => count.Status == TaskStatus.Error)
                                        .Sum(count => count.Count),
-                  CanceledTasks = countAll.Values.Where(count => count.Status is TaskStatus.Canceled or TaskStatus.Canceling)
-                                          .Sum(count => count.Count),
+                  CancelledTasks = countAll.Values.Where(count => count.Status is TaskStatus.Cancelled or TaskStatus.Cancelling)
+                                           .Sum(count => count.Count),
                 };
     logger.LogInformation("executions stats {@stats}",
                           stats);

--- a/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
+++ b/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.0.4" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
   </ItemGroup>
 

--- a/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
+++ b/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
@@ -25,7 +25,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="ArmoniK.Api.Client" Version="3.2.0-SNAPSHOT.4.d624710" />
+	  <PackageReference Include="ArmoniK.Api.Client" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />

--- a/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
+++ b/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.2.0-SNAPSHOT.4.d624710" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Htc.Mock" Version="3.0.0-alpha11" />
   </ItemGroup>

--- a/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
+++ b/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.2.0-SNAPSHOT.4.d624710" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="6.0.1" />

--- a/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
+++ b/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.2.0-SNAPSHOT.4.d624710" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.2.0-SNAPSHOT.8.ebd85d6" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add podname, acquisition date and reception date in TaskData and expose it through the new versions of ArmoniK.Api (3.2.0-SNAPSHOT.8.ebd85d6).

fix https://github.com/aneoconsulting/ArmoniK/issues/587
fix https://github.com/aneoconsulting/ArmoniK/issues/618