### PR TITLE
ci: increase timeout for stream tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -359,7 +359,7 @@ jobs:
           sleep 10
 
       - name: Run Stream Test
-        timeout-minutes: 3
+        timeout-minutes: 4
         run: |
           cd ./Tests/Stream/Client/
           export GrpcClient__Endpoint=http://localhost:5001


### PR DESCRIPTION
Increases timeout from 3 to 4 for stream tests because tests are successfull but action still times out. Compilation takes 30s and tests around 2m30s so it is really close.
