### PR TITLE
chore: change exposed port for seq

### DIFF
--- a/terraform/modules/monitoring/seq/inputs.tf
+++ b/terraform/modules/monitoring/seq/inputs.tf
@@ -12,7 +12,7 @@ variable "exposed_ports" {
     ingestion = number,
   })
   default = {
-    api       = 80
+    api       = 4080
     ingestion = 5341
   }
 }


### PR DESCRIPTION
Use a non privileged port for seq to account for the case when deploying with docker in rootless mode