### PR TITLE
Jg/streamtests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -418,6 +418,7 @@ jobs:
     env:
       VERSION: ${{ needs.versionning.outputs.version }}
     runs-on: ubuntu-latest
+    name: Stream ${{ matrix.queue }} ${{ matrix.log-level }}
     strategy:
       fail-fast: false
       matrix:

--- a/Tests/HtcMock/Client/src/GridClient.cs
+++ b/Tests/HtcMock/Client/src/GridClient.cs
@@ -29,6 +29,8 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 
 using Google.Protobuf.WellKnownTypes;
 
+using Grpc.Net.Client;
+
 using Htc.Mock;
 
 using Microsoft.Extensions.Logging;
@@ -37,15 +39,15 @@ namespace ArmoniK.Samples.HtcMock.Client;
 
 public class GridClient : IGridClient
 {
-  private readonly Submitter.SubmitterClient client_;
-  private readonly ILogger<GridClient>       logger_;
-  private readonly Options.HtcMock           optionsHtcMock_;
+  private readonly GrpcChannel         channel_;
+  private readonly ILogger<GridClient> logger_;
+  private readonly Options.HtcMock     optionsHtcMock_;
 
-  public GridClient(Submitter.SubmitterClient client,
-                    ILoggerFactory            loggerFactory,
-                    Options.HtcMock           optionsHtcMock)
+  public GridClient(GrpcChannel     channel,
+                    ILoggerFactory  loggerFactory,
+                    Options.HtcMock optionsHtcMock)
   {
-    client_         = client;
+    channel_        = channel;
     optionsHtcMock_ = optionsHtcMock;
     logger_         = loggerFactory.CreateLogger<GridClient>();
   }
@@ -87,8 +89,9 @@ public class GridClient : IGridClient
                                    optionsHtcMock_.Partition,
                                  },
                                };
-    var createSessionReply = client_.CreateSession(createSessionRequest);
-    return new SessionClient(client_,
+    var client             = new Submitter.SubmitterClient(channel_);
+    var createSessionReply = client.CreateSession(createSessionRequest);
+    return new SessionClient(channel_,
                              createSessionReply.SessionId,
                              logger_);
   }

--- a/Tests/HtcMock/Client/src/Program.cs
+++ b/Tests/HtcMock/Client/src/Program.cs
@@ -27,7 +27,6 @@ using System.Threading;
 
 using ArmoniK.Api.Client.Options;
 using ArmoniK.Api.Client.Submitter;
-using ArmoniK.Api.gRPC.V1.Submitter;
 
 using Htc.Mock.Core;
 
@@ -67,9 +66,7 @@ internal class Program
                  .Bind(optionsHtcMock);
     var channel = GrpcChannelFactory.CreateChannel(options);
 
-    var submitterClient = new Submitter.SubmitterClient(channel);
-
-    var gridClient = new GridClient(submitterClient,
+    var gridClient = new GridClient(channel,
                                     factory,
                                     optionsHtcMock);
 

--- a/Tests/Stream/Client/GrpcChannelExt.cs
+++ b/Tests/Stream/Client/GrpcChannelExt.cs
@@ -1,0 +1,94 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2022. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.Client.Submitter;
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Results;
+using ArmoniK.Api.gRPC.V1.Submitter;
+using ArmoniK.Api.gRPC.V1.Tasks;
+using ArmoniK.Extensions.Common.StreamWrapper.Tests.Common;
+
+using Grpc.Net.Client;
+
+namespace ArmoniK.Extensions.Common.StreamWrapper.Tests.Client;
+
+public static class GrpcChannelExt
+{
+  public static async Task<TestPayload> GetPayloadAsyncAndCheck(this GrpcChannel channel,
+                                                                string           sessionId,
+                                                                string           resultId)
+  {
+    var client = new Submitter.SubmitterClient(channel);
+
+    var request = new ResultRequest
+                  {
+                    ResultId = resultId,
+                    Session  = sessionId,
+                  };
+    try
+    {
+      var bytes = await client.GetResultAsync(request)
+                              .ConfigureAwait(false);
+      if (bytes.Length == 0)
+      {
+        throw new Exception("Output data is empty");
+      }
+
+      return TestPayload.Deserialize(bytes) ?? throw new InvalidOperationException("Payload cannot be deserialized");
+    }
+    catch (Exception e)
+    {
+      var resultClient = new Results.ResultsClient(channel);
+      var res = await resultClient.GetOwnerTaskIdAsync(new GetOwnerTaskIdRequest
+                                                       {
+                                                         ResultId =
+                                                         {
+                                                           resultId,
+                                                         },
+                                                         SessionId = sessionId,
+                                                       })
+                                  .ConfigureAwait(false);
+
+      var taskClient = new Tasks.TasksClient(channel);
+      var taskData = await taskClient.GetTaskAsync(new GetTaskRequest
+                                                   {
+                                                     TaskId = res.ResultTask.Single()
+                                                                 .TaskId,
+                                                   })
+                                     .ConfigureAwait(false);
+
+      if (taskData.Task.Output.Success)
+      {
+        throw;
+      }
+
+      throw new Exception($"Error in task : {taskData.Task.Output.Error}",
+                          e);
+    }
+  }
+}


### PR DESCRIPTION
- Improves the error message for tasks in error when the result is not available
- Stat to use channel in HtcMock instead of SubmitterClient in order to be able to use other clients.

fix https://github.com/aneoconsulting/ArmoniK/issues/756