### PR TITLE
feat: Add helper for getting stats such as throughput

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,4 @@ LICENSE
 README.md
 **/publish
 **/packages
+terraform

--- a/ArmoniK.Core.sln
+++ b/ArmoniK.Core.sln
@@ -81,6 +81,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Adapters.S3", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Adapters.S3.Tests", "Adaptors\S3\tests\ArmoniK.Core.Adapters.S3.Tests.csproj", "{35AC9746-51AC-4EB5-A6B9-AFC169868ABF}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Common.Tests.Client", "Tests\Common\Client\src\ArmoniK.Core.Common.Tests.Client.csproj", "{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -321,6 +323,14 @@ Global
 		{35AC9746-51AC-4EB5-A6B9-AFC169868ABF}.Release|Any CPU.Build.0 = Release|Any CPU
 		{35AC9746-51AC-4EB5-A6B9-AFC169868ABF}.Release|x64.ActiveCfg = Release|Any CPU
 		{35AC9746-51AC-4EB5-A6B9-AFC169868ABF}.Release|x64.Build.0 = Release|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Debug|x64.Build.0 = Debug|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Release|Any CPU.Build.0 = Release|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Release|x64.ActiveCfg = Release|Any CPU
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -363,6 +373,7 @@ Global
 		{19BEC0E4-8943-4AB8-8383-F7C11CFC3DB9} = {2D548C40-6260-4A4E-9C56-E8A80C639E13}
 		{4979ADF2-4574-4FF5-BDF4-B5EC0EFAC803} = {1A9BCE53-79D0-4761-B3A2-6967B610FA94}
 		{35AC9746-51AC-4EB5-A6B9-AFC169868ABF} = {2D548C40-6260-4A4E-9C56-E8A80C639E13}
+		{289EAA4A-15E5-4D8B-87B2-0CFFD9510207} = {CD412C3D-63D0-4726-B4C3-FEF701E4DCAF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1285A466-2AF6-43E6-8DCC-2F93A5D5F02E}

--- a/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
+++ b/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
@@ -25,7 +25,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
@@ -37,5 +36,9 @@
 
   <ItemGroup>
     <AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common\Client\src\ArmoniK.Core.Common.Tests.Client.csproj" />
   </ItemGroup>
 </Project>

--- a/Tests/Bench/Client/src/Dockerfile
+++ b/Tests/Bench/Client/src/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj", "Tests/Bench/Client/src/"]
+COPY ["Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj", "Tests/Common/Client/src/"]
 COPY ["Common/src/ArmoniK.Core.Common.csproj", "Common/src/"]
 RUN dotnet restore "Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj"
 COPY . .

--- a/Tests/Bench/Client/src/Program.cs
+++ b/Tests/Bench/Client/src/Program.cs
@@ -37,6 +37,7 @@ using ArmoniK.Api.gRPC.V1.Events;
 using Armonik.Api.Grpc.V1.Partitions;
 
 using ArmoniK.Api.gRPC.V1.Submitter;
+using ArmoniK.Core.Common.Tests.Client;
 using ArmoniK.Samples.Bench.Client.Options;
 
 using Google.Protobuf;
@@ -294,6 +295,10 @@ internal static class Program
                 };
     logger.LogInformation("executions stats {@stats}",
                           stats);
