### PR TITLE
chore: Clean up docker-compose usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,7 +64,7 @@ jobs:
           sudo apt-get install just
 
     - name: Minio Server UP
-      if: ${{matrix.projects}} == "Adaptors/S3/tests"
+      if: ${{ matrix.projects }} == "Adaptors/S3/tests"
       run: |
           just object=minio deployTargetObject
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,8 @@ jobs:
         os:
           - ubuntu-latest
         include:
-          - queue: rabbitmq091
+          - os: ubuntu-latest
+            queue: rabbitmq091
             projects: Adaptors/RabbitMQ/tests
       fail-fast: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,14 +74,17 @@ jobs:
         path: ${{ matrix.projects }}/TestResults/test-results.trx
         reporter: dotnet-trx
 
-  testsQueueProto100:
+  testsQueueProtos:
     strategy:
       matrix:
-        projects:
-          - Adaptors/Amqp/tests
         queue:
           - activemq
           - rabbitmq
+        projects:
+          - Adaptors/Amqp/tests
+        include:
+          - queue: rabbitmq091
+            projects: Adaptors/RabbitMQ/tests
         os:
           - ubuntu-latest
       fail-fast: false
@@ -97,54 +100,26 @@ jobs:
       uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 6.x
+    
+    - name: Setup just
+      run: |
+          curl -q 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
+          sudo apt-get update
+          sudo apt-get install just
 
-    - name: Setup queue
-      uses: isbang/compose-action@v1.4.0
-      with:
-        compose-file: "./docker-compose/queue-standalone/docker-compose.queue-${{ matrix.queue }}.yml"
+    - name: Set up queue
+      run: |
+          just queue=${{ matrix.queue }} deployTargetQueue
 
-    - name: Run tests
+    - name: Tests for AMQP 1.0.0 protcol
+      if: ${{ matrix.queue }} != "rabittmq091"
       run: |
         cd ${{ matrix.projects }}
         dotnet test --logger "trx;LogFileName=test-results.trx"
 
-    - name: Test Report
-      uses: dorny/test-reporter@v1
-      if: success() || failure()
-      with:
-        name: Test - ${{ matrix.queue }} ${{ matrix.projects }}
-        path: ${{ matrix.projects }}/TestResults/test-results.trx
-        reporter: dotnet-trx
-
-  testsQueueProto091:
-    strategy:
-      matrix:
-        projects:
-          - Adaptors/RabbitMQ/tests
-        queue:
-          - rabbitmq-0.9.1
-        os:
-          - ubuntu-latest
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ github.ref }}
-        submodules: true
-
-    - name: Install .NET Core
-      uses: actions/setup-dotnet@v3
-      with:
-        dotnet-version: 6.x
-
-    - name: Setup queue
-      uses: isbang/compose-action@v1.4.0
-      with:
-        compose-file: "./docker-compose/queue-standalone/docker-compose.queue-${{ matrix.queue }}.yml"
-
-    - name: Run tests
+    - name: Tests for AMQP 0.9.1 protcol
+      if: ${{ matrix.queue }} == "rabittmq091"
       run: |
         cd ${{ matrix.projects }}
         dotnet test --logger "trx;LogFileName=test-results.trx"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,10 +56,17 @@ jobs:
       with:
         dotnet-version: 6.x
 
+    - name: Setup just
+      run: |
+          curl -q 'https://proget.makedeb.org/debian-feeds/prebuilt-mpr.pub' | gpg --dearmor | sudo tee /usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg 1> /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/prebuilt-mpr-archive-keyring.gpg] https://proget.makedeb.org prebuilt-mpr $(lsb_release -cs)" | sudo tee /etc/apt/sources.list.d/prebuilt-mpr.list
+          sudo apt-get update
+          sudo apt-get install just
+
     - name: Minio Server UP
-      uses: isbang/compose-action@v1.4.0
-      with:
-        compose-file: "./docker-compose/S3/docker-compose-minio.yml"
+      if: ${{matrix.projects}} == "Adaptors/S3/tests"
+      run: |
+          just object=minio deployTargetObject
 
     - name: Run tests
       run: |
@@ -82,11 +89,11 @@ jobs:
           - rabbitmq
         projects:
           - Adaptors/Amqp/tests
+        os:
+          - ubuntu-latest
         include:
           - queue: rabbitmq091
             projects: Adaptors/RabbitMQ/tests
-        os:
-          - ubuntu-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -112,14 +119,7 @@ jobs:
       run: |
           just queue=${{ matrix.queue }} deployTargetQueue
 
