### PR TITLE
feat: Add endpoint on Polling Agent to kill the current task if task is in cancelling status

### DIFF
--- a/Common/tests/Helpers/ExceptionAsyncPipe.cs
+++ b/Common/tests/Helpers/ExceptionAsyncPipe.cs
@@ -1,0 +1,60 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.gRPC.V1.Worker;
+using ArmoniK.Core.Common.Utils;
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+public class ExceptionAsyncPipe<T> : IAsyncPipe<ProcessReply, ProcessRequest>
+  where T : Exception, new()
+{
+  private readonly int delay_;
+
+  public ExceptionAsyncPipe(int delay)
+    => delay_ = delay;
+
+  public async Task<ProcessReply> ReadAsync(CancellationToken cancellationToken)
+  {
+    await Task.Delay(TimeSpan.FromMilliseconds(delay_),
+                     cancellationToken)
+              .ConfigureAwait(false);
+    cancellationToken.ThrowIfCancellationRequested();
+    throw new T();
+  }
+
+  public Task WriteAsync(ProcessRequest message)
+    => Task.CompletedTask;
+
+  public Task WriteAsync(IEnumerable<ProcessRequest> message)
+    => Task.CompletedTask;
+
+  public Task CompleteAsync()
+    => Task.CompletedTask;
+}

--- a/Common/tests/Helpers/ExceptionWorkerStreamHandler.cs
+++ b/Common/tests/Helpers/ExceptionWorkerStreamHandler.cs
@@ -1,0 +1,61 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+//   W. Kirschenmann   <wkirschenmann@aneo.fr>
+//   J. Gurhem         <jgurhem@aneo.fr>
+//   D. Dubuc          <ddubuc@aneo.fr>
+//   L. Ziane Khodja   <lzianekhodja@aneo.fr>
+//   F. Lemaitre       <flemaitre@aneo.fr>
+//   S. Djebbar        <sdjebbar@aneo.fr>
+//   J. Fonseca        <jfonseca@aneo.fr>
+//   D. Brasseur       <dbrasseur@aneo.fr>
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.gRPC.V1.Worker;
+using ArmoniK.Core.Common.Storage;
+using ArmoniK.Core.Common.Stream.Worker;
+using ArmoniK.Core.Common.Utils;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+public class ExceptionWorkerStreamHandler<T> : IWorkerStreamHandler
+  where T : Exception, new()
+{
+  private readonly int delay_;
+
+  public ExceptionWorkerStreamHandler(int delay)
+    => delay_ = delay;
+
+  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => Task.FromResult(HealthCheckResult.Healthy());
+
+  public Task Init(CancellationToken cancellationToken)
+    => Task.CompletedTask;
+
+  public void Dispose()
+  {
+  }
+
+  public IAsyncPipe<ProcessReply, ProcessRequest>? Pipe { get; private set; }
+
+  public void StartTaskProcessing(TaskData          taskData,
+                                  CancellationToken cancellationToken)
+    => Pipe = new ExceptionAsyncPipe<T>(delay_);
+}

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -170,6 +170,18 @@ public static class Program
                          endpoints.MapGet("/taskprocessing",
                                           () => Task.FromResult(app.Services.GetRequiredService<Common.Pollster.Pollster>()
                                                                    .TaskProcessing));
+
+                         endpoints.MapGet("/stopcancelledtask",
+                                          async () =>
+                                          {
+                                            var stopCancelledTask = app.Services.GetRequiredService<Common.Pollster.Pollster>()
+                                                                       .StopCancelledTask;
+                                            if (stopCancelledTask != null)
+                                            {
+                                              await stopCancelledTask.Invoke()
+                                                                     .ConfigureAwait(false);
+                                            }
+                                          });
                        });
 
       var pushQueueStorage = app.Services.GetRequiredService<IPushQueueStorage>();


### PR DESCRIPTION
This PR adds an endpoint in the Agent to cancel the current task if the task is in cancelling state. It updates the taskData in the TaskHandler and eventually trigger the cancellation token if the task is in cancelling status.

fix https://github.com/aneoconsulting/ArmoniK/issues/510
