### PR TITLE
fix: workerCheckDelay in deployment

### DIFF
--- a/terraform/modules/compute_plane/locals.tf
+++ b/terraform/modules/compute_plane/locals.tf
@@ -8,7 +8,7 @@ locals {
   env = [
     "Pollster__MaxErrorAllowed=${var.polling_agent.max_error_allowed}",
     "InitWorker__WorkerCheckRetries=${var.polling_agent.worker_check_retries}",
-    "InitWorker__WorkerCheckDelay=${var.polling_agent.worker_check_retries}",
+    "InitWorker__WorkerCheckDelay=${var.polling_agent.worker_check_delay}",
     "Zipkin__Uri=${var.zipkin_uri}",
     "Amqp__PartitionId=TestPartition${local.partition_chooser}"
   ]

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -129,7 +129,7 @@ variable "compute_plane" {
       port                 = optional(number, 9980)
       max_error_allowed    = optional(number, -1)
       worker_check_retries = optional(number, 10)
-      worker_check_delay   = optional(string, "00:00:10")
+      worker_check_delay   = optional(string, "00:00:01")
     })
   })
   default = {


### PR DESCRIPTION
The workerCheckDelay variable was wrongly set in the terraform deployment.
In addition a smaller default time span has been defined to ensure the retries
in the WorkerStreamHandler Init function take place before the pollster main loop
starts/stops.
