### PR TITLE
fix: healthiness prove in queue adaptors

### DIFF
--- a/Adaptors/Amqp/src/PullQueueStorage.cs
+++ b/Adaptors/Amqp/src/PullQueueStorage.cs
@@ -33,10 +33,12 @@ using System.Threading.Tasks;
 using Amqp;
 
 using ArmoniK.Api.Common.Utils;
+using ArmoniK.Core.Common;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Utils;
 
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Adapters.Amqp;
@@ -64,6 +66,9 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
     receivers_ = Array.Empty<AsyncLazy<IReceiverLink>>();
     senders_   = Array.Empty<AsyncLazy<ISenderLink>>();
   }
+
+  public override Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => ConnectionAmqp.Check(tag);
 
   public override async Task Init(CancellationToken cancellationToken)
   {

--- a/Adaptors/RabbitMQ/src/ConnectionRabbit.cs
+++ b/Adaptors/RabbitMQ/src/ConnectionRabbit.cs
@@ -68,19 +68,22 @@ public class ConnectionRabbit : IConnectionRabbit
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
   {
-    if (!isInitialized_)
+    switch (tag)
     {
-      return Task.FromResult(tag != HealthCheckTag.Liveness
-                               ? HealthCheckResult.Degraded($"{nameof(ConnectionRabbit)} is not yet initialized.")
-                               : HealthCheckResult.Unhealthy($"{nameof(ConnectionRabbit)} is not yet initialized."));
+      case HealthCheckTag.Startup:
+      case HealthCheckTag.Readiness:
+        return Task.FromResult(isInitialized_
+                                 ? HealthCheckResult.Healthy()
+                                 : HealthCheckResult.Unhealthy($"{nameof(ConnectionRabbit)} is not yet initialized."));
+      case HealthCheckTag.Liveness:
+        return Task.FromResult(isInitialized_ && Connection is not null && Connection.IsOpen && Channel is not null && Channel.IsOpen
+                                 ? HealthCheckResult.Healthy()
+                                 : HealthCheckResult.Unhealthy($"{nameof(ConnectionRabbit)} not initialized or connection dropped."));
+      default:
+        throw new ArgumentOutOfRangeException(nameof(tag),
+                                              tag,
+                                              null);
     }
-
-    if (Connection is null || !Connection.IsOpen || Channel is null || Channel.IsClosed)
-    {
-      return Task.FromResult(HealthCheckResult.Unhealthy("Rabbit connection dropped."));
-    }
-
-    return Task.FromResult(HealthCheckResult.Healthy());
   }
 
   public void Dispose()

--- a/Adaptors/RabbitMQ/src/PullQueueStorage.cs
+++ b/Adaptors/RabbitMQ/src/PullQueueStorage.cs
@@ -30,10 +30,12 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
+using ArmoniK.Core.Common;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.Injection.Options;
 using ArmoniK.Core.Common.Storage;
 
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
 using RabbitMQ.Client;
@@ -60,6 +62,9 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
                                             $"{nameof(Options.PartitionId)} is not defined.");
     }
   }
+
+  public override Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => ConnectionRabbit.Check(tag);
 
   public override async Task Init(CancellationToken cancellationToken)
   {

--- a/Common/src/Storage/QueueStorageBase.cs
+++ b/Common/src/Storage/QueueStorageBase.cs
@@ -99,7 +99,7 @@ public class QueueStorageBase : IQueueStorage
   }
 
   /// <inheritdoc />
-  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+  public virtual Task<HealthCheckResult> Check(HealthCheckTag tag)
   {
     if (!IsInitialized)
     {

--- a/Common/tests/Helpers/SimpleAmqpClient.cs
+++ b/Common/tests/Helpers/SimpleAmqpClient.cs
@@ -47,7 +47,7 @@ public class SimpleAmqpClient : IConnectionAmqp, IAsyncDisposable
     loggerFactory_ = new LoggerFactory();
     loggerFactory_.AddProvider(new ConsoleForwardingLoggerProvider());
 
-    address_ = new Address("amqp://guest:guest@localhost:5672");
+    address_ = new Address("amqp://admin:admin@localhost:5672");
 
     connectionFactory_ = new ConnectionFactory();
   }

--- a/Common/tests/Helpers/SimpleAmqpClient.cs
+++ b/Common/tests/Helpers/SimpleAmqpClient.cs
@@ -47,7 +47,7 @@ public class SimpleAmqpClient : IConnectionAmqp, IAsyncDisposable
     loggerFactory_ = new LoggerFactory();
     loggerFactory_.AddProvider(new ConsoleForwardingLoggerProvider());
 
-    address_ = new Address("amqp://admin:admin@localhost:5672");
+    address_ = new Address("amqp://guest:guest@localhost:5672");
 
     connectionFactory_ = new ConnectionFactory();
   }

