### PR TITLE
fix: correct bucket name so it matches what unit test expects

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,7 +62,7 @@ variable "object_storage" {
     port        = optional(number, 9000)
     login       = optional(string, "minioadmin")
     password    = optional(string, "minioadmin")
-    bucket_name = optional(string, "minioBucket")
+    bucket_name = optional(string, "miniobucket")
 
   })
   validation {


### PR DESCRIPTION
The S3 unit tests were failing in a local deployment with terraform due to a mismatch in the bucked name

Fix: https://github.com/aneoconsulting/ArmoniK/issues/933