### PR TITLE
fix: missing nullability constraint of ILogger implem for tests

### DIFF
--- a/Common/tests/Helpers/ForwardingLoggerProvider.cs
+++ b/Common/tests/Helpers/ForwardingLoggerProvider.cs
@@ -63,13 +63,14 @@ internal class ForwardingLoggerProvider : ILoggerProvider
       logAction_    = logAction;
     }
 
+    public bool IsEnabled(LogLevel logLevel)
+      => true;
+
     public IDisposable BeginScope<TState>(TState state)
+      where TState : notnull
       => Disposable.Create(() =>
                            {
                            });
-
-    public bool IsEnabled(LogLevel logLevel)
-      => true;
 
     public void Log<TState>(LogLevel                         logLevel,
                             EventId                          eventId,


### PR DESCRIPTION
This PR fix the missing nullable constraint from ILogger interface for the FowardingLogger class. It removes the warning "Nullability in constraints for type parameter 'TState' of method 'ForwardingLoggerProvider.ForwardingLogger.BeginScope<TState>(TState)' doesn't match the constraints for type parameter 'TState' of interface method 'ILogger.BeginScope<TState>(TState)'. Consider using an explicit interface implementation instead."
