### PR TITLE
perf: Optimized dependency resolution

### DIFF
--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -431,7 +431,7 @@ public class TaskTable : ITaskTable
                                    {
                                      var remainingDep = data.RemainingDataDependencies;
 
-                                     foreach (var dep in dependenciesToRemove)
+                                     foreach (var dep in dependenciesToRemove.Select(TaskData.EscapeKey))
                                      {
                                        remainingDep.Remove(dep);
                                      }

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -414,35 +414,6 @@ public class TaskTable : ITaskTable
                                             Output = taskOutput,
                                           };
                                  });
-    return Task.CompletedTask;
-  }
-
-  public Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
-                                                   CancellationToken                                                      cancellationToken = default)
-  {
-    using var _ = Logger.LogFunction();
-
-    foreach (var (taskId, dependenciesToRemove) in dependencies)
-    {
-      taskId2TaskData_.AddOrUpdate(taskId,
-                                   _ => throw new TaskNotFoundException("The task does not exist."),
-                                   (_,
-                                    data) =>
-                                   {
-                                     var remainingDep = data.RemainingDataDependencies;
-
-                                     foreach (var dep in dependenciesToRemove.Select(TaskData.EscapeKey))
-                                     {
-                                       remainingDep.Remove(dep);
-                                     }
-
-                                     return data with
-                                            {
-                                              RemainingDataDependencies = remainingDep,
-                                            };
-                                   });
-    }
-
     return Task.CompletedTask;
   }
 

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -429,7 +429,7 @@ public class TaskTable : ITaskTable
                                    (_,
                                     data) =>
                                    {
-                                     var remainingDep = data.RemainingDataDependencies.ToList();
+                                     var remainingDep = data.RemainingDataDependencies;
 
                                      foreach (var dep in dependenciesToRemove)
                                      {

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -423,6 +423,36 @@ public class TaskTable : ITaskTable
     using var _ = Logger.LogFunction();
 
     foreach (var (taskId, dependenciesToRemove) in dependencies)
+    {
+      taskId2TaskData_.AddOrUpdate(taskId,
+                                   _ => throw new TaskNotFoundException("The task does not exist."),
+                                   (_,
+                                    data) =>
+                                   {
+                                     var remainingDep = data.RemainingDataDependencies;
+
+                                     foreach (var dep in dependenciesToRemove.Select(TaskData.EscapeKey))
+                                     {
+                                       remainingDep.Remove(dep);
+                                     }
+
+                                     return data with
+                                            {
+                                              RemainingDataDependencies = remainingDep,
+                                            };
+                                   });
+    }
+
+    return Task.CompletedTask;
+  }
+
+  public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskIds,
+                                                   ICollection<string> dependenciesToRemove,
+                                                   CancellationToken   cancellationToken = default)
+  {
+    using var _ = Logger.LogFunction();
+
+    foreach (var taskId in taskIds)
     {
       taskId2TaskData_.AddOrUpdate(taskId,
                                    _ => throw new TaskNotFoundException("The task does not exist."),

--- a/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
+++ b/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
   </ItemGroup>
 

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -1,27 +1,29 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Adapters.MongoDB.Common;
 using ArmoniK.Core.Common.Storage;
 
 using MongoDB.Bson.Serialization;
+using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 
 namespace ArmoniK.Core.Adapters.MongoDB.Table.DataModel;
@@ -51,7 +53,7 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                                                   .SetDefaultValue(Array.Empty<string>());
                                                 cm.MapProperty(nameof(TaskData.RemainingDataDependencies))
                                                   .SetIgnoreIfDefault(true)
-                                                  .SetDefaultValue(Array.Empty<string>());
+                                                  .SetDefaultValue(new Dictionary<string, bool>());
                                                 cm.MapProperty(nameof(TaskData.ExpectedOutputIds))
                                                   .SetIsRequired(true);
                                                 cm.MapProperty(nameof(TaskData.InitialTaskId))

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -23,7 +23,6 @@ using ArmoniK.Core.Adapters.MongoDB.Common;
 using ArmoniK.Core.Common.Storage;
 
 using MongoDB.Bson.Serialization;
-using MongoDB.Bson.Serialization.Serializers;
 using MongoDB.Driver;
 
 namespace ArmoniK.Core.Adapters.MongoDB.Table.DataModel;

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -534,11 +534,15 @@ public class TaskTable : ITaskTable
     using var activity       = activitySource_.StartActivity($"{nameof(RemoveRemainingDataDependenciesAsync)}");
     var       taskCollection = taskCollectionProvider_.Get();
 
+    // MongoDB driver does not support to unset a list, so Unset should be called multiple times.
+    // However, Unset on an UpdateDefinitionBuilder returns an UpdateDefinition.
+    // We need to call Unset on the first element outside of the loop.
     using var deps = dependenciesToRemove.GetEnumerator();
     if (!deps.MoveNext())
     {
       return;
     }
+
 
     var key0   = TaskData.EscapeKey(deps.Current);
     var update = new UpdateDefinitionBuilder<TaskData>().Unset(data => data.RemainingDataDependencies[key0]);

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -537,11 +537,21 @@ public class TaskTable : ITaskTable
 
     await taskCollection.BulkWriteAsync(sessionHandle,
                                         dependencies.Select(tuple
-                                                              => new UpdateOneModel<TaskData>(new ExpressionFilterDefinition<TaskData>(data => data.TaskId == tuple
-                                                                                                                                                 .taskId),
-                                                                                              new UpdateDefinitionBuilder<TaskData>()
-                                                                                                .PullAll(data => data.RemainingDataDependencies,
-                                                                                                         tuple.dependenciesToRemove))),
+                                                              =>
+                                                            {
+                                                              using var                  deps   = tuple.dependenciesToRemove.GetEnumerator();
+                                                              deps.MoveNext();
+                                                              var key = deps.Current;
+                                                              var update = new UpdateDefinitionBuilder<TaskData>().Unset(data => data.RemainingDataDependencies[key]);
+                                                              while (deps.MoveNext())
+                                                              {
+                                                                key = deps.Current;
+                                                                update = update.Unset(data => data.RemainingDataDependencies[key]);
+                                                              }
+                                                              return new UpdateOneModel<TaskData>(new ExpressionFilterDefinition<TaskData>(data => data.TaskId == tuple
+                                                                                                                                                     .taskId),
+                                                                                                  update);
+                                                            }),
                                         cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
   }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/MongoDB/tests/BsonSerializerTest.cs
+++ b/Adaptors/MongoDB/tests/BsonSerializerTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -179,6 +179,7 @@ internal class BsonSerializerTest
     Assert.AreEqual(tdm.Options.Options["key2"],
                     deserialized.Options.Options["key2"]);
     Assert.IsTrue(tdm.DataDependencies.SequenceEqual(deserialized.DataDependencies));
+    Assert.IsTrue(tdm.RemainingDataDependencies.SequenceEqual(deserialized.RemainingDataDependencies));
     Assert.AreEqual(tdm.Options.MaxDuration,
                     deserialized.Options.MaxDuration);
     Assert.AreEqual(tdm.Options.MaxRetries,

--- a/Adaptors/MongoDB/tests/BsonSerializerTest.cs
+++ b/Adaptors/MongoDB/tests/BsonSerializerTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -287,6 +287,19 @@ public interface ITaskTable : IInitializable
                                             CancellationToken                                                      cancellationToken = default);
 
   /// <summary>
+  ///   Remove data dependencies from remaining data dependencies
+  /// </summary>
+  /// <param name="taskIds">Tasks</param>
+  /// <param name="dependenciesToRemove">Dependencies</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Task representing the asynchronous execution of the method
+  /// </returns>
+  Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskIds,
+                                            ICollection<string> dependenciesToRemove,
+                                            CancellationToken   cancellationToken = default);
+
+  /// <summary>
   ///   Change the status of the task to canceled
   /// </summary>
   /// <param name="taskId">Id of the task to tag as canceled</param>

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -274,17 +274,6 @@ public interface ITaskTable : IInitializable
   /// </returns>
   Task SetTaskSuccessAsync(string            taskId,
                            CancellationToken cancellationToken = default);
-
-  /// <summary>
-  ///   Remove data dependencies from remaining data dependencies
-  /// </summary>
-  /// <param name="dependencies">Tuples representing the dependencies to remove from each tasks</param>
-  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
-  /// <returns>
-  ///   Task representing the asynchronous execution of the method
-  /// </returns>
-  Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
-                                            CancellationToken                                                      cancellationToken = default);
 
   /// <summary>
   ///   Remove data dependencies from remaining data dependencies

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -39,7 +39,7 @@ namespace ArmoniK.Core.Common.Storage;
 ///   represents a submission from the client
 /// </param>
 /// <param name="DataDependencies">Unique identifiers of the results the task depends on</param>
