### PR TITLE
feat(auth): implement auth for Partition service

### DIFF
--- a/Common/src/Auth/Authorization/Permissions/ServicesPermissions.cs
+++ b/Common/src/Auth/Authorization/Permissions/ServicesPermissions.cs
@@ -68,6 +68,9 @@ public static class ServicesPermissions
                                                                                     {
                                                                                       typeof(GrpcAuthService), "Authentication"
                                                                                     },
+                                                                                    {
+                                                                                      typeof(GrpcPartitionsService), "Partitions"
+                                                                                    },
                                                                                   });
 
   /// <summary>

--- a/Common/tests/Auth/AuthenticationIntegrationTest.cs
+++ b/Common/tests/Auth/AuthenticationIntegrationTest.cs
@@ -37,6 +37,9 @@ using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Applications;
 using ArmoniK.Api.gRPC.V1.Auth;
 using ArmoniK.Api.gRPC.V1.Events;
+
+using Armonik.Api.Grpc.V1.Partitions;
+
 using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.Submitter;
@@ -87,6 +90,7 @@ public class AuthenticationIntegrationTest
                                                s.AddSingleton<ITaskTable>(new SimpleTaskTable())
                                                 .AddSingleton<ISessionTable>(new SimpleSessionTable())
                                                 .AddSingleton<IResultTable>(new SimpleResultTable())
+                                                .AddSingleton<IPartitionTable>(new SimplePartitionTable())
                                                 .AddSingleton<ITaskWatcher>(new SimpleTaskWatcher())
                                                 .AddSingleton<IResultWatcher>(new SimpleResultWatcher());
                                              });
@@ -138,6 +142,8 @@ public class AuthenticationIntegrationTest
   private static readonly ListResultsRequest       ListResultsRequest;
   private static readonly GetCurrentUserRequest    GetCurrentUserRequest;
   private static readonly EventSubscriptionRequest EventSubscriptionRequest;
+  private static readonly ListPartitionsRequest    ListPartitionsRequest;
+  private static readonly GetPartitionRequest      GetPartitionRequest;
 
   static AuthenticationIntegrationTest()
   {
@@ -334,6 +340,26 @@ public class AuthenticationIntegrationTest
                                {
                                  SessionId = SessionId,
                                };
+
+    ListPartitionsRequest = new ListPartitionsRequest
+                            {
+                              Filter = new ListPartitionsRequest.Types.Filter
+                                       {
+                                         Id = "Id",
+                                       },
+                              Sort = new ListPartitionsRequest.Types.Sort
+                                     {
+                                       Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
+                                       Field     = ListPartitionsRequest.Types.OrderByField.Id,
+                                     },
+                              PageSize = 10,
+                              Page     = 0,
+                            };
+
+    GetPartitionRequest = new GetPartitionRequest
+                          {
+                            Id = "PartitionId",
+                          };
   }
 
   public enum AuthenticationType
@@ -737,6 +763,10 @@ public class AuthenticationIntegrationTest
                                                                                                                           typeof(Events.EventsClient),
                                                                                                                           typeof(GrpcEventsService)
                                                                                                                         },
+                                                                                                                        {
+                                                                                                                          typeof(Partitions.PartitionsClient),
+                                                                                                                          typeof(GrpcPartitionsService)
+                                                                                                                        },
                                                                                                                       });
 
   public static IEnumerable GetTestCases(string suffix)
@@ -780,6 +810,8 @@ public class AuthenticationIntegrationTest
                                                        (typeof(Tasks.TasksClient), nameof(Tasks.TasksClient.CancelTasks), CancelTasksRequest),
                                                        (typeof(Results.ResultsClient), nameof(Results.ResultsClient.GetOwnerTaskId), GetOwnerTaskIdRequest),
                                                        (typeof(Results.ResultsClient), nameof(Results.ResultsClient.ListResults), ListResultsRequest),
+                                                       (typeof(Partitions.PartitionsClient), nameof(Partitions.PartitionsClient.GetPartition), GetPartitionRequest),
+                                                       (typeof(Partitions.PartitionsClient), nameof(Partitions.PartitionsClient.ListPartitions), ListPartitionsRequest),
                                                      };
 
     return GetCases(methodObjectList.Select(t => (t.Item1, t.Item2 + suffix, t.Item3))

--- a/Common/tests/Helpers/GrpcSubmitterServiceHelper.cs
+++ b/Common/tests/Helpers/GrpcSubmitterServiceHelper.cs
@@ -96,6 +96,7 @@ public class GrpcSubmitterServiceHelper : IDisposable
     app_.MapGrpcService<GrpcApplicationsService>();
     app_.MapGrpcService<GrpcAuthService>();
     app_.MapGrpcService<GrpcEventsService>();
+    app_.MapGrpcService<GrpcPartitionsService>();
   }
 
   public GrpcSubmitterServiceHelper(ISubmitter                  submitter,

--- a/Common/tests/Helpers/SimplePartitionTable.cs
+++ b/Common/tests/Helpers/SimplePartitionTable.cs
@@ -1,0 +1,86 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Common.Storage;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+public class SimplePartitionTable : IPartitionTable
+{
+  public readonly PartitionData PartitionData = new("PartitionId",
+                                                    new List<string>(),
+                                                    1,
+                                                    2,
+                                                    10,
+                                                    2,
+                                                    new PodConfiguration(new Dictionary<string, string>()));
+
+  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
+
+  public Task Init(CancellationToken cancellationToken)
+    => Task.CompletedTask;
+
+  public Task CreatePartitionsAsync(IEnumerable<PartitionData> partitions,
+                                    CancellationToken          cancellationToken = default)
+    => Task.CompletedTask;
+
+  public Task<PartitionData> ReadPartitionAsync(string            partitionId,
+                                                CancellationToken cancellationToken = default)
+    => Task.FromResult(PartitionData);
+
+  public IAsyncEnumerable<PartitionData> GetPartitionWithAllocationAsync(CancellationToken cancellationToken = default)
+    => new List<PartitionData>
+       {
+         PartitionData,
+       }.ToAsyncEnumerable();
+
+  public Task DeletePartitionAsync(string            partitionId,
+                                   CancellationToken cancellationToken = default)
+    => Task.CompletedTask;
+
+  public Task<bool> ArePartitionsExistingAsync(IEnumerable<string> partitionIds,
+                                               CancellationToken   cancellationToken = default)
+    => Task.FromResult(true);
+
+  public Task<(IEnumerable<PartitionData> partitions, int totalCount)> ListPartitionsAsync(Expression<Func<PartitionData, bool>>    filter,
+                                                                                           Expression<Func<PartitionData, object?>> orderField,
+                                                                                           bool                                     ascOrder,
+                                                                                           int                                      page,
+                                                                                           int                                      pageSize,
+                                                                                           CancellationToken                        cancellationToken = default)
+    => Task.FromResult((new List<PartitionData>
+                        {
+                          PartitionData,
+                        }.AsEnumerable(), 1));
+}


### PR DESCRIPTION
This PR adds the missing implementation and tests for authentication for the partition service.
fix https://github.com/aneoconsulting/ArmoniK/issues/848