### PR TITLE
fix: properly ignore folders in .dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,8 +18,8 @@
 **/bin
 **/charts
 **/docker-compose*
-docker-compose/
-tools/
+docker-compose
+tools
 **/node_modules
 **/npm-debug.log
 **/obj


### PR DESCRIPTION
When using the `ncdu -X .dockerignore` command, we can see that the `tools` folder was not properly ignored inducing undesired rebuild for the docker images when modifing files in this folder.