-/// <param name="RemainingDataDependencies">Copy of data dependencies used for dependency resolution</param>
+/// <param name="RemainingDataDependencies">List of dependencies that are not yet satisfied</param>
 /// <param name="ExpectedOutputIds">
 ///   Identifiers of the outputs the task should produce or should transmit the
 ///   responsibility to produce
@@ -57,13 +57,17 @@ namespace ArmoniK.Core.Common.Storage;
 /// <param name="AcquisitionDate">Date when the task is acquired by the pollster</param>
 /// <param name="PodTtl">Task Time To Live on the current pod</param>
 /// <param name="Output">Output of the task after its successful completion</param>
-public record TaskData(string                    SessionId,
-                       string                    TaskId,
-                       string                    OwnerPodId,
-                       string                    OwnerPodName,
-                       string                    PayloadId,
-                       IList<string>             ParentTaskIds,
-                       IList<string>             DataDependencies,
+public record TaskData(string        SessionId,
+                       string        TaskId,
+                       string        OwnerPodId,
+                       string        OwnerPodName,
+                       string        PayloadId,
+                       IList<string> ParentTaskIds,
+                       IList<string> DataDependencies,
+                       // FIXME: RemainingDataDependencies should be a HashSet, but there is no HashSet in MongoDB.
+                       // List would also work but would make dependency management *much* slower when there is many dependencies on a single task.
+                       // (Removing elements from a list is linear time, but removing from an object in constant time)
+                       // Ideal solution would most likely be to put HashSet here, and have a custom Serializer/Deserializer in MongoDB "schema".
                        IDictionary<string, bool> RemainingDataDependencies,
                        IList<string>             ExpectedOutputIds,
                        string                    InitialTaskId,
@@ -139,6 +143,14 @@ public record TaskData(string                    SessionId,
   {
   }
 
+  /// <summary>
+  ///   ResultIds could contain dots (eg: it is the case in htcmock),
+  ///   but MongoDB does not support well dots in keys.
+  ///   This escapes the key to replace dots with something else.
+  ///   Escaped keys are guaranteed to have neither dots nor dollars
+  /// </summary>
+  /// <param name="key">Key string</param>
+  /// <returns>Escaped key</returns>
   public static string EscapeKey(string key)
     => new StringBuilder(key).Replace("@",
                                       "@at@")

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -1,22 +1,23 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Tasks;
@@ -55,28 +56,28 @@ namespace ArmoniK.Core.Common.Storage;
 /// <param name="AcquisitionDate">Date when the task is acquired by the pollster</param>
 /// <param name="PodTtl">Task Time To Live on the current pod</param>
 /// <param name="Output">Output of the task after its successful completion</param>
-public record TaskData(string        SessionId,
-                       string        TaskId,
-                       string        OwnerPodId,
-                       string        OwnerPodName,
-                       string        PayloadId,
-                       IList<string> ParentTaskIds,
-                       IList<string> DataDependencies,
-                       IList<string> RemainingDataDependencies,
-                       IList<string> ExpectedOutputIds,
-                       string        InitialTaskId,
-                       IList<string> RetryOfIds,
-                       TaskStatus    Status,
-                       string        StatusMessage,
-                       TaskOptions   Options,
-                       DateTime      CreationDate,
-                       DateTime?     SubmittedDate,
-                       DateTime?     StartDate,
-                       DateTime?     EndDate,
-                       DateTime?     ReceptionDate,
-                       DateTime?     AcquisitionDate,
-                       DateTime?     PodTtl,
-                       Output        Output)
+public record TaskData(string         SessionId,
+                       string         TaskId,
+                       string         OwnerPodId,
+                       string         OwnerPodName,
+                       string         PayloadId,
+                       IList<string>  ParentTaskIds,
+                       IList<string>  DataDependencies,
+                       IDictionary<string, bool> RemainingDataDependencies,
+                       IList<string>  ExpectedOutputIds,
+                       string         InitialTaskId,
+                       IList<string>  RetryOfIds,
+                       TaskStatus     Status,
+                       string         StatusMessage,
+                       TaskOptions    Options,
+                       DateTime       CreationDate,
+                       DateTime?      SubmittedDate,
+                       DateTime?      StartDate,
+                       DateTime?      EndDate,
+                       DateTime?      ReceptionDate,
+                       DateTime?      AcquisitionDate,
+                       DateTime?      PodTtl,
+                       Output         Output)
 {
   /// <summary>
   ///   Initializes task metadata with specified fields
@@ -118,7 +119,7 @@ public record TaskData(string        SessionId,
            payloadId,
            parentTaskIds,
            dataDependencies,
-           dataDependencies,
+           dataDependencies.ToDictionary(key => key, _ => true),
            expectedOutputIds,
            taskId,
            retryOfIds,

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Tasks;
@@ -56,28 +57,28 @@ namespace ArmoniK.Core.Common.Storage;
 /// <param name="AcquisitionDate">Date when the task is acquired by the pollster</param>
 /// <param name="PodTtl">Task Time To Live on the current pod</param>
 /// <param name="Output">Output of the task after its successful completion</param>
-public record TaskData(string         SessionId,
-                       string         TaskId,
-                       string         OwnerPodId,
-                       string         OwnerPodName,
-                       string         PayloadId,
-                       IList<string>  ParentTaskIds,
-                       IList<string>  DataDependencies,
+public record TaskData(string                    SessionId,
+                       string                    TaskId,
+                       string                    OwnerPodId,
+                       string                    OwnerPodName,
+                       string                    PayloadId,
+                       IList<string>             ParentTaskIds,
+                       IList<string>             DataDependencies,
                        IDictionary<string, bool> RemainingDataDependencies,
-                       IList<string>  ExpectedOutputIds,
-                       string         InitialTaskId,
-                       IList<string>  RetryOfIds,
-                       TaskStatus     Status,
-                       string         StatusMessage,
-                       TaskOptions    Options,
-                       DateTime       CreationDate,
-                       DateTime?      SubmittedDate,
-                       DateTime?      StartDate,
-                       DateTime?      EndDate,
-                       DateTime?      ReceptionDate,
-                       DateTime?      AcquisitionDate,
-                       DateTime?      PodTtl,
-                       Output         Output)
+                       IList<string>             ExpectedOutputIds,
+                       string                    InitialTaskId,
+                       IList<string>             RetryOfIds,
+                       TaskStatus                Status,
+                       string                    StatusMessage,
+                       TaskOptions               Options,
+                       DateTime                  CreationDate,
+                       DateTime?                 SubmittedDate,
+                       DateTime?                 StartDate,
+                       DateTime?                 EndDate,
+                       DateTime?                 ReceptionDate,
+                       DateTime?                 AcquisitionDate,
+                       DateTime?                 PodTtl,
+                       Output                    Output)
 {
   /// <summary>
   ///   Initializes task metadata with specified fields
@@ -119,7 +120,8 @@ public record TaskData(string         SessionId,
            payloadId,
            parentTaskIds,
            dataDependencies,
-           dataDependencies.ToDictionary(key => key, _ => true),
+           dataDependencies.ToDictionary(EscapeKey,
+                                         _ => true),
            expectedOutputIds,
            taskId,
            retryOfIds,
@@ -136,6 +138,15 @@ public record TaskData(string         SessionId,
            output)
   {
   }
+
+  public static string EscapeKey(string key)
+    => new StringBuilder(key).Replace("@",
+                                      "@at@")
+                             .Replace(".",
+                                      "@dot@")
+                             .Replace("$",
+                                      "@dollar@")
+                             .ToString();
 
 
   /// <summary>

--- a/Common/src/gRPC/Services/Agent.cs
+++ b/Common/src/gRPC/Services/Agent.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -139,10 +139,16 @@ public class Agent : IAgent
                                                           cancellationToken)
                     .ConfigureAwait(false);
 
-    var groups = (await taskTable_.FindTasksAsync(data => dependentTasks.Contains(data.TaskId),
-                                                  _ => _,
-                                                  cancellationToken)).Where(data => data.Status == TaskStatus.Creating && !data.RemainingDataDependencies.Any())
-                                                                     .GroupBy(data => (data.Options.PartitionId, data.Options.Priority));
+    var groups = (await taskTable_.FindTasksAsync(data => dependentTasks.Contains(data.TaskId) && data.Status == TaskStatus.Creating &&
+                                                          data.RemainingDataDependencies                      == new Dictionary<string, bool>(),
+                                                  data => new
+                                                          {
+                                                            data.TaskId,
+                                                            data.Options.PartitionId,
+                                                            data.Options.Priority,
+                                                          },
+                                                  cancellationToken)
+                                  .ConfigureAwait(false)).GroupBy(data => (data.PartitionId, data.Priority));
 
     foreach (var group in groups)
     {

--- a/Common/src/gRPC/Services/Agent.cs
+++ b/Common/src/gRPC/Services/Agent.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -158,10 +158,11 @@ public class Submitter : ISubmitter
                                                       .ToListAsync(cancellationToken)
                                                       .ConfigureAwait(false);
 
-        await taskTable_.RemoveRemainingDataDependenciesAsync(new List<(string taskId, IEnumerable<string> dependenciesToRemove)>
+        await taskTable_.RemoveRemainingDataDependenciesAsync(new[]
                                                               {
-                                                                (request.Id, completedDependencies),
+                                                                request.Id,
                                                               },
+                                                              completedDependencies,
                                                               cancellationToken)
                         .ConfigureAwait(false);
 

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -135,6 +135,11 @@ public class Submitter : ISubmitter
 
       if (dependencies.Any())
       {
+        // If there is dependencies, we need to register the current task as a dependant of its dependencies.
+        // This should be done *before* verifying if the dependencies are satisfied in order to avoid missing
+        // any result completion.
+        // If a result is completed at the same time, either the submitter will see the result has been completed,
+        // Or the Agent will remove the result from the remaining dependencies of the task.
         await resultTable_.AddTaskDependency(sessionId,
                                              dependencies,
                                              new List<string>
@@ -144,12 +149,7 @@ public class Submitter : ISubmitter
                                              cancellationToken)
                           .ConfigureAwait(false);
 
-        // This Get is required to avoid race-condition with the dependency resolution.
-        // A result can be marked Completed after the submitter has checked the result status,
-        // but before the task has been added to the dependency list.
-        // This is a typical case of TOCTOU issues (Time Of Check, Time Of Use).
-        // The second check ensures that the result completion will be visible,
-        // even if it happens in parallel to the task submission.
+        // Get the dependencies that are already completed in order to remove them from the remaining dependencies.
         var completedDependencies = await resultTable_.GetResults(sessionId,
                                                                   dependencies,
                                                                   cancellationToken)
@@ -158,6 +158,13 @@ public class Submitter : ISubmitter
                                                       .ToListAsync(cancellationToken)
                                                       .ConfigureAwait(false);
 
+        // Remove all the dependencies that are already completed from the task.
+        // If an Agent has completed one of the dependencies between the GetResults and this remove,
+        // One will succeed removing the dependency, the other will silently fail.
+        // In either case, the task will be submitted without error by the Agent.
+        // If the agent completes the dependencies _before_ the GetResults, both will try to remove it,
+        // and both will queue the task.
+        // This is benign as it will be handled during dequeue with message deduplication.
         await taskTable_.RemoveRemainingDataDependenciesAsync(new[]
                                                               {
                                                                 request.Id,
@@ -166,6 +173,7 @@ public class Submitter : ISubmitter
                                                               cancellationToken)
                         .ConfigureAwait(false);
 
+        // If all dependencies were already completed, the task is ready to be started.
         if (dependencies.Count == completedDependencies.Count)
         {
           readyTasks.Add(request.Id);

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -238,6 +238,11 @@ public class SimpleTaskTable : ITaskTable
 
   public Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
                                                    CancellationToken                                                      cancellationToken = default)
+    => Task.CompletedTask;
+
+  public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
+                                                   ICollection<string> dependenciesToRemove,
+                                                   CancellationToken   cancellationToken = default)
     => Task.CompletedTask;
 
   public Task SetTaskCanceledAsync(string            taskId,

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -236,10 +236,6 @@ public class SimpleTaskTable : ITaskTable
                                   CancellationToken cancellationToken = default)
     => Task.CompletedTask;
 
-  public Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
-                                                   CancellationToken                                                      cancellationToken = default)
-    => Task.CompletedTask;
-
   public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
                                                    ICollection<string> dependenciesToRemove,
                                                    CancellationToken   cancellationToken = default)

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -365,7 +365,7 @@ public class TaskHandlerTest
                                 "payload",
                                 new List<string>(),
                                 new List<string>(),
-                                new List<string>(),
+                                new Dictionary<string, bool>(),
                                 new List<string>(),
                                 "init",
                                 new List<string>(),
@@ -457,7 +457,7 @@ public class TaskHandlerTest
                           "payload",
                           new List<string>(),
                           new List<string>(),
-                          new List<string>(),
+                          new Dictionary<string, bool>(),
                           new List<string>(),
                           "taskId",
                           new List<string>(),
@@ -594,7 +594,7 @@ public class TaskHandlerTest
                           "payload",
                           new List<string>(),
                           new List<string>(),
-                          new List<string>(),
+                          new Dictionary<string, bool>(),
                           new List<string>(),
                           "taskId",
                           new List<string>(),
@@ -631,7 +631,7 @@ public class TaskHandlerTest
                                       "payload",
                                       new List<string>(),
                                       new List<string>(),
-                                      new List<string>(),
+                                      new Dictionary<string, bool>(),
                                       new List<string>(),
                                       "taskId",
                                       new List<string>(),

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -562,6 +562,11 @@ public class TaskHandlerTest
                                                      CancellationToken                                                      cancellationToken = default)
       => Task.CompletedTask;
 
+    public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
+                                                     ICollection<string> dependenciesToRemove,
+                                                     CancellationToken   cancellationToken = default)
+      => Task.CompletedTask;
+
     public Task SetTaskCanceledAsync(string            taskId,
                                      CancellationToken cancellationToken)
       => throw new NotImplementedException();

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -558,10 +558,6 @@ public class TaskHandlerTest
                                     CancellationToken cancellationToken)
       => throw new NotImplementedException();
 
-    public Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
-                                                     CancellationToken                                                      cancellationToken = default)
-      => Task.CompletedTask;
-
     public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
                                                      ICollection<string> dependenciesToRemove,
                                                      CancellationToken   cancellationToken = default)

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -926,10 +926,6 @@ internal class IntegrationGrpcSubmitterServiceTest
                                     CancellationToken cancellationToken = default)
       => throw new T();
 
-    public Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
-                                                     CancellationToken                                                      cancellationToken = default)
-      => throw new T();
-
     public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
                                                      ICollection<string> dependenciesToRemove,
                                                      CancellationToken   cancellationToken = default)

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -928,6 +928,11 @@ internal class IntegrationGrpcSubmitterServiceTest
 
     public Task RemoveRemainingDataDependenciesAsync(IEnumerable<(string taskId, IEnumerable<string> dependenciesToRemove)> dependencies,
                                                      CancellationToken                                                      cancellationToken = default)
