### PR TITLE
chore: add terraform output files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -369,3 +369,8 @@ FodyWeavers.xsd
 .idea
 
 patch.diff
+
+terraform/.terraform.lock.hcl
+terraform/.terraform/
+terraform/terraform.tfstate
+terraform/terraform.tfstate.backup


### PR DESCRIPTION
This PR adds some terraform file created during deployment in .gitignore.
