### PR TITLE
ci: checkout on the right reference in terraform format checker

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.ref }}
 
       - name: Check Format
         run: terraform fmt -check -recursive -diff


### PR DESCRIPTION
Fix the checkout to the branch in Terraform format check.