+
+    await channel.LogStatsFromSessionAsync(createSessionReply.SessionId,
+                                           logger)
+                 .ConfigureAwait(false);
 
     if (benchOptions.ShowEvents)
     {

--- a/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
+++ b/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
@@ -1,0 +1,35 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Company>ANEO</Company>
+    <Copyright>Copyright (C) ANEO, 2021-2021</Copyright>
+    <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <IsPackable>true</IsPackable>
+    <RuntimeIdentifiers>win-x64;linux-x64</RuntimeIdentifiers>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>Embedded</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <Optimize>true</Optimize>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+	<ItemGroup>
+	  <PackageReference Include="ArmoniK.Api.Client" Version="3.3.0" />
+	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+	</ItemGroup>
+	
+	<ItemGroup>
+		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+	</ItemGroup>
+</Project>

--- a/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj.DotSettings
+++ b/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Daemon/ConfigureAwaitAnalysisMode/@EntryValue">Library</s:String></wpf:ResourceDictionary>

--- a/Tests/Common/Client/src/GrpcChannelExt.cs
+++ b/Tests/Common/Client/src/GrpcChannelExt.cs
@@ -1,0 +1,200 @@
+// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-$CURRENT_YEAR$. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.gRPC.V1.Results;
+using ArmoniK.Api.gRPC.V1.Tasks;
+
+using Google.Protobuf.WellKnownTypes;
+
+using Grpc.Core;
+
+using Microsoft.Extensions.Logging;
+
+using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
+
+namespace ArmoniK.Core.Common.Tests.Client;
+
+public static class GrpcChannelExt
+{
+  public static async IAsyncEnumerable<TaskRaw> ListTasksAsync(this ChannelBase              channel,
+                                                               ListTasksRequest.Types.Filter filter,
+                                                               ListTasksRequest.Types.Sort   sort)
+  {
+    var               read       = 0;
+    var               page       = 0;
+    var               taskClient = new Tasks.TasksClient(channel);
+    ListTasksResponse res;
+
+    while ((res = await taskClient.ListTasksAsync(new ListTasksRequest
+                                                  {
+                                                    Filter   = filter,
+                                                    Sort     = sort,
+                                                    PageSize = 50,
+                                                    Page     = page,
+                                                  })
+                                  .ConfigureAwait(false)).Total > read)
+    {
+      foreach (var taskSummary in res.Tasks)
+      {
+        var taskRaw = taskClient.GetTask(new GetTaskRequest
+                                         {
+                                           TaskId = taskSummary.Id,
+                                         })
+                                .Task;
+        read++;
+        yield return taskRaw;
+      }
+
+      page++;
+    }
+  }
+
+
+  public static async Task LogStatsFromSessionAsync(this ChannelBase channel,
+                                                    string           sessionId,
+                                                    ILogger          logger)
+  {
+    var resultClient = new Results.ResultsClient(channel);
+
+    var taskDependencies = new Dictionary<string, TaskRaw>();
+    var taskAggregation  = new List<TaskRaw>();
+    var usageRatio       = new List<double>();
+
+
+    await foreach (var taskRaw in channel.ListTasksAsync(new ListTasksRequest.Types.Filter
+                                                         {
+                                                           SessionId = sessionId,
+                                                         },
+                                                         new ListTasksRequest.Types.Sort
+                                                         {
+                                                           Direction = ListTasksRequest.Types.OrderDirection.Asc,
+                                                           Field     = ListTasksRequest.Types.OrderByField.CreatedAt,
+                                                         })
+                                         .ConfigureAwait(false))
+    {
+      if (taskRaw.Status is TaskStatus.Completed or TaskStatus.Error)
+      {
+        var useRatio = (taskRaw.EndedAt - taskRaw.StartedAt).ToTimeSpan()
+                                                            .TotalMilliseconds / (taskRaw.EndedAt - taskRaw.ReceivedAt).ToTimeSpan()
+                                                                                                                       .TotalMilliseconds;
+
+        usageRatio.Add(useRatio);
+      }
+
+      if (taskRaw.DataDependencies.Count > 0)
+      {
+        taskAggregation.Add(taskRaw);
+      }
+
+      taskDependencies.Add(taskRaw.Id,
+                           taskRaw);
+    }
+
+    var timediff = new List<double>();
+
+    foreach (var agg in taskAggregation)
+    {
+      var result2Task = resultClient.GetOwnerTaskId(new GetOwnerTaskIdRequest
+                                                    {
+                                                      ResultId =
+                                                      {
+                                                        agg.DataDependencies,
+                                                      },
+                                                      SessionId = sessionId,
+                                                    })
+                                    .ResultTask.Select(m => m.TaskId);
+
+      var lastDependencyFinished = taskDependencies.Where(pair => result2Task.Contains(pair.Key))
+                                                   .Select(pair => pair.Value)
+                                                   .MaxBy(pair => pair.EndedAt);
+      if (lastDependencyFinished is not null)
+      {
+        var diff = agg.StartedAt - lastDependencyFinished?.EndedAt;
+        timediff.Add(diff.ToTimeSpan()
+                         .TotalMilliseconds / 1000);
+      }
+    }
+
+
+    if (timediff.Any())
+    {
+      logger.LogInformation("Time spent between the end of the last dependency and the start of aggregation tasks {min}, {max}, {avg}",
+                            timediff.Min(),
+                            timediff.Max(),
+                            timediff.Average());
+    }
+
+    if (usageRatio.Any())
+    {
+      logger.LogInformation("Ratio between time spent on a task and processing time {min}, {max}, {avg}",
+                            usageRatio.Min(),
+                            usageRatio.Max(),
+                            usageRatio.Average());
+    }
+
+
+    var sessionStart    = taskDependencies.Values.Min(raw => raw.CreatedAt);
+    var sessionEnd      = taskDependencies.Values.Max(raw => raw.EndedAt);
+    var sessionDuration = (sessionEnd - sessionStart).ToTimeSpan();
+    var taskCount       = taskDependencies.Count(pair => pair.Value.Status is TaskStatus.Completed or TaskStatus.Error);
+
+    logger.LogInformation("Throughput for session {session} : {sessionThroughput} task/s (completed {nTasks}, total {total} tasks in {timespan})",
+                          sessionId,
+                          taskCount / sessionDuration.TotalMilliseconds * 1000,
+                          taskCount,
+                          taskDependencies.Count,
+                          sessionDuration);
+    var count = 0;
+    await foreach (var _ in channel.ListTasksAsync(new ListTasksRequest.Types.Filter
+                                                   {
+                                                     CreatedAfter = sessionStart - Duration.FromTimeSpan(TimeSpan.FromMilliseconds(1)),
+                                                     EndedBefore  = sessionEnd   + Duration.FromTimeSpan(TimeSpan.FromMilliseconds(1)),
+                                                     Status =
+                                                     {
+                                                       TaskStatus.Completed,
+                                                       TaskStatus.Error,
+                                                     },
+                                                   },
+                                                   new ListTasksRequest.Types.Sort
+                                                   {
+                                                     Direction = ListTasksRequest.Types.OrderDirection.Asc,
+                                                     Field     = ListTasksRequest.Types.OrderByField.CreatedAt,
+                                                   })
+                                   .ConfigureAwait(false))
+    {
+      count++;
+    }
+
+    logger.LogInformation("Throughput during session {session} : {throughput} task/s ({nTasks} tasks in {timespan})",
+                          sessionId,
+                          count / sessionDuration.TotalMilliseconds * 1000,
+                          count,
+                          sessionDuration);
+  }
+}

--- a/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
+++ b/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
@@ -25,7 +25,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="ArmoniK.Api.Client" Version="3.3.0" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
@@ -38,5 +37,9 @@
 	
 	<ItemGroup>
 		<AssemblyAttribute Include="System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverageAttribute" />
+	</ItemGroup>
+	
+	<ItemGroup>
+	  <ProjectReference Include="..\..\..\Common\Client\src\ArmoniK.Core.Common.Tests.Client.csproj" />
 	</ItemGroup>
 </Project>

--- a/Tests/HtcMock/Client/src/Dockerfile
+++ b/Tests/HtcMock/Client/src/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
 WORKDIR /src
 COPY ["Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj", "Tests/HtcMock/Client/src/"]
+COPY ["Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj", "Tests/Common/Client/src/"]
 COPY ["Common/src/ArmoniK.Core.Common.csproj", "Common/src/"]
 RUN dotnet restore "Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj"
 COPY . .

--- a/Tests/HtcMock/Client/src/GridClient.cs
+++ b/Tests/HtcMock/Client/src/GridClient.cs
@@ -91,6 +91,10 @@ public class GridClient : IGridClient
                                };
     var client             = new Submitter.SubmitterClient(channel_);
     var createSessionReply = client.CreateSession(createSessionRequest);
+
+    logger_.LogInformation("Session {sessionId} created",
+                           createSessionReply.SessionId);
+
     return new SessionClient(channel_,
                              createSessionReply.SessionId,
                              logger_);


### PR DESCRIPTION
This PR adds helpers to compute the throughput of the session and during the session (it counts task from other sessions if any). It also computes ratio between time spent on a task and processing time as well as the time spent between the end of the last dependency and the start of aggregation tasks.
Bench and HtcMock tests use this helper at their end.
