### PR TITLE
Improve task acquisition when messages are duplicated

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -267,6 +267,7 @@ public class Pollster : IInitializable
                                                              ("messageHandler", message.MessageId),
                                                              ("taskId", message.TaskId),
                                                              ("ownerPodId", ownerPodId_));
+            TaskProcessing = message.TaskId;
             // ReSharper disable once ExplicitCallerInfoArgument
             using var activity = activitySource_.StartActivity("ProcessQueueMessage");
             activity?.SetBaggage("TaskId",
@@ -299,8 +300,6 @@ public class Pollster : IInitializable
 
               if (precondition)
               {
-                TaskProcessing = taskHandler.GetAcquiredTask();
-
                 await taskHandler.PreProcessing()
                                  .ConfigureAwait(false);
 

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -357,6 +357,8 @@ public class TaskHandler : IAsyncDisposable
           taskData_ = await taskTable_.ReadTaskAsync(messageHandler_.TaskId,
                                                      CancellationToken.None)
                                       .ConfigureAwait(false);
+          logger_.LogInformation("Task is not running on the other polling agent, status : {status}",
+                                 taskData_.Status);
           if (taskData_.Status is TaskStatus.Processing or TaskStatus.Dispatched or TaskStatus.Processed)
           {
             logger_.LogDebug("Resubmitting task {task} on another pod",

--- a/Common/src/Pollster/TaskProcessingChecker/TaskProcessingCheckerClient.cs
+++ b/Common/src/Pollster/TaskProcessingChecker/TaskProcessingCheckerClient.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
@@ -55,6 +55,8 @@ public class TaskProcessingCheckerClient : ITaskProcessingChecker
       var result = await client.GetStringAsync("http://" + ownerPodId + ":1080/taskprocessing",
                                                cancellationToken)
                                .ConfigureAwait(false);
+      logger_.LogDebug("Result from other polling agent: {result}",
+                       result);
       return result.Equals(taskId);
     }
     catch (InvalidOperationException ex)


### PR DESCRIPTION
This PR improves the acquisition of the task when the message is duplicated which happen a lot with the Artemis message queue.

Several polling agents were able to acquire the same thus leading to lots of issues when 2 tasks are being processed at the same time. Previously the endpoint `/taskprocessing` of the polling agent was returning the task id only after the acquisition of the task. In the time between the reception of the message and the acquisition of the task on the first polling agent, a second one was able to try to acquire the task, receive an empty response from the first polling agent, consider that the other polling agent was not running the task and resubmit the task. Now the endpoint returns the task id in the message from the queue before the acquisition, allowing the other polling agent to know that the task is already being processed and to deduplicate the message.

fix https://github.com/aneoconsulting/ArmoniK/issues/757