### PR TITLE
refactor: update OpenTelemetry projects to their new version

### DIFF
--- a/Compute/PollingAgent/src/ArmoniK.Core.Compute.PollingAgent.csproj
+++ b/Compute/PollingAgent/src/ArmoniK.Core.Compute.PollingAgent.csproj
@@ -31,9 +31,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="1.0.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.6" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -118,13 +118,14 @@ public static class Program
                                            });
 
         builder.Services.AddSingleton(ActivitySource)
-               .AddOpenTelemetryTracing(b =>
-                                        {
-                                          b.AddSource(ActivitySource.Name);
-                                          b.AddAspNetCoreInstrumentation();
-                                          b.AddMongoDBInstrumentation();
-                                          b.AddZipkinExporter(options => options.Endpoint = new Uri(builder.Configuration["Zipkin:Uri"]));
-                                        });
+               .AddOpenTelemetry()
+               .WithTracing(b =>
+                            {
+                              b.AddSource(ActivitySource.Name);
+                              b.AddAspNetCoreInstrumentation();
+                              b.AddMongoDBInstrumentation();
+                              b.AddZipkinExporter(options => options.Endpoint = new Uri(builder.Configuration["Zipkin:Uri"]));
+                            });
       }
 
       builder.Services.AddHealthChecks();

--- a/Control/DependencyChecker/src/ArmoniK.Core.Control.DependencyChecker.csproj
+++ b/Control/DependencyChecker/src/ArmoniK.Core.Control.DependencyChecker.csproj
@@ -31,9 +31,9 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.50.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.6" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Control/DependencyChecker/src/Program.cs
+++ b/Control/DependencyChecker/src/Program.cs
@@ -95,12 +95,13 @@ public static class Program
                                            });
 
         builder.Services.AddSingleton(ActivitySource)
-               .AddOpenTelemetryTracing(b =>
-                                        {
-                                          b.AddSource(ActivitySource.Name);
-                                          b.AddAspNetCoreInstrumentation();
-                                          b.AddZipkinExporter(options => options.Endpoint = new Uri(builder.Configuration["Zipkin:Uri"]));
-                                        });
+               .AddOpenTelemetry()
+               .WithTracing(b =>
+                            {
+                              b.AddSource(ActivitySource.Name);
+                              b.AddAspNetCoreInstrumentation();
+                              b.AddZipkinExporter(options => options.Endpoint = new Uri(builder.Configuration["Zipkin:Uri"]));
+                            });
       }
 
       builder.WebHost.UseKestrel(options => options.ListenAnyIP(1081,

--- a/Control/Metrics/src/ArmoniK.Core.Control.Metrics.csproj
+++ b/Control/Metrics/src/ArmoniK.Core.Control.Metrics.csproj
@@ -30,8 +30,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Control/Metrics/src/Program.cs
+++ b/Control/Metrics/src/Program.cs
@@ -63,15 +63,17 @@ public static class Program
       builder.Services.AddLogging(logger.Configure)
              .AddMongoComponents(builder.Configuration,
                                  logger.GetLogger())
-             .AddOpenTelemetryMetrics(b =>
-                                      {
-                                        b.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 2000);
-                                        b.SetResourceBuilder(ResourceBuilder.CreateDefault()
-                                                                            .AddService("armonik-service"));
-                                        b.AddMeter(nameof(ArmoniKMeter));
-                                      })
              .AddHostedService<ArmoniKMeter>()
              .AddControllers();
+
+      builder.Services.AddOpenTelemetry()
+             .WithMetrics(b =>
+                          {
+                            b.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 2000);
+                            b.SetResourceBuilder(ResourceBuilder.CreateDefault()
+                                                                .AddService("armonik-service"));
+                            b.AddMeter(nameof(ArmoniKMeter));
+                          });
 
       var app = builder.Build();
 

--- a/Control/PartitionMetrics/src/ArmoniK.Core.Control.PartitionMetrics.csproj
+++ b/Control/PartitionMetrics/src/ArmoniK.Core.Control.PartitionMetrics.csproj
@@ -31,8 +31,8 @@
   <ItemGroup>
     <PackageReference Include="Fennel" Version="0.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus" Version="1.3.0-rc.2" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.4.0-rc.4" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
   </ItemGroup>
 
 

--- a/Control/PartitionMetrics/src/Program.cs
+++ b/Control/PartitionMetrics/src/Program.cs
@@ -65,18 +65,20 @@ public static class Program
       builder.Services.AddLogging(logger.Configure)
              .AddMongoComponents(builder.Configuration,
                                  logger.GetLogger())
-             .AddOpenTelemetryMetrics(b =>
-                                      {
-                                        b.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 2000);
-                                        b.SetResourceBuilder(ResourceBuilder.CreateDefault()
-                                                                            .AddService("armonik-service"));
-                                        b.AddMeter(nameof(ArmoniKMeter));
-                                      })
              .AddOption<MetricsExporter>(builder.Configuration,
                                          MetricsExporter.SettingSection)
              .AddHostedService<ArmoniKMeter>()
              .AddHttpClient()
              .AddControllers();
+
+      builder.Services.AddOpenTelemetry()
+             .WithMetrics(b =>
+                          {
+                            b.AddPrometheusExporter(options => options.ScrapeResponseCacheDurationMilliseconds = 2000);
+                            b.SetResourceBuilder(ResourceBuilder.CreateDefault()
+                                                                .AddService("armonik-service"));
+                            b.AddMeter(nameof(ArmoniKMeter));
+                          });
 
       var app = builder.Build();
 

--- a/Control/Submitter/src/ArmoniK.Core.Control.Submitter.csproj
+++ b/Control/Submitter/src/ArmoniK.Core.Control.Submitter.csproj
@@ -31,9 +31,9 @@
   <ItemGroup>
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.50.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.3.1" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.0.0-rc9.6" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.6" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.4.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.0.0-rc9.14" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -113,12 +113,13 @@ public static class Program
                                            });
 
         builder.Services.AddSingleton(ActivitySource)
-               .AddOpenTelemetryTracing(b =>
-                                        {
-                                          b.AddSource(ActivitySource.Name);
-                                          b.AddAspNetCoreInstrumentation();
-                                          b.AddZipkinExporter(options => options.Endpoint = new Uri(builder.Configuration["Zipkin:Uri"]));
-                                        });
+               .AddOpenTelemetry()
+               .WithTracing(b =>
+                            {
+                              b.AddSource(ActivitySource.Name);
+                              b.AddAspNetCoreInstrumentation();
+                              b.AddZipkinExporter(options => options.Endpoint = new Uri(builder.Configuration["Zipkin:Uri"]));
+                            });
       }
 
       builder.Services.AddClientSubmitterAuthenticationStorage(builder.Configuration,

--- a/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
+++ b/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
@@ -30,7 +30,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="6.0.2" />
     <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.3.1" />
+    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update OpenTelemetry nugets to their new version and use their new way to register OpenTelemetry functionnalities.
