### PR TITLE
refactor: Show more stats from task data in Bench and HtcMock

### DIFF
--- a/Tests/Common/Client/src/GrpcChannelExt.cs
+++ b/Tests/Common/Client/src/GrpcChannelExt.cs
@@ -181,6 +181,16 @@ public static class GrpcChannelExt
                           timeSpentList.Max(),
                           timeSpentList.Average());
 
+    timeSpentList = taskDependencies.Values.Select(raw => (raw.EndedAt - raw.AcquiredAt).ToTimeSpan()
+                                                                                        .TotalMilliseconds / 1000)
+                                    .ToList();
+    logger.LogInformation("Time spent between {status1} and {status2} : {min}s, {max}s, {avg}s",
+                          TaskStatus.Dispatched,
+                          TaskStatus.Completed,
+                          timeSpentList.Min(),
+                          timeSpentList.Max(),
+                          timeSpentList.Average());
+
     var sessionStart    = taskDependencies.Values.Min(raw => raw.CreatedAt);
     var sessionEnd      = taskDependencies.Values.Max(raw => raw.EndedAt);
     var sessionDuration = (sessionEnd - sessionStart).ToTimeSpan();


### PR DESCRIPTION
Compute time between task acquisition and end to show it in perf logs.