-    - name: Tests for AMQP 1.0.0 protcol
-      if: ${{ matrix.queue }} != "rabittmq091"
-      run: |
-        cd ${{ matrix.projects }}
-        dotnet test --logger "trx;LogFileName=test-results.trx"
-
-    - name: Tests for AMQP 0.9.1 protcol
-      if: ${{ matrix.queue }} == "rabittmq091"
+    - name: Run tests
       run: |
         cd ${{ matrix.projects }}
         dotnet test --logger "trx;LogFileName=test-results.trx"
@@ -816,8 +816,7 @@ jobs:
   canMerge:
     needs:
       - tests
-      - testsQueueProto091
-      - testsQueueProto100
+      - testsQueueProtos
       - testsWinOnly
       - testHtcMockDC
       - defaultPartitionMock

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -368,12 +368,12 @@ jobs:
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -czf - terraform/logs/armonik-logs.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/${{ github.run_number }}/${{ github.run_attempt }}/stream-${{ matrix.queue }}-${{ matrix.log-level }}.json.tar.gz
-      - name: Collect docker compose logs
+      - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@v2
         if: always()
         with:
           dest: './container-logs'
-      - name: Upload docker compose logs
+      - name: Upload docker container logs
         if: always()
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -502,12 +502,12 @@ jobs:
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -czf - terraform/logs/armonik-logs.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-${{ matrix.queue }}-${{ matrix.object }}-${{ matrix.log-level }}.json.tar.gz
 
-      - name: Collect docker compose logs
+      - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@v2
         if: always()
         with:
           dest: './container-logs'
-      - name: Upload docker compose logs
+      - name: Upload docker container logs
         if: always()
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -601,12 +601,12 @@ jobs:
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -czf - terraform/logs/armonik-logs.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/${{ github.run_number }}/${{ github.run_attempt }}/runBench.json.tar.gz
-      - name: Collect docker compose logs
+      - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@v2
         if: always()
         with:
           dest: './container-logs'
-      - name: Upload docker compose logs
+      - name: Upload docker container logs
         if: always()
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -668,12 +668,12 @@ jobs:
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -czf - terraform/logs/armonik-logs.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-defaultpartition.json.tar.gz
-      - name: Collect docker compose logs
+      - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@v2
         if: always()
         with:
           dest: './container-logs'
-      - name: Upload docker compose logs
+      - name: Upload docker container logs
         if: always()
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -802,12 +802,12 @@ jobs:
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}
           export AWS_SECRET_ACCESS_KEY=${{ secrets.AWS_SECRET_ACCESS_KEY }}
           tar -czf - terraform/logs/armonik-logs.json | aws s3 cp - s3://${{ secrets.AWS_LOG_BUCKET_NAME }}/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-healthchecktest.json.tar.gz
-      - name: Collect docker compose logs
+      - name: Collect docker container logs
         uses: jwalton/gh-docker-logs@v2
         if: always()
         with:
           dest: './container-logs'
-      - name: Upload docker compose logs
+      - name: Upload docker container logs
         if: always()
         run: |
           export AWS_ACCESS_KEY_ID=${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,9 +92,9 @@ jobs:
         os:
           - ubuntu-latest
         include:
-          - os: ubuntu-latest
-            queue: rabbitmq091
+          - queue: rabbitmq091
             projects: Adaptors/RabbitMQ/tests
+            os: ubuntu-latest
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/justfile
+++ b/justfile
@@ -144,6 +144,32 @@ plan: (init)
 deploy: (init)
   terraform -chdir=./terraform apply -auto-approve
 
+# Deploy target: object standalone
+deployTargetObject: (init)
+  terraform -chdir=./terraform apply -target="module.object_{{object}}" -auto-approve
+
+# Destroy target: queue standalone
+destroyTargetObject:
+  terraform -chdir=./terraform destroy -target="module.object_{{object}}" -auto-approve
+
+# Deploy target: queue standalone
+deployTargetQueue: (init)
+  #!/usr/bin/env bash
+  which_module="module.queue_{{queue}}"
+  if [ {{queue}} = "rabbitmq091" ]; then
+    which_module="module.queue_rabbitmq"
+  fi
+  terraform -chdir=./terraform apply -target="${which_module}" -auto-approve
+
+# Destroy target: queue standalone
+destroyTargetQueue:
+  #!/usr/bin/env bash
+  which_module="module.queue_{{queue}}"
+  if [ {{queue}} = "rabbitmq091" ]; then
+    which_module="module.queue_rabbitmq"
+  fi
+  terraform -chdir=./terraform destroy -target="${which_module}" -auto-approve
+
 # Destroy ArmoniK Core
 destroy:
   terraform -chdir=./terraform destroy -auto-approve


### PR DESCRIPTION
This PR prepares the way to fully deprecate the docker-compose based deployment. In particular the PR removes all references
to docker-compose actions in the pipeline. 