### PR TITLE
fix(ci): Adapt pipeline to the new method to install docfx

### DIFF
--- a/.github/workflows/build_documentations.yml
+++ b/.github/workflows/build_documentations.yml
@@ -13,23 +13,19 @@ jobs:
     - name: Checkout repo
       uses: actions/checkout@v3
 
-    - name: Get mono
+    - name: Get dotnet sdk
       run: |
-        sudo apt-get -y install gnupg ca-certificates
-        sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
-        echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | sudo tee /etc/apt/sources.list.d/mono-official-stable.list
+        wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
+        sudo dpkg -i packages-microsoft-prod.deb
+        rm packages-microsoft-prod.deb
         sudo apt-get update
-        sudo apt -y dist-upgrade
-        sudo apt -y install mono-runtime mono-devel msbuild
-
+        sudo apt-get install -y dotnet-sdk-7.0
     - name: Get docfx
       run: |
-        curl -L https://github.com/dotnet/docfx/releases/latest/download/docfx.zip -o docfx.zip
-        unzip -d $HOME/.docfx docfx.zip
-
+        dotnet tool update -g docfx
     - name: Build docs
       run:  |
-        mono $HOME/.docfx/docfx.exe Documentation/docfx.json build
+        docfx Documentation/docfx.json build
 
     - name: Deploy docfx documentation
       uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Microsoft changed the method how to install docfx. This PR is adapting the pipeline to this change.

fix: https://github.com/aneoconsulting/ArmoniK/issues/835