### PR TITLE
Fix mongo db tests

### DIFF
--- a/Adaptors/MongoDB/tests/IndexTest.cs
+++ b/Adaptors/MongoDB/tests/IndexTest.cs
@@ -4,11 +4,12 @@ using System.Diagnostics;
 
 using ArmoniK.Core.Common.Storage;
 
+using EphemeralMongo;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Driver;
 
@@ -23,8 +24,14 @@ internal class IndexTest
   public void StartUp()
   {
     var logger = NullLogger.Instance;
-    runner_ = MongoDbRunner.Start(singleNodeReplSet: false,
-                                  logger: logger);
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = false,
+                    StandardOuputLogger     = line => logger.LogInformation(line),
+                    StandardErrorLogger     = line => logger.LogError(line),
+                  };
+
+    runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB
@@ -64,7 +71,7 @@ internal class IndexTest
     runner_?.Dispose();
   }
 
-  private                 MongoDbRunner?   runner_;
+  private                 IMongoRunner?    runner_;
   private                 IMongoClient?    client_;
   private const           string           DatabaseName   = "ArmoniK_TestDB";
   private static readonly ActivitySource   ActivitySource = new("ArmoniK.Core.Adapters.MongoDB.Tests");

--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 
 using ArmoniK.Core.Common.Injection.Options;
 
@@ -59,7 +60,8 @@ internal class MongoDatabaseProvider : IDisposable
     var logger = LoggerFactory.Create(builder => builder.AddSerilog(loggerSerilog))
                               .CreateLogger("root");
 
