### PR TITLE
ci: Change release process so that we can create tags and release through github

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -24,7 +24,6 @@ jobs:
     - name: Remove tag locally
     # This is done so that codacy/git-version can compute the version of the images deployed on docker hub
       run: |
-        git checkout $(git rev-parse HEAD)
         git tag -d ${{ github.ref_name }}
 
     - name: Compute branch for codacy

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,16 +1,18 @@
 name: Release
 
+permissions:
+  contents: write
+
 on:
   push:
-    branches:
-      - release
-    tags-ignore: [ '**' ]
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
   versionning:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.pre-rel.outputs.version }}
+      version: ${{ steps.snapshot.outputs.version }}
       release: ${{ steps.release.outputs.version }}
     steps:
     - name: Checkout
@@ -19,26 +21,46 @@ jobs:
         ref: ${{ github.ref }}
         fetch-depth: 0
 
-    - name: Generate Pre-Release Version
-      id: pre-rel
+    - name: Remove tag locally
+    # This is done so that codacy/git-version can compute the version of the images deployed on docker hub
+      run: |
+        git checkout $(git rev-parse HEAD)
+        git tag -d ${{ github.ref_name }}
+
+    - name: Compute branch for codacy
+    # This is the branch to give to codacy to compute the snapshot version
+      id: rev
+      run: |
+        export CURRENT_BRANCH=$(git describe --tags)
+        echo "current-branch=$CURRENT_BRANCH" >> $GITHUB_OUTPUT
+
+    - name: Generate Snapshot Version
+      id: snapshot
       uses: codacy/git-version@2.7.1
       with:
         minor-identifier: "feat:"
         release-branch: ${{ github.ref_name }}-pre
-        dev-branch: ${{ github.ref_name }}
+        dev-branch: ${{ steps.rev.outputs.current-branch }}
 
     - name: Generate Release Version
       id: release
       uses: codacy/git-version@2.7.1
       with:
         minor-identifier: "feat:"
-        release-branch: ${{ github.ref_name }}
+        release-branch: ${{ steps.rev.outputs.current-branch }}
         dev-branch: main
 
-    - name: Print version
+    - name: Put versions in step summary
       run: |
-        echo PREREL ${{ steps.pre-rel.outputs.version }} >> $GITHUB_STEP_SUMMARY
-        echo RELASE ${{ steps.release.outputs.version }} >> $GITHUB_STEP_SUMMARY
+        echo SNAPSHOT => ${{ steps.snapshot.outputs.version }} >> $GITHUB_STEP_SUMMARY
+        echo RELASE   => ${{ steps.release.outputs.version }} >> $GITHUB_STEP_SUMMARY
+
+    - name: Validate tag
+      run : test ${{ steps.release.outputs.version }} == ${{ github.ref_name }}
+
+    - name: Delete tag if invalid
+      if: failure() || cancelled()
+      run : git push origin -d ${{ github.ref_name }}
 
 
   tagImagesRelease:
@@ -78,21 +100,21 @@ jobs:
     - name: ReTag latest
       run: docker buildx imagetools create ${{ matrix.image }}:${VERSION} --tag ${{ matrix.image }}:latest
 
-  tag:
+
+  update-changelog:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/release' }}
     needs:
       - versionning
-      - tagImagesRelease
-    env:
-      RELEASE: ${{ needs.versionning.outputs.release }}
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.ref }}
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-    - name: tag
-      run: |
-        git tag $RELEASE
-        git push origin $RELEASE
+      - name: Set node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - run: npx changelogithub
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Change the release creation process so that we can create tags and release through github. This is a step to uniformize release processes accross our repositories.

The release workflow for new merged code on main would be:
- Create a release from github interface
- Choose the proper next version tag according to the features (feat:) present in the history from the last tag.
- Publish the release
- If the tag is valid, docker images with the new tag are released
- If the tag is __not__ valid, tag is deleted and released is put in draft.