### PR TITLE
ci: fix csharp patch name in code formatting workflow

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -53,7 +53,7 @@ jobs:
     - uses: actions/upload-artifact@v3
       if: ${{ failure() && steps.check-diff.conclusion == 'failure' }}
       with:
-        name: patch
+        name: patch-csharp
         path: ./patch-csharp.diff
 
   format-terraform:


### PR DESCRIPTION
Patch output name was not the same in pipeline and tools/applypatch.sh script. This is fixed now.
