### PR TITLE
fix: add missing filter in ListPartionsRequest

### DIFF
--- a/Common/src/gRPC/ListPartitionsRequestExt.cs
+++ b/Common/src/gRPC/ListPartitionsRequestExt.cs
@@ -73,6 +73,11 @@ public static class ListPartitionsRequestExt
       predicate = predicate.And(data => data.PartitionId == filter.Id);
     }
 
+    if (!string.IsNullOrEmpty(filter.ParentPartitionId))
+    {
+      predicate = predicate.And(data => data.ParentPartitionIds.Contains(filter.ParentPartitionId));
+    }
+
     if (filter.Priority > 0)
     {
       predicate = predicate.And(data => data.Priority == filter.Priority);

--- a/Common/tests/ListPartitionsRequestExt/ToTaskDataFilterTest.cs
+++ b/Common/tests/ListPartitionsRequestExt/ToTaskDataFilterTest.cs
@@ -262,4 +262,50 @@ public class ToPartitionDataFilterTest
                                  Priority = 877,
                                }));
   }
+
+  [Test]
+  public void FilterParentPartitionIdShouldSucceed()
+  {
+    var func = new ListPartitionsRequest
+               {
+                 Filter = new ListPartitionsRequest.Types.Filter
+                          {
+                            ParentPartitionId = "ParentPartitionId1",
+                          },
+                 Sort = new ListPartitionsRequest.Types.Sort
+                        {
+                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
+                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
+                        },
+               }.Filter.ToPartitionFilter()
+                .Compile();
+
+    Assert.IsTrue(func.Invoke(partitionData_));
+  }
+
+  [Test]
+  public void FilterWrongParentPartitionIdShouldFail()
+  {
+    var func = new ListPartitionsRequest
+               {
+                 Filter = new ListPartitionsRequest.Types.Filter
+                          {
+                            ParentPartitionId = "ParentPartitionId1",
+                          },
+                 Sort = new ListPartitionsRequest.Types.Sort
+                        {
+                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
+                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
+                        },
+               }.Filter.ToPartitionFilter()
+                .Compile();
+
+    Assert.IsFalse(func.Invoke(partitionData_ with
+                               {
+                                 ParentPartitionIds = new List<string>
+                                                      {
+                                                        "AnotherPartitionId",
+                                                      },
+                               }));
+  }
 }

--- a/Common/tests/PartitionTableTestBase.cs
+++ b/Common/tests/PartitionTableTestBase.cs
@@ -61,6 +61,16 @@ public class PartitionTableTestBase
                                                                 50,
                                                                 1,
                                                                 new PodConfiguration(new Dictionary<string, string>())),
+                                              new PartitionData("PartitionId2",
+                                                                new List<string>
+                                                                {
+                                                                  "ParentPartitionId",
+                                                                },
+                                                                1,
+                                                                13,
+                                                                50,
+                                                                1,
+                                                                new PodConfiguration(new Dictionary<string, string>())),
                                             })
                      .Wait();
     }
@@ -216,6 +226,24 @@ public class PartitionTableTestBase
                                            .ConfigureAwait(false);
 
       Assert.AreEqual(0,
+                      listTasks.totalCount);
+    }
+  }
+
+  [Test]
+  public async Task ListPartitionsContainsShouldSucceed()
+  {
+    if (RunTests)
+    {
+      var listTasks = await PartitionTable!.ListPartitionsAsync(data => data.ParentPartitionIds.Contains("ParentPartitionId"),
+                                                                data => data.PartitionId,
+                                                                false,
+                                                                0,
+                                                                20,
+                                                                CancellationToken.None)
+                                           .ConfigureAwait(false);
+
+      Assert.AreEqual(1,
                       listTasks.totalCount);
     }
   }


### PR DESCRIPTION
Filter on ParentPartitionId in ListPartionsRequest was not implemented. This PR fixes this issue.
