### PR TITLE
fix: correct metrics exporter host name

### DIFF
--- a/terraform/modules/monitoring/metrics/outputs.tf
+++ b/terraform/modules/monitoring/metrics/outputs.tf
@@ -1,6 +1,6 @@
 output "metrics_env_vars" {
   value = ({
-    "MetricsExporter__Host" = "http://armonik.control.metrics"
+    "MetricsExporter__Host" = "http://localhost"
     "MetricsExporter__Port" = var.exposed_port
     "MetricsExporter__Path" = "/metrics"
   })


### PR DESCRIPTION
Service `partition_metrics` was using the wrong host name to communicate with the `metrics` server. In a  local deployment the later simply uses `localhost` as host name. 