### PR TITLE
Remove input payload after completed task in Redis

### DIFF
--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -456,6 +456,14 @@ public class Submitter : ISubmitter
       await taskTable_.SetTaskSuccessAsync(taskData.TaskId,
                                            cancellationToken)
                       .ConfigureAwait(false);
+
+      logger_.LogInformation("Remove input payload of {task}",
+                             taskData.TaskId);
+
+      await PayloadStorage(taskData.SessionId)
+            .TryDeleteAsync(taskData.TaskId,
+                            cancellationToken)
+            .ConfigureAwait(false);
     }
     else
     {

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -460,10 +460,11 @@ public class Submitter : ISubmitter
       logger_.LogInformation("Remove input payload of {task}",
                              taskData.TaskId);
 
-      await PayloadStorage(taskData.SessionId)
+      //Discard value is used to remove warnings CS4014 !!
+      _ = Task.Factory.StartNew(async () => await PayloadStorage(taskData.SessionId)
             .TryDeleteAsync(taskData.TaskId,
-                            cancellationToken)
-            .ConfigureAwait(false);
+                            CancellationToken.None)
+            .ConfigureAwait(false), cancellationToken);
     }
     else
     {

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -462,9 +462,10 @@ public class Submitter : ISubmitter
 
       //Discard value is used to remove warnings CS4014 !!
       _ = Task.Factory.StartNew(async () => await PayloadStorage(taskData.SessionId)
-            .TryDeleteAsync(taskData.TaskId,
-                            CancellationToken.None)
-            .ConfigureAwait(false), cancellationToken);
+                                                  .TryDeleteAsync(taskData.TaskId,
+                                                                  CancellationToken.None)
+                                                  .ConfigureAwait(false),
+                                cancellationToken);
     }
     else
     {

--- a/Common/tests/ObjectStorageTestBase.cs
+++ b/Common/tests/ObjectStorageTestBase.cs
@@ -236,23 +236,17 @@ public class ObjectStorageTestBase
       Assert.AreEqual(listChunks.Count,
                       res.Count);
 
-      foreach (var comparison in listChunks.Zip(res.Select(chunk => Encoding.ASCII.GetString(chunk)),
-                                                (resChunk,
-                                                 expectedData) => new
-                                                                  {
-                                                                    Result       = resChunk,
-                                                                    ExpectedData = expectedData,
-                                                                  }))
-      {
-        Assert.AreEqual(comparison.ExpectedData,
-                        comparison.Result);
-      }
+      Assert.AreEqual(string.Join("",
+                                  listChunks),
+                      string.Join("",
+                                  res.Select(chunk => Encoding.ASCII.GetString(chunk)));
 
-      var resValue = ObjectStorage!.GetValuesAsync("dataKey");
+      await ObjectStorage!.TryDeleteAsync("dataKey")
+                          .ConfigureAwait(false);
 
-
-      Assert.ThrowsAsync<ObjectDataNotFoundException>(async () => await resValue.FirstAsync()
-                                                                                .ConfigureAwait(false));
+      Assert.ThrowsAsync<ObjectDataNotFoundException>(async () => await ObjectStorage!.GetValuesAsync("dataKey")
+                                                                                      .FirstAsync()
+                                                                                      .ConfigureAwait(false));
     }
   }
 }

--- a/Common/tests/ObjectStorageTestBase.cs
+++ b/Common/tests/ObjectStorageTestBase.cs
@@ -237,7 +237,7 @@ public class ObjectStorageTestBase
                       res.Count);
 
       Assert.AreEqual(string.Join("",
-                                  listChunks),
+                                  listChunks.Select(chunk => Encoding.ASCII.GetString(chunk))),
                       string.Join("",
                                   res.Select(chunk => Encoding.ASCII.GetString(chunk))));
 

--- a/Common/tests/ObjectStorageTestBase.cs
+++ b/Common/tests/ObjectStorageTestBase.cs
@@ -239,7 +239,7 @@ public class ObjectStorageTestBase
       Assert.AreEqual(string.Join("",
                                   listChunks),
                       string.Join("",
-                                  res.Select(chunk => Encoding.ASCII.GetString(chunk)));
+                                  res.Select(chunk => Encoding.ASCII.GetString(chunk))));
 
       await ObjectStorage!.TryDeleteAsync("dataKey")
                           .ConfigureAwait(false);


### PR DESCRIPTION
Redis is a in memory database and it should be use as Cold Db when the data won't be used anymore. For input data we know the input should be removed when the task is properly completed. 

This feature removes the input data when the task was marked as completed in the taskTable

- [X] Update the function TryDeleteKeyAsync in ObjectStorage of Redis
- [X] Call the delete method in post-processing of submitter when task is in Success state