### PR TITLE
fix: warning when using AddInMemoryCollection with ConfigurationBuilder

### DIFF
--- a/Tests/Stream/Client/CreateSessionTests.cs
+++ b/Tests/Stream/Client/CreateSessionTests.cs
@@ -48,15 +48,15 @@ internal class CreateSessionTests
   [SetUp]
   public void SetUp()
   {
-    Dictionary<string, string> baseConfig = new()
-                                            {
-                                              {
-                                                "GrpcClient:Endpoint", "http://localhost:5001"
-                                              },
-                                              {
-                                                "Partition", "TestPartition"
-                                              },
-                                            };
+    Dictionary<string, string?> baseConfig = new()
+                                             {
+                                               {
+                                                 "GrpcClient:Endpoint", "http://localhost:5001"
+                                               },
+                                               {
+                                                 "Partition", "TestPartition"
+                                               },
+                                             };
 
     var builder = new ConfigurationBuilder().AddInMemoryCollection(baseConfig)
                                             .AddEnvironmentVariables();

--- a/Tests/Stream/Client/StreamWrapperTests.cs
+++ b/Tests/Stream/Client/StreamWrapperTests.cs
@@ -52,15 +52,15 @@ internal class StreamWrapperTests
   [SetUp]
   public void SetUp()
   {
-    Dictionary<string, string> baseConfig = new()
-                                            {
-                                              {
-                                                "GrpcClient:Endpoint", "http://localhost:5001"
-                                              },
-                                              {
-                                                "Partition", "TestPartition"
-                                              },
-                                            };
+    Dictionary<string, string?> baseConfig = new()
+                                             {
+                                               {
+                                                 "GrpcClient:Endpoint", "http://localhost:5001"
+                                               },
+                                               {
+                                                 "Partition", "TestPartition"
+                                               },
+                                             };
 
     var builder = new ConfigurationBuilder().AddInMemoryCollection(baseConfig)
                                             .AddEnvironmentVariables();


### PR DESCRIPTION
This PR fixes another warning encountered in tests when initializing ConfigurationBuilder with a dictionary. The value can be nullable. This PR adds the missing ?.
This fixes the warning "Argument of type 'Dictionary<string, string>' cannot be used for parameter 'initialData' of type 'IEnumerable<KeyValuePair<string, string?>>' in 'IConfigurationBuilder MemoryConfigurationBuilderExtensions.AddInMemoryCollection(IConfigurationBuilder configurationBuilder, IEnumerable<KeyValuePair<string, string?>>? initialData)' due to differences in the nullability of reference types.".
