### PR TITLE
refactor: put tests in folders

### DIFF
--- a/Adaptors/Amqp/tests/QueueStorageTests.cs
+++ b/Adaptors/Amqp/tests/QueueStorageTests.cs
@@ -19,8 +19,8 @@ using System;
 using System.Collections;
 using System.Threading.Tasks;
 
-using ArmoniK.Core.Common.Tests;
 using ArmoniK.Core.Common.Tests.Helpers;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Adaptors/LocalStorage/tests/ObjectStorageTests.cs
+++ b/Adaptors/LocalStorage/tests/ObjectStorageTests.cs
@@ -18,7 +18,7 @@
 using System;
 using System.IO;
 
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Adaptors/Memory/tests/ResultTableTests.cs
+++ b/Adaptors/Memory/tests/ResultTableTests.cs
@@ -18,7 +18,7 @@
 using System.Collections.Concurrent;
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/Memory/tests/SessionTableTests.cs
+++ b/Adaptors/Memory/tests/SessionTableTests.cs
@@ -32,7 +32,7 @@
 using System.Collections.Concurrent;
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/Memory/tests/TaskTableTests.cs
+++ b/Adaptors/Memory/tests/TaskTableTests.cs
@@ -18,7 +18,7 @@
 using System.Collections.Concurrent;
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/AuthenticationTableTest.cs
+++ b/Adaptors/MongoDB/tests/AuthenticationTableTest.cs
@@ -19,7 +19,7 @@ using System;
 
 using ArmoniK.Core.Adapters.MongoDB.Table.DataModel.Auth;
 using ArmoniK.Core.Common.Auth.Authentication;
-using ArmoniK.Core.Common.Tests.Auth;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/ObjectStorageTests.cs
+++ b/Adaptors/MongoDB/tests/ObjectStorageTests.cs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/PartitionTableTests.cs
+++ b/Adaptors/MongoDB/tests/PartitionTableTests.cs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/ResultTableTests.cs
+++ b/Adaptors/MongoDB/tests/ResultTableTests.cs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/ResultWatcherTests.cs
+++ b/Adaptors/MongoDB/tests/ResultWatcherTests.cs
@@ -17,7 +17,7 @@
 
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Storage.Events;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/SessionTableTests.cs
+++ b/Adaptors/MongoDB/tests/SessionTableTests.cs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/TaskTableTests.cs
+++ b/Adaptors/MongoDB/tests/TaskTableTests.cs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/MongoDB/tests/TaskWatcherTests.cs
+++ b/Adaptors/MongoDB/tests/TaskWatcherTests.cs
@@ -17,7 +17,7 @@
 
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Storage.Events;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.DependencyInjection;
 

--- a/Adaptors/RabbitMQ/tests/QueueStorageTests.cs
+++ b/Adaptors/RabbitMQ/tests/QueueStorageTests.cs
@@ -18,8 +18,8 @@
 using System;
 using System.Threading.Tasks;
 
-using ArmoniK.Core.Common.Tests;
 using ArmoniK.Core.Common.Tests.Helpers;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.Logging.Abstractions;
 

--- a/Adaptors/Redis/tests/ObjectStorageTests.cs
+++ b/Adaptors/Redis/tests/ObjectStorageTests.cs
@@ -20,7 +20,7 @@ using System.Collections.Generic;
 using System.IO;
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;

--- a/Adaptors/S3/tests/ObjectStorageTests.cs
+++ b/Adaptors/S3/tests/ObjectStorageTests.cs
@@ -16,7 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Tests;
+using ArmoniK.Core.Common.Tests.TestBase;
 using ArmoniK.Core.Common.Utils;
 
 using Microsoft.Extensions.Configuration;

--- a/Common/tests/TestBase/AuthenticationTableTestBase.cs
+++ b/Common/tests/TestBase/AuthenticationTableTestBase.cs
@@ -29,7 +29,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests.Auth;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class AuthenticationTableTestBase

--- a/Common/tests/TestBase/ObjectStorageTestBase.cs
+++ b/Common/tests/TestBase/ObjectStorageTestBase.cs
@@ -29,7 +29,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class ObjectStorageTestBase

--- a/Common/tests/TestBase/PartitionTableTestBase.cs
+++ b/Common/tests/TestBase/PartitionTableTestBase.cs
@@ -26,7 +26,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class PartitionTableTestBase

--- a/Common/tests/TestBase/QueueStorageTestsBase.cs
+++ b/Common/tests/TestBase/QueueStorageTestsBase.cs
@@ -24,7 +24,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class QueueStorageTestsBase
@@ -54,8 +54,8 @@ public class QueueStorageTestsBase
    * an instance of this class */
   protected bool RunTests;
 
-/* Function be override so it returns the suitable instance
- * of QueueStorage to the corresponding interface implementation */
+  /* Function be override so it returns the suitable instance
+   * of QueueStorage to the corresponding interface implementation */
   protected virtual Task GetQueueStorageInstance()
     => Task.CompletedTask;
 

