### PR TITLE
fix: CI multi arch build for docker images and releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -420,10 +420,13 @@ jobs:
       with:
         file: ${{ matrix.path }}
         context: .
-        platforms: linux/amd64, linux/arm64
+        platforms: linux/arm64
         push: true
         tags: |
-            ${{ matrix.img }}:${{ needs.versionning.outputs.version }}
+            ${{ matrix.img }}:${{ needs.versionning.outputs.version }}-arm
+
+    - name: Create multi-arch manifest
+      run: docker buildx imagetools create ${{ matrix.img }}:${VERSION} --tag ${{ matrix.img }}:${VERSION} --append ${{ matrix.img }}:${VERSION}-arm
 
   testStreamDC:
     needs:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -60,13 +60,11 @@ jobs:
     - name: login
       run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_LOGIN }} --password-stdin
 
-    - name: ReTag
-      run: |
-        set -xe
-        docker buildx imagetools inspect ${{ matrix.image }}:${VERSION} --raw | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:${RELEASE} -a
-        docker buildx imagetools inspect ${{ matrix.image }}:${VERSION} --raw | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:latest -a
-        docker manifest push ${{ matrix.image }}:${RELEASE}
-        docker manifest push ${{ matrix.image }}:latest
+    - name: ReTag release
+      run: docker buildx imagetools create ${{ matrix.image }}:${VERSION} --tag ${{ matrix.image }}:${RELEASE}
+
+    - name: ReTag latest
+      run: docker buildx imagetools create ${{ matrix.image }}:${VERSION} --tag ${{ matrix.image }}:latest
 
   tag:
     runs-on: ubuntu-latest

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -63,8 +63,8 @@ jobs:
     - name: ReTag
       run: |
         set -xe
-        docker manifest inspect ${{ matrix.image }}:${VERSION} | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:${RELEASE} -a 
-        docker manifest inspect ${{ matrix.image }}:${VERSION} | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:latest -a 
+        docker buildx imagetools inspect ${{ matrix.image }}:${VERSION} --raw | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:${RELEASE} -a
+        docker buildx imagetools inspect ${{ matrix.image }}:${VERSION} --raw | jq --raw-output ".manifests[].digest" | sed -e 's:^:${{ matrix.image }}@:g' | xargs docker manifest create ${{ matrix.image }}:latest -a
         docker manifest push ${{ matrix.image }}:${RELEASE}
         docker manifest push ${{ matrix.image }}:latest
 


### PR DESCRIPTION
This PR attempts to fix docker image retag during release while trying to use `docker buildx imagetools` to edit manifests.