+      => throw new T();
+
+    public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
+                                                     ICollection<string> dependenciesToRemove,
+                                                     CancellationToken   cancellationToken = default)
       => throw new T();
 
     public Task SetTaskCanceledAsync(string            taskId,

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -1590,8 +1590,8 @@ public class TaskTableTestBase
     {
       var taskId = Guid.NewGuid()
                        .ToString();
-      var dd1 = "dependency1";
-      var dd2 = "dependency2";
+      var dd1 = "dependency.1";
+      var dd2 = "dependency.2";
 
       await TaskTable!.CreateTasks(new[]
                                    {

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -1622,13 +1622,14 @@ public class TaskTableTestBase
                                    })
                       .ConfigureAwait(false);
 
-      await TaskTable.RemoveRemainingDataDependenciesAsync(new List<(string taskId, IEnumerable<string> dependenciesToRemove)>
+      await TaskTable.RemoveRemainingDataDependenciesAsync(new[]
                                                            {
-                                                             (taskId, new List<string>
-                                                                      {
-                                                                        dd1,
-                                                                        dd2,
-                                                                      }),
+                                                             taskId,
+                                                           },
+                                                           new[]
+                                                           {
+                                                             dd1,
+                                                             dd2,
                                                            },
                                                            CancellationToken.None)
                      .ConfigureAwait(false);
@@ -1675,12 +1676,13 @@ public class TaskTableTestBase
                                    })
                       .ConfigureAwait(false);
 
-      await TaskTable.RemoveRemainingDataDependenciesAsync(new List<(string taskId, IEnumerable<string> dependenciesToRemove)>
+      await TaskTable.RemoveRemainingDataDependenciesAsync(new[]
                                                            {
-                                                             (taskId, new List<string>
-                                                                      {
-                                                                        dd1,
-                                                                      }),
+                                                             taskId,
+                                                           },
+                                                           new[]
+                                                           {
+                                                             dd1,
                                                            },
                                                            CancellationToken.None)
                      .ConfigureAwait(false);

--- a/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
+++ b/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
@@ -28,7 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="6.0.2" />
-    <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.19.1" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.3.0" />
     <PackageReference Include="OpenTelemetry" Version="1.4.0" />
   </ItemGroup>


### PR DESCRIPTION
Previous PR was slowing down dependency resolution in case some tasks had *many* dependencies. This PR solves it by replacing the list of dependencies by an object in MongoDB to avoid linear time to remove elements from the dependencies of a task.
This also solves an increase in memory consumption of the agents.

fix https://github.com/aneoconsulting/ArmoniK/issues/1017