### PR TITLE
chore: update api to 3.5.2

### DIFF
--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -26,7 +26,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Core" Version="3.5.0-SNAPSHOT.16.822ea77" />
+    <PackageReference Include="ArmoniK.Api.Core" Version="3.5.2" />
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.2.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.50.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />

--- a/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
+++ b/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.5.0-SNAPSHOT.16.822ea77" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.5.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
   </ItemGroup>
 

--- a/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
+++ b/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="ArmoniK.Api.Client" Version="3.5.0-SNAPSHOT.16.822ea77" />
+	  <PackageReference Include="ArmoniK.Api.Client" Version="3.5.2" />
 	  <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
 	</ItemGroup>
 	

--- a/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
+++ b/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.5.0-SNAPSHOT.16.822ea77" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.5.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Htc.Mock" Version="3.0.0-alpha11" />
   </ItemGroup>

--- a/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
+++ b/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.5.0-SNAPSHOT.16.822ea77" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.5.2" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
+++ b/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.5.0-SNAPSHOT.16.822ea77" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.5.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR updates ArmoniK.Api to its latest stable version : 3.5.2 in preparation for the new release