--- a/Common/tests/TestBase/ResultTableTestBase.cs
+++ b/Common/tests/TestBase/ResultTableTestBase.cs
@@ -31,7 +31,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class ResultTableTestBase

--- a/Common/tests/TestBase/ResultWatcherTestBase.cs
+++ b/Common/tests/TestBase/ResultWatcherTestBase.cs
@@ -29,7 +29,7 @@ using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class ResultWatcherTestBase

--- a/Common/tests/TestBase/SessionTableTestBase.cs
+++ b/Common/tests/TestBase/SessionTableTestBase.cs
@@ -33,7 +33,7 @@ using NUnit.Framework;
 
 using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class SessionTableTestBase

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -36,7 +36,7 @@ using NUnit.Framework;
 
 using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class TaskTableTestBase

--- a/Common/tests/TestBase/TaskWatcherTestBase.cs
+++ b/Common/tests/TestBase/TaskWatcherTestBase.cs
@@ -29,7 +29,7 @@ using NUnit.Framework;
 
 using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.TestBase;
 
 [TestFixture]
 public class TaskWatcherTestBase

--- a/Common/tests/Validators/CancelTasksRequestValidatorTest.cs
+++ b/Common/tests/Validators/CancelTasksRequestValidatorTest.cs
@@ -20,7 +20,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(CancelTasksRequestValidator))]
 public class CancelTasksRequestValidatorTest

--- a/Common/tests/Validators/CreateLargeTaskRequestValidatorTest.cs
+++ b/Common/tests/Validators/CreateLargeTaskRequestValidatorTest.cs
@@ -26,7 +26,7 @@ using Google.Protobuf.WellKnownTypes;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(CreateLargeTaskRequestValidator))]
 public class CreateLargeTaskRequestValidatorTest

--- a/Common/tests/Validators/CreateSessionRequestValidatorTest.cs
+++ b/Common/tests/Validators/CreateSessionRequestValidatorTest.cs
@@ -25,7 +25,7 @@ using Google.Protobuf.WellKnownTypes;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(CreateSessionRequestValidator))]
 public class CreateSessionRequestValidatorTest

--- a/Common/tests/Validators/CreateSmallTaskRequestValidatorTest.cs
+++ b/Common/tests/Validators/CreateSmallTaskRequestValidatorTest.cs
@@ -27,7 +27,7 @@ using Google.Protobuf.WellKnownTypes;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(CreateSmallTaskRequestValidator))]
 public class CreateSmallTaskRequestValidatorTest

--- a/Common/tests/Validators/ListApplicationsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListApplicationsRequestValidatorTest.cs
@@ -22,7 +22,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(ListApplicationsRequestValidator))]
 public class ListApplicationsRequestValidatorTest

--- a/Common/tests/Validators/ListPartitionsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListPartitionsRequestValidatorTest.cs
@@ -23,7 +23,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(ListPartitionsRequestValidator))]
 public class ListPartitionsRequestValidatorTest

--- a/Common/tests/Validators/ListResultsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListResultsRequestValidatorTest.cs
@@ -22,7 +22,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(ListResultsRequestValidator))]
 public class ListResultsRequestValidatorTest

--- a/Common/tests/Validators/ListSessionsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListSessionsRequestValidatorTest.cs
@@ -22,7 +22,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(ListSessionsRequestValidator))]
 public class ListSessionsRequestValidatorTest

--- a/Common/tests/Validators/ListTasksRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListTasksRequestValidatorTest.cs
@@ -22,7 +22,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(ListTasksRequestValidator))]
 public class ListTasksRequestValidatorTest

--- a/Common/tests/Validators/SessionFilterValidatorTest.cs
+++ b/Common/tests/Validators/SessionFilterValidatorTest.cs
@@ -21,7 +21,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(SessionFilterValidator))]
 public class SessionFilterValidatorTest

--- a/Common/tests/Validators/TaskFilterValidatorTest.cs
+++ b/Common/tests/Validators/TaskFilterValidatorTest.cs
@@ -23,7 +23,7 @@ using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(TaskFilterValidator))]
 public class TaskFilterValidatorTest

--- a/Common/tests/Validators/TaskOptionsValidatorTest.cs
+++ b/Common/tests/Validators/TaskOptionsValidatorTest.cs
@@ -24,7 +24,7 @@ using Google.Protobuf.WellKnownTypes;
 
 using NUnit.Framework;
 
-namespace ArmoniK.Core.Common.Tests;
+namespace ArmoniK.Core.Common.Tests.Validators;
 
 [TestFixture(TestOf = typeof(TaskOptionsValidator))]
 public class TaskOptionsValidatorTest


### PR DESCRIPTION
This PR reorganizes tests. It puts TestBase and Validator tests in folders.