--- a/Common/tests/Helpers/SimpleAmqpClient.cs
+++ b/Common/tests/Helpers/SimpleAmqpClient.cs
@@ -1,5 +1,5 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2022. All rights reserved.
 //   W. Kirschenmann   <wkirschenmann@aneo.fr>
 //   J. Gurhem         <jgurhem@aneo.fr>
@@ -8,17 +8,17 @@
 //   F. Lemaitre       <flemaitre@aneo.fr>
 //   S. Djebbar        <sdjebbar@aneo.fr>
 //   J. Fonseca        <jfonseca@aneo.fr>
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -40,6 +40,7 @@ public class SimpleAmqpClient : IConnectionAmqp, IAsyncDisposable
   private readonly Address           address_;
   private readonly ConnectionFactory connectionFactory_;
   private readonly ILoggerFactory    loggerFactory_;
+  private          bool              isInitialized_;
 
   public SimpleAmqpClient()
   {
@@ -66,9 +67,14 @@ public class SimpleAmqpClient : IConnectionAmqp, IAsyncDisposable
   public Connection? Connection { get; private set; }
 
   public async Task Init(CancellationToken cancellation)
-    => Connection = await connectionFactory_.CreateAsync(address_)
-                                            .ConfigureAwait(false);
+  {
+    Connection = await connectionFactory_.CreateAsync(address_)
+                                         .ConfigureAwait(false);
+    isInitialized_ = true;
+  }
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
-    => Task.FromResult(HealthCheckResult.Healthy());
+    => Task.FromResult(isInitialized_
+                         ? HealthCheckResult.Healthy()
+                         : HealthCheckResult.Unhealthy());
 }

--- a/Common/tests/Helpers/SimpleRabbitClient.cs
+++ b/Common/tests/Helpers/SimpleRabbitClient.cs
@@ -74,5 +74,9 @@ public class SimpleRabbitClient : IConnectionRabbit
   }
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
-    => Task.FromResult(HealthCheckResult.Healthy());
+  {
+    return Task.FromResult(connection_ is not null && connection_.IsOpen && Channel is not null && Channel.IsOpen
+                             ? HealthCheckResult.Healthy()
+                             : HealthCheckResult.Unhealthy());
+  }
 }

--- a/Common/tests/Helpers/SimpleRabbitClient.cs
+++ b/Common/tests/Helpers/SimpleRabbitClient.cs
@@ -74,9 +74,7 @@ public class SimpleRabbitClient : IConnectionRabbit
   }
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
-  {
-    return Task.FromResult(connection_ is not null && connection_.IsOpen && Channel is not null && Channel.IsOpen
-                             ? HealthCheckResult.Healthy()
-                             : HealthCheckResult.Unhealthy());
-  }
+    => Task.FromResult(connection_ is not null && connection_.IsOpen && Channel is not null && Channel.IsOpen
+                         ? HealthCheckResult.Healthy()
+                         : HealthCheckResult.Unhealthy());
 }

--- a/Common/tests/QueueStorageTestsBase.cs
+++ b/Common/tests/QueueStorageTestsBase.cs
@@ -139,7 +139,7 @@ public class QueueStorageTestsBase
                                              .ConfigureAwait(false)).Status);
       Assert.AreEqual(HealthStatus.Healthy,
                       (await PullQueueStorage.Check(HealthCheckTag.Readiness)
-                                            .ConfigureAwait(false)).Status);
+                                             .ConfigureAwait(false)).Status);
       Assert.AreEqual(HealthStatus.Healthy,
                       (await PullQueueStorage.Check(HealthCheckTag.Startup)
                                              .ConfigureAwait(false)).Status);

