### PR TITLE
fix:  issue with AWSSDK.SecurityToken

### DIFF
--- a/Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj
+++ b/Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="AWSSDK.S3" Version="3.7.101.46" />
+    <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.101.36" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Fix issue with missing package when SecurityToken is used on S3