### PR TITLE
Al/builder fix for factory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -399,10 +399,6 @@ jobs:
         ref: ${{ github.ref }}
         submodules: true
 
-    - name: login
-      run: |
-        echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_LOGIN }} --password-stdin
-
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
@@ -410,23 +406,24 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v2
 
+    - name: login
+      uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_HUB_LOGIN }}
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
     - name: platforms
       run: echo ${{ steps.buildx.outputs.platforms }}
 
-    - name: Build
-      run: |
-        docker buildx create --use
-        docker buildx build \
-          --platform linux/arm64 \
-          -t ${{ matrix.img }}:${VERSION}-arm \
-          -f ${{ matrix.path }} . \
-          --push
-
-    - name: Create multi-arch manifest
-      run: docker manifest create ${{ matrix.img }}:${VERSION} -a ${{ matrix.img }}:${VERSION} -a ${{ matrix.img }}:${VERSION}-arm
-
-    - name: Push multi-arch manifest
-      run: docker manifest push ${{ matrix.img }}:${VERSION}
+    - name: Build and push
+      uses: docker/build-push-action@v3
+      with:
+        file: ${{ matrix.path }}
+        context: .
+        platforms: linux/amd64, linux/arm64
+        push: true
+        tags: |
+            ${{ matrix.img }}:${{ needs.versionning.outputs.version }}
 
   testStreamDC:
     needs:


### PR DESCRIPTION
goal : fix factory step : _buildImagesCross_

The code [see](https://github.com/aneoconsulting/ArmoniK.Core/pull/225/files#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L426) , is expecting to add 2 manifests arm64+amd64 to create a list of manifests.

But 'docker buildx create' does not create a manifest, but a manifest[] [see](https://docs.docker.com/registry/spec/manifest-v2-2/#example-manifest-list)

As a result, the code is failing because it is trying to add : manifest + manifest[] instead of manifest + manifest
The error message is : _docker.io/dockerhubaneo/armonik_pollingagent:0.9.0-SNAPSHOT.172.11041066-arm is a manifest list_

To fix this issue, the 'docker buildx create' command should be used to build arm64+amd64, as it will automatically publish an appropriate manifest list. This will result in three builds instead of two for each Dockerfile."

rem: 
        tags: |
            ${{ matrix.img }}:${{ needs.versionning.outputs.version }}-arm
instead of
        tags: |
            ${{ matrix.img }}:${VERSION}-arm
because variable is empty otherwise. I don't know why
