### PR TITLE
fix: too many queries on metrics exporter on mongodb

### DIFF
--- a/Common/src/Utils/ExecutionSingleizer.cs
+++ b/Common/src/Utils/ExecutionSingleizer.cs
@@ -32,6 +32,11 @@ public class ExecutionSingleizer<T> : IDisposable
   private readonly long   tickValidity_;
   private          Handle handle_ = new();
 
+
+  /// <summary>
+  /// Allow initialization of <see cref="ExecutionSingleizer"/>
+  /// </summary>
+  /// <param name="timeValidity">Results from the execution will be in cache during timeValidity</param>
   public ExecutionSingleizer(TimeSpan timeValidity = default)
     => tickValidity_ = (long)Math.Ceiling(Stopwatch.Frequency * timeValidity.TotalSeconds);
 
@@ -126,7 +131,6 @@ public class ExecutionSingleizer<T> : IDisposable
     }
     finally
     {
-
       // Reset the validity of the result once the result is available.
       // This is done by all threads in order to avoid race condition with the Waiters decrement.
       if (!currentHandle.CancellationTokenSource.IsCancellationRequested)

--- a/Common/src/Utils/ExecutionSingleizer.cs
+++ b/Common/src/Utils/ExecutionSingleizer.cs
@@ -52,7 +52,7 @@ public class ExecutionSingleizer<T> : IDisposable
 
     // If there is no waiters, the task is complete (success or failed), and no thread is currently running it.
     // We therefore need to call func again
-    if (currentHandle.Waiters == 0)
+    if (currentHandle.Waiters == 0 && DateTime.Now > currentHandle.ValidUntil)
     {
       // Prepare new handle, with new cancellation token source and new task
       var cts         = new CancellationTokenSource();
@@ -63,6 +63,7 @@ public class ExecutionSingleizer<T> : IDisposable
                         CancellationTokenSource = cts,
                         // Unwrap allows the handle to have a single level Task, instead of a Task<Task<...>>
                         InnerTask = delayedTask.Unwrap(),
+                        ValidUntil = DateTime.Now.AddSeconds(5),
                         // Current thread is implicitly waiting for the task
                         Waiters = 1,
                       };
@@ -183,6 +184,8 @@ public class ExecutionSingleizer<T> : IDisposable
     ///   Task that creates the result.
     /// </summary>
     public Task<T> InnerTask { get; init; }
+
+    public DateTime ValidUntil { get; set; }
 
     /// <inheritdoc />
     public void Dispose()

--- a/Common/src/Utils/ExecutionSingleizer.cs
+++ b/Common/src/Utils/ExecutionSingleizer.cs
@@ -90,7 +90,6 @@ public class ExecutionSingleizer<T> : IDisposable
         // We can now start the task, other threads will just wait on the result.
         delayedTask.Start();
         currentHandle                   = newHandle;
-        currentHandle.SetTimeValidityMs(timeValidityMs_);
 
         // There is no need increment number of waiters as it has been initialized to 1.
       }
@@ -140,6 +139,7 @@ public class ExecutionSingleizer<T> : IDisposable
         // If we enter here because the task has completed without errors,
         // cancelling is a no op, therefore, we do not need to check why we went here.
         currentHandle.CancellationTokenSource.Cancel();
+        currentHandle.SetTimeValidityMs(timeValidityMs_);
 
         // FIXME: There might be a race condition between the dispose and the cancel here.
         // ManyConcurrentExecutionShouldSucceed fails with:
@@ -200,7 +200,7 @@ public class ExecutionSingleizer<T> : IDisposable
     public void SetTimeValidityMs(int timeValidityMs)
     {
       timeValidityTicks_ = timeValidityMs / 1000 * Stopwatch.Frequency;
-      stopWatch_         = Stopwatch.StartNew();
+      stopWatch_.Restart();
     }
 
     public bool IsOutOfDate

