### PR TITLE
Generate and upload patch when format fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -111,6 +111,7 @@ jobs:
         jb cleanupcode ArmoniK.Core.sln
 
     - name: Check Diff
+      id: check-diff
       run: |
         DIFF="$(git diff --name-only)"
 
@@ -124,6 +125,16 @@ jobs:
           exit 1
         fi
 
+    - name: Generate patch
+      if: ${{ failure() && steps.check-diff.conclusion == 'failure' }}
+      run: |
+        git diff > patch.diff
+
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() && steps.check-diff.conclusion == 'failure' }}
+      with:
+        name: patch
+        path: ./patch.diff
 
   tests:
     strategy:


### PR DESCRIPTION
This PR adds steps in C# format checking. Those steps generate and upload a git patch when the formatting fails. This will quicken the process of fixing formatting. Now, we can download the patch and apply it instead of running the formatting cleanup locally.

fix https://github.com/aneoconsulting/ArmoniK/issues/831