--- a/Common/tests/QueueStorageTestsBase.cs
+++ b/Common/tests/QueueStorageTestsBase.cs
@@ -121,28 +121,28 @@ public class QueueStorageTestsBase
   {
     if (RunTests)
     {
-      Assert.AreNotEqual(HealthCheckResult.Healthy(),
-                         await PullQueueStorage!.Check(HealthCheckTag.Liveness)
-                                                .ConfigureAwait(false));
-      Assert.AreNotEqual(HealthCheckResult.Healthy(),
-                         await PullQueueStorage.Check(HealthCheckTag.Readiness)
-                                               .ConfigureAwait(false));
-      Assert.AreNotEqual(HealthCheckResult.Healthy(),
-                         await PullQueueStorage.Check(HealthCheckTag.Startup)
-                                               .ConfigureAwait(false));
+      Assert.AreNotEqual(HealthStatus.Healthy,
+                         (await PullQueueStorage!.Check(HealthCheckTag.Liveness)
+                                                 .ConfigureAwait(false)).Status);
+      Assert.AreNotEqual(HealthStatus.Healthy,
+                         (await PullQueueStorage.Check(HealthCheckTag.Readiness)
+                                                .ConfigureAwait(false)).Status);
+      Assert.AreNotEqual(HealthStatus.Healthy,
+                         (await PullQueueStorage.Check(HealthCheckTag.Startup)
+                                                .ConfigureAwait(false)).Status);
 
       await PullQueueStorage.Init(CancellationToken.None)
                             .ConfigureAwait(false);
 
-      Assert.AreEqual(HealthCheckResult.Healthy(),
-                      await PullQueueStorage.Check(HealthCheckTag.Liveness)
-                                            .ConfigureAwait(false));
-      Assert.AreEqual(HealthCheckResult.Healthy(),
-                      await PullQueueStorage.Check(HealthCheckTag.Readiness)
-                                            .ConfigureAwait(false));
-      Assert.AreEqual(HealthCheckResult.Healthy(),
-                      await PullQueueStorage.Check(HealthCheckTag.Startup)
-                                            .ConfigureAwait(false));
+      Assert.AreEqual(HealthStatus.Healthy,
+                      (await PullQueueStorage.Check(HealthCheckTag.Liveness)
+                                             .ConfigureAwait(false)).Status);
+      Assert.AreEqual(HealthStatus.Healthy,
+                      (await PullQueueStorage.Check(HealthCheckTag.Readiness)
+                                            .ConfigureAwait(false)).Status);
+      Assert.AreEqual(HealthStatus.Healthy,
+                      (await PullQueueStorage.Check(HealthCheckTag.Startup)
+                                             .ConfigureAwait(false)).Status);
     }
   }
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,8 +1,11 @@
 locals {
   partitions = toset([for s in range(var.num_partitions) : tostring(s)])
   replicas   = toset([for s in range(var.num_replicas) : tostring(s)])
-  logging_env_vars = { "Serilog__MinimumLevel" = "${var.serilog_level}",
-    "ASPNETCORE_ENVIRONMENT" = "${var.aspnet_core_env}"
+  logging_env_vars = { "Serilog__MinimumLevel" = "${var.serilog.loggin_level}",
+    "Serilog__MinimumLevel__Override__Microsoft.AspNetCore.Hosting.Diagnostics"        = "${var.serilog.loggin_level_routing}",
+    "Serilog__MinimumLevel__Override__Microsoft.AspNetCore.Routing.EndpointMiddleware" = "${var.serilog.loggin_level_routing}",
+    "Serilog__MinimumLevel__Override__Serilog.AspNetCore.RequestLoggingMiddleware"     = "${var.serilog.loggin_level_routing}",
+    "ASPNETCORE_ENVIRONMENT"                                                           = "${var.aspnet_core_env}"
   }
   worker            = merge(var.compute_plane.worker, { image = var.worker_image, docker_file_path = var.worker_docker_file_path })
   queue             = one(concat(module.queue_activemq, module.queue_rabbitmq, module.queue_artemis))

--- a/terraform/modules/compute_plane/locals.tf
+++ b/terraform/modules/compute_plane/locals.tf
@@ -1,9 +1,9 @@
 locals {
   test-cmd          = <<-EOF
-    exec 3<>"/dev/tcp/localhost/1080"
-    echo -en "GET /liveness HTTP/1.1\r\nHost: localhost:1080\r\nConnection: close\r\n\r\n">&3 &
+    exec 3<>"/dev/tcp/localhost/1080" &&
+    echo -en "GET /liveness HTTP/1.1\r\nHost: localhost:1080\r\nConnection: close\r\n\r\n">&3 &&
     grep Healthy <&3 &>/dev/null || exit 1
-    EOF
+  EOF
   partition_chooser = var.replica_counter % var.num_partitions
   env = [
     "Pollster__MaxErrorAllowed=${var.polling_agent.max_error_allowed}",

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -98,7 +98,7 @@ resource "docker_container" "polling_agent" {
   }
 
   healthcheck {
-    test         = concat(["CMD", "bash", "-c"], split(" ", local.test-cmd))
+    test         = ["CMD", "bash", "-c", "exec 3<>\"/dev/tcp/localhost/1080\" && echo -en \"GET /liveness HTTP/1.1\r\nHost: localhost:1080\r\nConnection: close\r\n\r\n\">&3 && grep Healthy <&3 &>/dev/null || exit 1"]
     interval     = "5s"
     timeout      = "3s"
     start_period = "20s"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,9 +31,12 @@ variable "mongodb_params" {
   default = {}
 }
 
-variable "serilog_level" {
-  type    = string
-  default = "Information"
+variable "serilog" {
+  type = object({
+    loggin_level         = optional(string, "Information")
+    loggin_level_routing = optional(string, "Warning")
+  })
+  default = {}
 }
 
 variable "aspnet_core_env" {


### PR DESCRIPTION
If the connection to queue was lost,  the logs were flooded with the message "Error while pulling the messages from the queue". The reason was that we were not calling the right health check  before executing the pollster's main loop. The aim of this PR is to correct this behavior.

Fix https://github.com/aneoconsulting/ArmoniK/issues/857