--- a/Common/src/Utils/ExecutionSingleizer.cs
+++ b/Common/src/Utils/ExecutionSingleizer.cs
@@ -34,7 +34,7 @@ public class ExecutionSingleizer<T> : IDisposable
 
 
   /// <summary>
-  /// Allow initialization of <see cref="ExecutionSingleizer"/>
+  ///   Allow initialization of <see cref="ExecutionSingleizer" />
   /// </summary>
   /// <param name="timeValidity">Results from the execution will be in cache during timeValidity</param>
   public ExecutionSingleizer(TimeSpan timeValidity = default)

--- a/Common/src/Utils/ExecutionSingleizer.cs
+++ b/Common/src/Utils/ExecutionSingleizer.cs
@@ -15,8 +15,6 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-using Google.Protobuf.WellKnownTypes;
-
 using System;
 using System.Diagnostics;
 using System.Threading;
@@ -31,17 +29,15 @@ namespace ArmoniK.Core.Common.Utils;
 /// <typeparam name="T">Type of the return object</typeparam>
 public class ExecutionSingleizer<T> : IDisposable
 {
-  private Handle handle_ = new();
+  private readonly long   tickValidity_;
+  private          Handle handle_ = new();
+
+  public ExecutionSingleizer(TimeSpan timeValidity = default)
+    => tickValidity_ = (long)Math.Ceiling(Stopwatch.Frequency * timeValidity.TotalSeconds);
 
   /// <inheritdoc />
   public void Dispose()
     => handle_.Dispose();
-
-  private readonly int timeValidityMs_;
-  public ExecutionSingleizer(int timeValidityMs = 5000)
-  {
-    timeValidityMs_ = timeValidityMs;
-  }
 
   /// <summary>
   ///   Call the asynchronous function func.
@@ -60,8 +56,8 @@ public class ExecutionSingleizer<T> : IDisposable
     var currentHandle = handle_;
 
     // If there is no waiters, the task is complete (success or failed), and no thread is currently running it.
-    // We therefore need to call func again
-    if (currentHandle.Waiters == 0 && currentHandle.IsOutOfDate)
+    // We therefore need to call func again if the data has expired.
+    if (currentHandle.Waiters == 0 && Stopwatch.GetTimestamp() > currentHandle.ValidUntil)
     {
       // Prepare new handle, with new cancellation token source and new task
       var cts         = new CancellationTokenSource();
@@ -89,7 +85,7 @@ public class ExecutionSingleizer<T> : IDisposable
         // Current thread has won, the others will see this new handle.
         // We can now start the task, other threads will just wait on the result.
         delayedTask.Start();
-        currentHandle                   = newHandle;
+        currentHandle = newHandle;
 
         // There is no need increment number of waiters as it has been initialized to 1.
       }
@@ -130,6 +126,14 @@ public class ExecutionSingleizer<T> : IDisposable
     }
     finally
     {
+
+      // Reset the validity of the result once the result is available.
+      // This is done by all threads in order to avoid race condition with the Waiters decrement.
+      if (!currentHandle.CancellationTokenSource.IsCancellationRequested)
+      {
+        currentHandle.ValidUntil = Stopwatch.GetTimestamp() + tickValidity_;
+      }
+
       // Remove the current thread from the list of waiters.
       var i = Interlocked.Decrement(ref currentHandle.Waiters);
 
@@ -139,7 +143,6 @@ public class ExecutionSingleizer<T> : IDisposable
         // If we enter here because the task has completed without errors,
         // cancelling is a no op, therefore, we do not need to check why we went here.
         currentHandle.CancellationTokenSource.Cancel();
-        currentHandle.SetTimeValidityMs(timeValidityMs_);
 
         // FIXME: There might be a race condition between the dispose and the cancel here.
         // ManyConcurrentExecutionShouldSucceed fails with:
@@ -165,12 +168,14 @@ public class ExecutionSingleizer<T> : IDisposable
   private sealed class Handle : IDisposable
   {
     /// <summary>
+    ///   Specify the timestamp until the data is valid
+    /// </summary>
+    public long ValidUntil = long.MinValue;
+
+    /// <summary>
     ///   Number of threads waiting for the result.
     /// </summary>
     public int Waiters;
-
-    private Stopwatch stopWatch_ = Stopwatch.StartNew();
-    private long      timeValidityTicks_ = 1;
 
     /// <summary>
     ///   Construct an handle that is cancelled.
@@ -197,21 +202,7 @@ public class ExecutionSingleizer<T> : IDisposable
     /// </summary>
     public Task<T> InnerTask { get; init; }
 
-    public void SetTimeValidityMs(int timeValidityMs)
-    {
-      timeValidityTicks_ = timeValidityMs / 1000 * Stopwatch.Frequency;
-      stopWatch_.Restart();
-    }
-
-    public bool IsOutOfDate
-    {
-      get
-      {
-        return stopWatch_.ElapsedTicks > timeValidityTicks_;
-      }
-    }
-
-  /// <inheritdoc />
+    /// <inheritdoc />
     public void Dispose()
     {
       CancellationTokenSource.Dispose();

--- a/Common/tests/Utils/ExecutionSingleizerTest.cs
+++ b/Common/tests/Utils/ExecutionSingleizerTest.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -204,6 +205,42 @@ public class ExecutionSingleizerTest
     Assert.ThrowsAsync<TaskCanceledException>(async () => await t2.ConfigureAwait(false));
 
     Assert.AreEqual(0,
+                    val_);
+  }
+
+
+  [Test]
+  public async Task CheckExpire()
+  {
+    var single = new ExecutionSingleizer<int>(TimeSpan.FromMilliseconds(100));
+    var i = await single.Call(ct => Set(1,
+                                        0,
+                                        ct))
+                        .ConfigureAwait(false);
+    Assert.AreEqual(1,
+                    i);
+    Assert.AreEqual(1,
+                    val_);
+
+    i = await single.Call(ct => Set(2,
+                                    0,
+                                    ct))
+                    .ConfigureAwait(false);
+    Assert.AreEqual(1,
+                    i);
+    Assert.AreEqual(1,
+                    val_);
+
+    await Task.Delay(150)
+              .ConfigureAwait(false);
+
+    i = await single.Call(ct => Set(3,
+                                    0,
+                                    ct))
+                    .ConfigureAwait(false);
+    Assert.AreEqual(3,
+                    i);
+    Assert.AreEqual(3,
                     val_);
   }
 

--- a/Control/Metrics/src/ArmoniKMeter.cs
+++ b/Control/Metrics/src/ArmoniKMeter.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -51,7 +51,7 @@ public class ArmoniKMeter : Meter, IHostedService
     taskTable_    = taskTable;
     logger_       = logger;
     gauges_       = new Dictionary<Tuple<string, string>, ObservableGauge<long>>();
-    measurements_ = new ExecutionSingleizer<IDictionary<Tuple<string, string>, long>>();
+    measurements_ = new ExecutionSingleizer<IDictionary<Tuple<string, string>, long>>(TimeSpan.FromSeconds(5));
 
     CreateObservableCounter("test",
                             () => i_++);

--- a/Control/PartitionMetrics/src/ArmoniKMeter.cs
+++ b/Control/PartitionMetrics/src/ArmoniKMeter.cs
@@ -57,7 +57,7 @@ public class ArmoniKMeter : Meter, IHostedService
     partitionTable_ = partitionTable;
     logger_         = logger;
     gauges_         = new Dictionary<string, ObservableGauge<long>>();
-    measurements_   = new ExecutionSingleizer<IDictionary<string, long>>();
+    measurements_   = new ExecutionSingleizer<IDictionary<string, long>>(TimeSpan.FromSeconds(5));
 
     CreateObservableCounter("test",
                             () => i_++);


### PR DESCRIPTION
previously : metrics exporter was calling about 15 times mongodb by cycle of refresh
now : only one call is performed