-    runner_ = MongoDbRunner.Start(logger: NullLogger.Instance);
+    runner_ = MongoDbRunner.Start(logger: NullLogger.Instance,
+                                  binariesSearchDirectory: Path.GetTempPath() + "/" + Path.GetRandomFileName());
     var settings = MongoClientSettings.FromUrl(new MongoUrl(runner_.ConnectionString));
 
     settings.ClusterConfigurator = cb => cb.Subscribe<CommandStartedEvent>(e => logger.LogInformation("{CommandName} - {Command}",

--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -25,16 +25,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 
 using ArmoniK.Core.Common.Injection.Options;
+
+using EphemeralMongo;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -49,7 +47,7 @@ internal class MongoDatabaseProvider : IDisposable
   private const           string          DatabaseName   = "ArmoniK_TestDB";
   private static readonly ActivitySource  ActivitySource = new("ArmoniK.Core.Adapters.MongoDB.Tests");
   private readonly        ServiceProvider provider_;
-  private readonly        MongoDbRunner?  runner_;
+  private readonly        IMongoRunner?   runner_;
 
   public MongoDatabaseProvider(Action<IServiceCollection>? serviceConfigurator = null)
   {
@@ -60,8 +58,14 @@ internal class MongoDatabaseProvider : IDisposable
     var logger = LoggerFactory.Create(builder => builder.AddSerilog(loggerSerilog))
                               .CreateLogger("root");
 
-    runner_ = MongoDbRunner.Start(logger: NullLogger.Instance,
-                                  binariesSearchDirectory: Path.GetTempPath() + "/" + Path.GetRandomFileName());
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = false,
+                    StandardOuputLogger     = line => logger.LogInformation(line),
+                    StandardErrorLogger     = line => logger.LogError(line),
+                  };
+
+    runner_ = MongoRunner.Run(options);
     var settings = MongoClientSettings.FromUrl(new MongoUrl(runner_.ConnectionString));
 
     settings.ClusterConfigurator = cb => cb.Subscribe<CommandStartedEvent>(e => logger.LogInformation("{CommandName} - {Command}",

--- a/Adaptors/MongoDB/tests/SessionProviderTests.cs
+++ b/Adaptors/MongoDB/tests/SessionProviderTests.cs
@@ -31,12 +31,13 @@ using System.Threading.Tasks;
 using ArmoniK.Core.Adapters.MongoDB.Common;
 using ArmoniK.Core.Common;
 
+using EphemeralMongo;
+
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Driver;
 
@@ -60,8 +61,14 @@ public class SessionProviderTests
   public void SetUp()
   {
     var logger = NullLogger.Instance;
-    runner_ = MongoDbRunner.Start(singleNodeReplSet: false,
-                                  logger: logger);
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = false,
+                    StandardOuputLogger     = line => logger.LogInformation(line),
+                    StandardErrorLogger     = line => logger.LogError(line),
+                  };
+
+    runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB
@@ -95,7 +102,7 @@ public class SessionProviderTests
   }
 
   private                 MongoClient?     client_;
-  private                 MongoDbRunner?   runner_;
+  private                 IMongoRunner?    runner_;
   private const           string           DatabaseName   = "ArmoniK_TestDB";
   private static readonly ActivitySource   ActivitySource = new("ArmoniK.Core.Adapters.MongoDB.Tests");
   private                 ServiceProvider? provider_;

--- a/Common/tests/ArmoniK.Core.Common.Tests.csproj
+++ b/Common/tests/ArmoniK.Core.Common.Tests.csproj
@@ -13,9 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="EphemeralMongo5" Version="0.1.3" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.9" />
     <PackageReference Include="Microsoft.Azure.Amqp" Version="2.5.12" />
-    <PackageReference Include="Mongo2Go" Version="3.1.3" />
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -37,13 +37,13 @@ using ArmoniK.Core.Common.Pollster.TaskProcessingChecker;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Stream.Worker;
 
+using EphemeralMongo;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -58,7 +58,7 @@ public class TestPollsterProvider : IDisposable
   private readonly        IMongoClient             client_;
   public readonly         IPartitionTable          PartitionTable;
   private readonly        IResultTable             resultTable_;
-  private readonly        MongoDbRunner            runner_;
+  private readonly        IMongoRunner             runner_;
   private readonly        ISessionTable            sessionTable_;
   public readonly         ISubmitter               Submitter;
   public readonly         ITaskTable               TaskTable;
@@ -69,8 +69,15 @@ public class TestPollsterProvider : IDisposable
                               IAgentHandler        agentHandler,
                               IPullQueueStorage    pullQueueStorage)
   {
-    runner_ = MongoDbRunner.Start(singleNodeReplSet: false,
-                                  logger: NullLogger.Instance);
+    var logger = NullLogger.Instance;
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = false,
+                    StandardOuputLogger     = line => logger.LogInformation(line),
+                    StandardErrorLogger     = line => logger.LogError(line),
+                  };
+
+    runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -37,13 +37,13 @@ using ArmoniK.Core.Common.Pollster.TaskProcessingChecker;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Stream.Worker;
 
+using EphemeralMongo;
+
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -59,7 +59,7 @@ public class TestTaskHandlerProvider : IDisposable
   private readonly        LoggerFactory   loggerFactory_;
   public readonly         IPartitionTable PartitionTable;
   private readonly        IResultTable    resultTable_;
-  private readonly        MongoDbRunner   runner_;
+  private readonly        IMongoRunner    runner_;
   public readonly         ISessionTable   SessionTable;
   public readonly         ISubmitter      Submitter;
   public readonly         TaskHandler     TaskHandler;
@@ -74,8 +74,15 @@ public class TestTaskHandlerProvider : IDisposable
                                  ISessionTable?          inputSessionTable = null)
   {
     var logger = NullLogger.Instance;
-    runner_ = MongoDbRunner.Start(singleNodeReplSet: false,
-                                  logger: logger);
+
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = false,
+                    StandardOuputLogger     = line => logger.LogInformation(line),
+                    StandardErrorLogger     = line => logger.LogError(line),
+                  };
+
+    runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB

--- a/Common/tests/Submitter/SubmitterTests.cs
+++ b/Common/tests/Submitter/SubmitterTests.cs
@@ -43,14 +43,14 @@ using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Helpers;
 using ArmoniK.Core.Common.Utils;
 
+using EphemeralMongo;
+
 using Google.Protobuf.WellKnownTypes;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-
-using Mongo2Go;
 
 using MongoDB.Bson;
 using MongoDB.Driver;
@@ -72,8 +72,14 @@ public class SubmitterTests
   public void SetUp()
   {
     var logger = NullLogger.Instance;
-    runner_ = MongoDbRunner.Start(singleNodeReplSet: false,
-                                  logger: logger);
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = false,
+                    StandardOuputLogger     = line => logger.LogInformation(line),
+                    StandardErrorLogger     = line => logger.LogError(line),
+                  };
+
+    runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB
@@ -159,7 +165,7 @@ public class SubmitterTests
   }
 
   private                 ISubmitter?      submitter_;
-  private                 MongoDbRunner?   runner_;
+  private                 IMongoRunner?    runner_;
   private                 MongoClient?     client_;
   private const           string           DatabaseName     = "ArmoniK_TestDB";
   private static readonly string           ExpectedOutput1  = "ExpectedOutput1";


### PR DESCRIPTION
For an unknown reason, all mongodb tests on Linux were failing during mongo2go initialization.
This PR uses EphemeralMongo instead of Mongo2Go for the tests. It solved the issue.

see https://github.com/Mongo2Go/Mongo2Go/issues/141

fix https://github.com/aneoconsulting/ArmoniK/issues/745