### PR TITLE
Fix multiple connections in AMQP adapter

### DIFF
--- a/Common/src/Utils/AsyncLazy.cs
+++ b/Common/src/Utils/AsyncLazy.cs
@@ -1,5 +1,5 @@
 ﻿// This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
 //   J. Gurhem         <jgurhem@aneo.fr>
@@ -8,17 +8,17 @@
 //   F. Lemaitre       <flemaitre@aneo.fr>
 //   S. Djebbar        <sdjebbar@aneo.fr>
 //   J. Fonseca        <jfonseca@aneo.fr>
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -41,5 +41,25 @@ public class AsyncLazy<T> : Lazy<Task<T>>
   }
 
   public TaskAwaiter<T> GetAwaiter()
+    => Value.GetAwaiter();
+}
+
+public class AsyncLazy : Lazy<Task>
+{
+  public AsyncLazy(Action valueFactory)
+    : base(() =>
+           {
+             valueFactory();
+             return Task.CompletedTask;
+           })
+  {
+  }
+
+  public AsyncLazy(Func<Task> taskFactory)
+    : base(taskFactory)
+  {
+  }
+
+  public TaskAwaiter GetAwaiter()
     => Value.GetAwaiter();
 }


### PR DESCRIPTION
An AMQP QueueStorage is initialized twice, and therefore create two connections to the queue. This fixes it by using an AsyncLazy.