### PR TITLE
Revert "Fix versionning in pipeline"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,9 +72,9 @@ jobs:
       run: |
         if [[ "${{ github.ref_name }}" == "releases/"* ]]
         then
-          VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version:2.5.3 /bin/git-version --folder=/repo --release-branch=release --dev-branch=${{ github.ref_name }}) 
+          VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version /bin/git-version --folder=/repo --release-branch=release --dev-branch=${{ github.ref_name }}) 
         else
-          VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version:2.5.3 /bin/git-version --folder=/repo --release-branch=release --dev-branch=main)
+          VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version /bin/git-version --folder=/repo --release-branch=release --dev-branch=main)
         fi
 
         echo "version=$VERSION" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Fix is no longer needed
This reverts commit ce19b70eb42b11c7a5221ed77f73ffbf89ff5b65.

Should we pick a specific version and stick with it ?