### PR TITLE
ci: change codacy to use feat for updating minor version instead of feature

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         dev-branch: main
 
     - name: Print version
-      run: echo VERSION ${{ steps.version.outputs.version }} >> $GITHUB_STEP_SUMMARY
+      run: echo VERSION ${{ steps.genver.outputs.version }} >> $GITHUB_STEP_SUMMARY
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,18 +69,14 @@ jobs:
 
     - name: Generate Version
       id: genver
-      run: |
-        if [[ "${{ github.ref_name }}" == "releases/"* ]]
-        then
-          VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version /bin/git-version --folder=/repo --release-branch=release --dev-branch=${{ github.ref_name }})
-        else
-          VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version /bin/git-version --folder=/repo --release-branch=release --dev-branch=main)
-        fi
+      uses: codacy/git-version@2.7.1
+      with:
+        minor-identifier: "feat:"
+        release-branch: release
+        dev-branch: main
 
-        echo "version=$VERSION" >> $GITHUB_OUTPUT
-        echo "Version :" >> $GITHUB_STEP_SUMMARY
-        echo "$VERSION" >> $GITHUB_STEP_SUMMARY
-        echo $VERSION
+    - name: Print version
+      run: echo VERSION ${{ steps.version.outputs.version }} >> $GITHUB_STEP_SUMMARY
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -10,8 +10,8 @@ jobs:
   versionning:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.genver.outputs.version }}
-      release: ${{ steps.genver.outputs.release }}
+      version: ${{ steps.pre-rel.outputs.version }}
+      release: ${{ steps.release.outputs.version }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -19,15 +19,27 @@ jobs:
         ref: ${{ github.ref }}
         fetch-depth: 0
 
-    - name: Generate Version
-      id: genver
+    - name: Generate Pre-Release Version
+      id: pre-rel
+      uses: codacy/git-version@2.7.1
+      with:
+        minor-identifier: "feat:"
+        release-branch: ${{ github.ref_name }}-pre
+        dev-branch: ${{ github.ref_name }}
+
+    - name: Generate Release Version
+      id: release
+      uses: codacy/git-version@2.7.1
+      with:
+        minor-identifier: "feat:"
+        release-branch: ${{ github.ref_name }}
+        dev-branch: main
+
+    - name: Print version
       run: |
-        VERSION=$(docker run --rm -v $(pwd):/repo codacy/git-version /bin/git-version --folder=/repo --release-branch=${{ github.ref_name }}-pre --dev-branch=${{ github.ref_name }})
-        echo "::set-output name=version::$VERSION"
-        echo "VERSION : $VERSION"
-        RELEASE=$(docker run --rm -v $(pwd):/repo codacy/git-version /bin/git-version --folder=/repo --release-branch=${{ github.ref_name }} --dev-branch=main)
-        echo "::set-output name=release::$RELEASE"
-        echo "RELEASE : $RELEASE"
+        echo PREREL ${{ steps.pre-rel.outputs.version }} >> $GITHUB_STEP_SUMMARY
+        echo RELASE ${{ steps.release.outputs.version }} >> $GITHUB_STEP_SUMMARY
+
 
   tagImagesRelease:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR updates CI to use `feat:` instead of `feature:` to increase the minor part of the version during the version generation.
