### PR TITLE
feat: implement rpc methods to create tasks and results independently

### DIFF
--- a/Adaptors/Memory/src/ResultTable.cs
+++ b/Adaptors/Memory/src/ResultTable.cs
@@ -254,6 +254,32 @@ public class ResultTable : IResultTable
     return Task.CompletedTask;
   }
 
+  public Task<Result> CompleteResult(string            sessionId,
+                                     string            resultId,
+                                     CancellationToken cancellationToken = default)
+  {
+    try
+    {
+      var result = results_[sessionId][resultId];
+      var newResult = result with
+                      {
+                        Status = ResultStatus.Completed,
+                      };
+
+      results_[result.SessionId]
+        .TryUpdate(result.ResultId,
+                   newResult,
+                   result);
+
+      return Task.FromResult(newResult);
+    }
+    catch (KeyNotFoundException e)
+    {
+      throw new ResultNotFoundException($"Result {resultId} not found",
+                                        e);
+    }
+  }
+
   /// <inheritdoc />
   public Task<IEnumerable<GetResultStatusReply.Types.IdStatus>> GetResultStatus(IEnumerable<string> ids,
                                                                                 string              sessionId,

--- a/Adaptors/MongoDB/tests/BsonSerializerTest.cs
+++ b/Adaptors/MongoDB/tests/BsonSerializerTest.cs
@@ -25,15 +25,13 @@ using ArmoniK.Core.Adapters.MongoDB.Table.DataModel.Auth;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Storage;
 
-using Google.Protobuf.WellKnownTypes;
-
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 
 using NUnit.Framework;
 
 using Output = ArmoniK.Core.Common.Storage.Output;
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
 
 namespace ArmoniK.Core.Adapters.MongoDB.Tests;
 
@@ -50,12 +48,16 @@ internal class BsonSerializerTest
                                 "part1",
                                 "part2",
                               },
-                              new TaskOptions
-                              {
-                                MaxDuration = Duration.FromTimeSpan(TimeSpan.FromHours(1)),
-                                MaxRetries  = 2,
-                                Priority    = 1,
-                              });
+                              new TaskOptions(new Dictionary<string, string>(),
+                                              TimeSpan.FromHours(1),
+                                              2,
+                                              1,
+                                              "part1",
+                                              "ApplicationName2",
+                                              "ApplicationVersion2",
+                                              "",
+                                              "",
+                                              ""));
 
     var serialized = rdm.ToBson();
 
@@ -143,24 +145,24 @@ internal class BsonSerializerTest
                            },
                            Array.Empty<string>(),
                            TaskStatus.Completed,
-                           new Core.Common.Storage.TaskOptions(new Dictionary<string, string>
-                                                               {
-                                                                 {
-                                                                   "key1", "data1"
-                                                                 },
-                                                                 {
-                                                                   "key2", "data2"
-                                                                 },
-                                                               },
-                                                               TimeSpan.FromSeconds(200),
-                                                               5,
-                                                               1,
-                                                               "part1",
-                                                               "applicationName",
-                                                               "applicationVersion",
-                                                               "applicationNamespace",
-                                                               "applicationService",
-                                                               "engineType"),
+                           new TaskOptions(new Dictionary<string, string>
+                                           {
+                                             {
+                                               "key1", "data1"
+                                             },
+                                             {
+                                               "key2", "data2"
+                                             },
+                                           },
+                                           TimeSpan.FromSeconds(200),
+                                           5,
+                                           1,
+                                           "part1",
+                                           "applicationName",
+                                           "applicationVersion",
+                                           "applicationNamespace",
+                                           "applicationService",
+                                           "engineType"),
                            new Output(true,
                                       ""));
 

--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -26,7 +26,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Core" Version="3.9.0-3814g80ad90e.4.80ad90e" />
+    <PackageReference Include="ArmoniK.Api.Core" Version="3.9.0-SNAPSHOT.14.74bbbc4" />
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.2.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.50.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />

--- a/Common/src/Pollster/DataPrefetcher.cs
+++ b/Common/src/Pollster/DataPrefetcher.cs
@@ -105,7 +105,7 @@ public class DataPrefetcher : IInitializable
     computeRequests.Init(PayloadConfiguration.MaxChunkSize,
                          taskData.SessionId,
                          taskData.TaskId,
-                         taskData.Options,
+                         taskData.Options.ToGrpcTaskOptions(),
                          payloadChunks.FirstOrDefault(),
                          taskData.ExpectedOutputIds);
 

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -207,6 +207,19 @@ public interface IResultTable : IInitializable
                  CancellationToken cancellationToken = default);
 
   /// <summary>
+  ///   Complete result
+  /// </summary>
+  /// <param name="sessionId">id of the session containing the results</param>
+  /// <param name="resultId">Id of the result to complete</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   The new version of the result metadata
+  /// </returns>
+  Task<Result> CompleteResult(string            sessionId,
+                              string            resultId,
+                              CancellationToken cancellationToken = default);
+
+  /// <summary>
   ///   Get the status of the given results
   /// </summary>
   /// <param name="ids">ids of the results</param>

--- a/Common/src/Storage/SessionData.cs
+++ b/Common/src/Storage/SessionData.cs
@@ -52,7 +52,7 @@ public record SessionData(string        SessionId,
                          ? FromDateTime(sessionData.CancellationDate.Value)
                          : null,
          CreatedAt = FromDateTime(sessionData.CreationDate),
-         Options   = sessionData.Options,
+         Options   = sessionData.Options.ToGrpcTaskOptions(),
          PartitionIds =
          {
            sessionData.PartitionIds,

--- a/Common/src/Storage/TaskCreationRequest.cs
+++ b/Common/src/Storage/TaskCreationRequest.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
 // 
@@ -19,6 +19,8 @@ using System.Collections.Generic;
 
 namespace ArmoniK.Core.Common.Storage;
 
-public record TaskRequest(string              Id,
-                          IEnumerable<string> ExpectedOutputKeys,
-                          IEnumerable<string> DataDependencies);
+public record TaskCreationRequest(string              TaskId,
+                                  string              PayloadId,
+                                  TaskOptions         Options,
+                                  ICollection<string> ExpectedOutputKeys,
+                                  ICollection<string> DataDependencies);

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -175,7 +175,7 @@ public record TaskData(string        SessionId,
          Status     = taskData.Status,
          Output     = taskData.Output,
          OwnerPodId = taskData.OwnerPodId,
-         Options    = taskData.Options,
+         Options    = taskData.Options.ToGrpcTaskOptions(),
          DataDependencies =
          {
            taskData.DataDependencies,
@@ -228,7 +228,7 @@ public record TaskData(string        SessionId,
        {
          SessionId = taskData.SessionId,
          Status    = taskData.Status,
-         Options   = taskData.Options,
+         Options   = taskData.Options.ToGrpcTaskOptions(),
          CreatedAt = FromDateTime(taskData.CreationDate),
          EndedAt = taskData.EndDate is not null
                      ? FromDateTime(taskData.EndDate.Value)

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -1,0 +1,237 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.Common.Utils;
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Common.Exceptions;
+using ArmoniK.Utils;
+
+using Grpc.Core;
+
+using Microsoft.Extensions.Logging;
+
+using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
+
+namespace ArmoniK.Core.Common.Storage;
+
+public static class TaskLifeCycleHelper
+{
+  public static TaskOptions ValidateSession(SessionData       sessionData,
+                                            TaskOptions?      submissionOptions,
+                                            string            parentTaskId,
+                                            int               maxPriority,
+                                            ILogger           logger,
+                                            CancellationToken cancellationToken)
+  {
+    var localOptions = submissionOptions != null
+                         ? TaskOptions.Merge(submissionOptions,
+                                             sessionData.Options)
+                         : sessionData.Options;
+
+    using var logFunction = logger.LogFunction(parentTaskId);
+    using var sessionScope = logger.BeginPropertyScope(("Session", sessionData.SessionId),
+                                                       ("TaskId", parentTaskId),
+                                                       ("PartitionId", localOptions.PartitionId));
+
+    if (logger.IsEnabled(LogLevel.Trace))
+    {
+      cancellationToken.Register(() => logger.LogTrace("CancellationToken from ServerCallContext has been triggered"));
+    }
+
+    var availablePartitionIds = sessionData.PartitionIds ?? Array.Empty<string>();
+    if (!availablePartitionIds.Contains(localOptions.PartitionId))
+    {
+      throw new InvalidOperationException($"The session {sessionData.SessionId} is assigned to the partitions " +
+                                          $"[{string.Join(", ", availablePartitionIds)}], but TaskRequest is assigned to partition {localOptions.PartitionId}");
+    }
+
+    if (localOptions.Priority >= maxPriority)
+    {
+      var exception = new RpcException(new Status(StatusCode.InvalidArgument,
+                                                  $"Max priority is {maxPriority}"));
+      logger.LogError(exception,
+                      "Invalid Argument");
+      throw exception;
+    }
+
+    return localOptions;
+  }
+
+  public static async Task CreateTasks(ITaskTable                       taskTable,
+                                       IResultTable                     resultTable,
+                                       string                           sessionId,
+                                       string                           parentTaskId,
+                                       ICollection<TaskCreationRequest> taskCreationRequests,
+                                       ILogger                          logger,
+                                       CancellationToken                cancellationToken)
+  {
+    var parentTaskIds = new List<string>();
+
+    if (!parentTaskId.Equals(sessionId))
+    {
+      var res = await taskTable.GetParentTaskIds(parentTaskId,
+                                                 cancellationToken)
+                               .ConfigureAwait(false);
+      parentTaskIds.AddRange(res);
+    }
+
+    parentTaskIds.Add(parentTaskId);
+
+    await taskTable.CreateTasks(taskCreationRequests.Select(request => new TaskData(sessionId,
+                                                                                    request.TaskId,
+                                                                                    "",
+                                                                                    "",
+                                                                                    request.PayloadId,
+                                                                                    parentTaskIds,
+                                                                                    request.DataDependencies.ToList(),
+                                                                                    request.ExpectedOutputKeys.ToList(),
+                                                                                    Array.Empty<string>(),
+                                                                                    TaskStatus.Creating,
+                                                                                    request.Options ??
+                                                                                    throw new ArmoniKException("Task Options should not be null here"),
+                                                                                    new Output(false,
+                                                                                               ""))),
+                                cancellationToken)
+                   .ConfigureAwait(false);
+
+    await resultTable.SetTaskOwnership(sessionId,
+                                       taskCreationRequests.SelectMany(r => r.ExpectedOutputKeys.Select(key => (key, r.TaskId)))
+                                                           .AsICollection(),
+                                       cancellationToken)
+                     .ConfigureAwait(false);
+  }
+
+  public static async Task FinalizeTaskCreation(ITaskTable                       taskTable,
+                                                IResultTable                     resultTable,
+                                                IPushQueueStorage                pushQueueStorage,
+                                                ICollection<TaskCreationRequest> taskRequests,
+                                                string                           sessionId,
+                                                string                           parentTaskId,
+                                                ILogger                          logger,
+                                                CancellationToken                cancellationToken)
+  {
+    if (!taskRequests.Any())
+    {
+      return;
+    }
+
+    var parentExpectedOutputKeys = new List<string>();
+
+    if (!parentTaskId.Equals(sessionId))
+    {
+      parentExpectedOutputKeys.AddRange(await taskTable.GetTaskExpectedOutputKeys(parentTaskId,
+                                                                                  cancellationToken)
+                                                       .ConfigureAwait(false));
+    }
+
+    var taskDataModels = taskRequests.Select(request => new IResultTable.ChangeResultOwnershipRequest(parentExpectedOutputKeys.Intersect(request.ExpectedOutputKeys),
+                                                                                                      request.TaskId));
+    await resultTable.ChangeResultOwnership(sessionId,
+                                            parentTaskId,
+                                            taskDataModels,
+                                            cancellationToken)
+                     .ConfigureAwait(false);
+
+    var readyTasks = new List<(string taskId, int priority, string partitionId)>();
+
+    foreach (var request in taskRequests)
+    {
+      var dependencies = request.DataDependencies.ToList();
+
+      logger.LogDebug("Process task request {request}",
+                      request);
+
+      if (dependencies.Any())
+      {
+        // If there is dependencies, we need to register the current task as a dependent of its dependencies.
+        // This should be done *before* verifying if the dependencies are satisfied in order to avoid missing
+        // any result completion.
+        // If a result is completed at the same time, either the submitter will see the result has been completed,
+        // Or the Agent will remove the result from the remaining dependencies of the task.
+        await resultTable.AddTaskDependency(sessionId,
+                                            dependencies,
+                                            new List<string>
+                                            {
+                                              request.TaskId,
+                                            },
+                                            cancellationToken)
+                         .ConfigureAwait(false);
+
+        // Get the dependencies that are already completed in order to remove them from the remaining dependencies.
+        var completedDependencies = await resultTable.GetResults(sessionId,
+                                                                 dependencies,
+                                                                 cancellationToken)
+                                                     .Where(result => result.Status == ResultStatus.Completed)
+                                                     .Select(result => result.ResultId)
+                                                     .ToListAsync(cancellationToken)
+                                                     .ConfigureAwait(false);
+
+        // Remove all the dependencies that are already completed from the task.
+        // If an Agent has completed one of the dependencies between the GetResults and this remove,
+        // One will succeed removing the dependency, the other will silently fail.
+        // In either case, the task will be submitted without error by the Agent.
+        // If the agent completes the dependencies _before_ the GetResults, both will try to remove it,
+        // and both will queue the task.
+        // This is benign as it will be handled during dequeue with message deduplication.
+        await taskTable.RemoveRemainingDataDependenciesAsync(new[]
+                                                             {
+                                                               request.TaskId,
+                                                             },
+                                                             completedDependencies,
+                                                             cancellationToken)
+                       .ConfigureAwait(false);
+
+        // If all dependencies were already completed, the task is ready to be started.
+        if (dependencies.Count == completedDependencies.Count)
+        {
+          readyTasks.Add((request.TaskId, request.Options.Priority, request.Options.PartitionId));
+        }
+      }
+      else
+      {
+        readyTasks.Add((request.TaskId, request.Options.Priority, request.Options.PartitionId));
+      }
+    }
+
+    if (readyTasks.Any())
+    {
+      var groups = readyTasks.GroupBy(tuple => (tuple.partitionId, tuple.priority));
+
+      foreach (var group in groups)
+      {
+        var ids = group.Select(tuple => tuple.taskId)
+                       .ToList();
+
+        await pushQueueStorage.PushMessagesAsync(ids,
+                                                 group.Key.partitionId,
+                                                 group.Key.priority,
+                                                 cancellationToken)
+                              .ConfigureAwait(false);
+        await taskTable.FinalizeTaskCreation(ids,
+                                             cancellationToken)
+                       .ConfigureAwait(false);
+      }
+    }
+  }
+}

--- a/Common/src/Storage/TaskOptions.cs
+++ b/Common/src/Storage/TaskOptions.cs
@@ -33,39 +33,14 @@ public record TaskOptions(IDictionary<string, string> Options,
                           string                      ApplicationService,
                           string                      EngineType)
 {
-  public static implicit operator Api.gRPC.V1.TaskOptions(TaskOptions taskOption)
-    => new()
-       {
-         MaxDuration = Duration.FromTimeSpan(taskOption.MaxDuration),
-         MaxRetries  = taskOption.MaxRetries,
-         Priority    = taskOption.Priority,
-         PartitionId = taskOption.PartitionId,
-         Options =
-         {
-           taskOption.Options,
-         },
-         ApplicationName      = taskOption.ApplicationName,
-         ApplicationVersion   = taskOption.ApplicationVersion,
-         ApplicationNamespace = taskOption.ApplicationNamespace,
-         ApplicationService   = taskOption.ApplicationService,
-         EngineType           = taskOption.EngineType,
-       };
-
-  public static implicit operator TaskOptions(Api.gRPC.V1.TaskOptions taskOption)
-    => new(taskOption.Options,
-           taskOption.MaxDuration.ToTimeSpan(),
-           taskOption.MaxRetries,
-           taskOption.Priority,
-           taskOption.PartitionId,
-           taskOption.ApplicationName,
-           taskOption.ApplicationVersion,
-           taskOption.ApplicationNamespace,
-           taskOption.ApplicationService,
-           taskOption.EngineType);
-
-  public static TaskOptions Merge(TaskOptions taskOption,
-                                  TaskOptions defaultOption)
+  public static TaskOptions Merge(TaskOptions? taskOption,
+                                  TaskOptions  defaultOption)
   {
+    if (taskOption is null)
+    {
+      return defaultOption;
+    }
+
     var options = new Dictionary<string, string>(defaultOption.Options);
     foreach (var option in taskOption.Options)
     {
@@ -99,4 +74,43 @@ public record TaskOptions(IDictionary<string, string> Options,
                              ? taskOption.EngineType
                              : defaultOption.EngineType);
   }
+}
+
+public static class GrpcTaskOptionsExt
+{
+  public static TaskOptions ToTaskOptions(this Api.gRPC.V1.TaskOptions taskOption)
+    => new(taskOption.Options,
+           taskOption.MaxDuration.ToTimeSpan(),
+           taskOption.MaxRetries,
+           taskOption.Priority,
+           taskOption.PartitionId,
+           taskOption.ApplicationName,
+           taskOption.ApplicationVersion,
+           taskOption.ApplicationNamespace,
+           taskOption.ApplicationService,
+           taskOption.EngineType);
+
+  public static TaskOptions? ToNullableTaskOptions(this Api.gRPC.V1.TaskOptions? taskOption)
+    => taskOption?.ToTaskOptions();
+}
+
+public static class TaskOptionsExt
+{
+  public static Api.gRPC.V1.TaskOptions ToGrpcTaskOptions(this TaskOptions taskOption)
+    => new()
+       {
+         MaxDuration          = Duration.FromTimeSpan(taskOption.MaxDuration),
+         ApplicationName      = taskOption.ApplicationName,
+         ApplicationVersion   = taskOption.ApplicationVersion,
+         ApplicationNamespace = taskOption.ApplicationNamespace,
+         ApplicationService   = taskOption.ApplicationService,
+         EngineType           = taskOption.EngineType,
+         MaxRetries           = taskOption.MaxRetries,
+         Options =
+         {
+           taskOption.Options,
+         },
+         Priority    = taskOption.Priority,
+         PartitionId = taskOption.PartitionId,
+       };
 }

--- a/Common/src/gRPC/Services/GrpcAgentService.cs
+++ b/Common/src/gRPC/Services/GrpcAgentService.cs
@@ -134,4 +134,49 @@ public class GrpcAgentService : Api.gRPC.V1.Agent.Agent.AgentBase
                                       "No task is accepting request"),
                            "No task is accepting request");
   }
+
+  public override async Task<SubmitTasksResponse> SubmitTasks(SubmitTasksRequest request,
+                                                              ServerCallContext  context)
+  {
+    if (agent_ != null)
+    {
+      return await agent_.SubmitTasks(request,
+                                      context.CancellationToken)
+                         .ConfigureAwait(false);
+    }
+
+    throw new RpcException(new Status(StatusCode.Unavailable,
+                                      "No task is accepting request"),
+                           "No task is accepting request");
+  }
+
+  public override async Task<UploadResultDataResponse> UploadResultData(IAsyncStreamReader<UploadResultDataRequest> requestStream,
+                                                                        ServerCallContext                           context)
+  {
+    if (agent_ != null)
+    {
+      return await agent_.UploadResultData(requestStream,
+                                           context.CancellationToken)
+                         .ConfigureAwait(false);
+    }
+
+    throw new RpcException(new Status(StatusCode.Unavailable,
+                                      "No task is accepting request"),
+                           "No task is accepting request");
+  }
+
+  public override async Task<CreateResultsResponse> CreateResults(CreateResultsRequest request,
+                                                                  ServerCallContext    context)
+  {
+    if (agent_ != null)
+    {
+      return await agent_.CreateResults(request,
+                                        context.CancellationToken)
+                         .ConfigureAwait(false);
+    }
+
+    throw new RpcException(new Status(StatusCode.Unavailable,
+                                      "No task is accepting request"),
+                           "No task is accepting request");
+  }
 }

--- a/Common/src/gRPC/Services/IAgent.cs
+++ b/Common/src/gRPC/Services/IAgent.cs
@@ -110,4 +110,37 @@ public interface IAgent : IDisposable
   /// </returns>
   Task<CreateResultsMetaDataResponse> CreateResultsMetaData(CreateResultsMetaDataRequest request,
                                                             CancellationToken            cancellationToken);
+
+  /// <summary>
+  ///   Submit tasks with payload already existing
+  /// </summary>
+  /// <param name="request">Requests containing the tasks to submit</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Reply sent to the worker with the submitted tasks
+  /// </returns>
+  Task<SubmitTasksResponse> SubmitTasks(SubmitTasksRequest request,
+                                        CancellationToken  cancellationToken);
+
+  /// <summary>
+  ///   Associate data to an existing result
+  /// </summary>
+  /// <param name="requestStream">Requests containing the result data</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Reply sent to the worker describing the status of the execution of the received requests
+  /// </returns>
+  Task<UploadResultDataResponse> UploadResultData(IAsyncStreamReader<UploadResultDataRequest> requestStream,
+                                                  CancellationToken                           cancellationToken);
+
+  /// <summary>
+  ///   Create a result (with data and metadata)
+  /// </summary>
+  /// <param name="request">Requests containing the result to create and the data</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Reply sent to the worker with the id of the created result
+  /// </returns>
+  Task<CreateResultsResponse> CreateResults(CreateResultsRequest request,
+                                            CancellationToken    cancellationToken);
 }

--- a/Common/src/gRPC/Services/ISubmitter.cs
+++ b/Common/src/gRPC/Services/ISubmitter.cs
@@ -27,7 +27,7 @@ using ArmoniK.Core.Common.Storage;
 using Grpc.Core;
 
 using Output = ArmoniK.Api.gRPC.V1.Output;
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
@@ -44,15 +44,13 @@ public interface ISubmitter
                                          TaskOptions       defaultTaskOptions,
                                          CancellationToken cancellationToken);
 
-  Task<(IEnumerable<Storage.TaskRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
+  Task<(IEnumerable<TaskCreationRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
                                                                                                   string                        parentTaskId,
-                                                                                                  TaskOptions                   options,
+                                                                                                  TaskOptions?                  options,
                                                                                                   IAsyncEnumerable<TaskRequest> taskRequests,
                                                                                                   CancellationToken             cancellationToken);
 
-  Task FinalizeTaskCreation(IEnumerable<Storage.TaskRequest> requests,
-                            int                              priority,
-                            string                           partitionId,
+  Task FinalizeTaskCreation(IEnumerable<TaskCreationRequest> requests,
                             string                           sessionId,
                             string                           parentTaskId,
                             CancellationToken                cancellationToken);

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -39,7 +39,7 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.Logging;
 
 using Output = ArmoniK.Api.gRPC.V1.Output;
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
 using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
@@ -109,94 +109,19 @@ public class Submitter : ISubmitter
   }
 
   /// <inheritdoc />
-  public async Task FinalizeTaskCreation(IEnumerable<Storage.TaskRequest> requests,
-                                         int                              priority,
-                                         string                           partitionId,
+  public async Task FinalizeTaskCreation(IEnumerable<TaskCreationRequest> requests,
                                          string                           sessionId,
                                          string                           parentTaskId,
                                          CancellationToken                cancellationToken)
-  {
-    var taskRequests = requests.ToList();
-
-    await ChangeResultOwnership(sessionId,
-                                parentTaskId,
-                                taskRequests,
-                                cancellationToken)
-      .ConfigureAwait(false);
-
-    var readyTasks = new List<string>();
-
-    foreach (var request in taskRequests)
-    {
-      var dependencies = request.DataDependencies.ToList();
-
-      logger_.LogDebug("Process task request {request}",
-                       request);
-
-      if (dependencies.Any())
-      {
-        // If there is dependencies, we need to register the current task as a dependent of its dependencies.
-        // This should be done *before* verifying if the dependencies are satisfied in order to avoid missing
-        // any result completion.
-        // If a result is completed at the same time, either the submitter will see the result has been completed,
-        // Or the Agent will remove the result from the remaining dependencies of the task.
-        await resultTable_.AddTaskDependency(sessionId,
-                                             dependencies,
-                                             new List<string>
-                                             {
-                                               request.Id,
-                                             },
-                                             cancellationToken)
-                          .ConfigureAwait(false);
-
-        // Get the dependencies that are already completed in order to remove them from the remaining dependencies.
-        var completedDependencies = await resultTable_.GetResults(sessionId,
-                                                                  dependencies,
-                                                                  cancellationToken)
-                                                      .Where(result => result.Status == ResultStatus.Completed)
-                                                      .Select(result => result.ResultId)
-                                                      .ToListAsync(cancellationToken)
-                                                      .ConfigureAwait(false);
-
-        // Remove all the dependencies that are already completed from the task.
-        // If an Agent has completed one of the dependencies between the GetResults and this remove,
-        // One will succeed removing the dependency, the other will silently fail.
-        // In either case, the task will be submitted without error by the Agent.
-        // If the agent completes the dependencies _before_ the GetResults, both will try to remove it,
-        // and both will queue the task.
-        // This is benign as it will be handled during dequeue with message deduplication.
-        await taskTable_.RemoveRemainingDataDependenciesAsync(new[]
-                                                              {
-                                                                request.Id,
-                                                              },
-                                                              completedDependencies,
-                                                              cancellationToken)
-                        .ConfigureAwait(false);
-
-        // If all dependencies were already completed, the task is ready to be started.
-        if (dependencies.Count == completedDependencies.Count)
-        {
-          readyTasks.Add(request.Id);
-        }
-      }
-      else
-      {
-        readyTasks.Add(request.Id);
-      }
-    }
-
-    if (readyTasks.Any())
-    {
-      await pushQueueStorage_.PushMessagesAsync(readyTasks,
-                                                partitionId,
-                                                priority,
-                                                cancellationToken)
-                             .ConfigureAwait(false);
-      await taskTable_.FinalizeTaskCreation(readyTasks,
-                                            cancellationToken)
-                      .ConfigureAwait(false);
-    }
-  }
+    => await TaskLifeCycleHelper.FinalizeTaskCreation(taskTable_,
+                                                      resultTable_,
+                                                      pushQueueStorage_,
+                                                      requests.ToList(),
+                                                      sessionId,
+                                                      parentTaskId,
+                                                      logger_,
+                                                      cancellationToken)
+                                .ConfigureAwait(false);
 
   /// <inheritdoc />
   public async Task<CreateSessionReply> CreateSession(IList<string>     partitionIds,
@@ -224,7 +149,10 @@ public class Submitter : ISubmitter
 
     if (string.IsNullOrEmpty(defaultTaskOptions.PartitionId))
     {
-      defaultTaskOptions.PartitionId = submitterOptions_.DefaultPartition;
+      defaultTaskOptions = defaultTaskOptions with
+                           {
+                             PartitionId = submitterOptions_.DefaultPartition,
+                           };
     }
 
     if (!await partitionTable_.ArePartitionsExistingAsync(new[]
@@ -481,14 +409,14 @@ public class Submitter : ISubmitter
                                                    cancellationToken)
                                         .ConfigureAwait(false);
 
-        await FinalizeTaskCreation(new List<Storage.TaskRequest>
+        await FinalizeTaskCreation(new List<TaskCreationRequest>
                                    {
                                      new(newTaskId,
+                                         taskData.PayloadId,
+                                         taskData.Options,
                                          taskData.ExpectedOutputIds,
                                          taskData.DataDependencies),
                                    },
-                                   taskData.Options.Priority,
-                                   taskData.Options.PartitionId,
                                    taskData.SessionId,
                                    taskData.TaskId,
                                    cancellationToken)
@@ -590,19 +518,22 @@ public class Submitter : ISubmitter
   }
 
   /// <inheritdoc />
-  public async Task<(IEnumerable<Storage.TaskRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
+  public async Task<(IEnumerable<TaskCreationRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
                                                                                                                string                        parentTaskId,
-                                                                                                               TaskOptions                   options,
+                                                                                                               TaskOptions?                  options,
                                                                                                                IAsyncEnumerable<TaskRequest> taskRequests,
                                                                                                                CancellationToken             cancellationToken)
   {
     var sessionData = await sessionTable_.GetSessionAsync(sessionId,
                                                           cancellationToken)
                                          .ConfigureAwait(false);
-    options = options != null
-                ? Storage.TaskOptions.Merge(options,
-                                            sessionData.Options)
-                : sessionData.Options;
+
+    options = TaskLifeCycleHelper.ValidateSession(sessionData,
+                                                  options,
+                                                  sessionId,
+                                                  pushQueueStorage_.MaxPriority,
+                                                  logger_,
+                                                  cancellationToken);
 
     using var logFunction = logger_.LogFunction(parentTaskId);
     using var activity    = activitySource_.StartActivity($"{nameof(CreateTasks)}");
@@ -610,29 +541,7 @@ public class Submitter : ISubmitter
                                                         ("TaskId", parentTaskId),
                                                         ("PartitionId", options.PartitionId));
 
-    if (logger_.IsEnabled(LogLevel.Trace))
-    {
-      cancellationToken.Register(() => logger_.LogTrace("CancellationToken from ServerCallContext has been triggered"));
-    }
-
-    var availablePartitionIds = sessionData.PartitionIds ?? Array.Empty<string>();
-    if (!availablePartitionIds.Contains(options.PartitionId))
-    {
-      throw new InvalidOperationException($"The session {sessionData.SessionId} is assigned to the partitions " +
-                                          $"[{string.Join(", ", availablePartitionIds)}], but TaskRequest is assigned to partition {options.PartitionId}");
-    }
-
-    if (options.Priority >= pushQueueStorage_.MaxPriority)
-    {
-      var exception = new RpcException(new Status(StatusCode.InvalidArgument,
-                                                  $"Max priority is {pushQueueStorage_.MaxPriority}"));
-      logger_.LogError(exception,
-                       "Invalid Argument");
-      throw exception;
-    }
-
-
-    var requests           = new List<Storage.TaskRequest>();
+    var requests           = new List<TaskCreationRequest>();
     var payloadUploadTasks = new List<Task>();
 
     await foreach (var taskRequest in taskRequests.WithCancellation(cancellationToken)
@@ -640,81 +549,29 @@ public class Submitter : ISubmitter
     {
       var taskId = Guid.NewGuid()
                        .ToString();
-      requests.Add(new Storage.TaskRequest(taskId,
-                                           taskRequest.ExpectedOutputKeys,
-                                           taskRequest.DataDependencies));
+
+      requests.Add(new TaskCreationRequest(taskId,
+                                           taskId,
+                                           options,
+                                           taskRequest.ExpectedOutputKeys.ToList(),
+                                           taskRequest.DataDependencies.ToList()));
       payloadUploadTasks.Add(objectStorage_.AddOrUpdateAsync(taskId,
                                                              taskRequest.PayloadChunks,
                                                              cancellationToken));
     }
 
-    var parentTaskIds = new List<string>();
-
-    if (!parentTaskId.Equals(sessionData.SessionId))
-    {
-      var res = await taskTable_.GetParentTaskIds(parentTaskId,
-                                                  cancellationToken)
-                                .ConfigureAwait(false);
-      parentTaskIds.AddRange(res);
-    }
-
-    parentTaskIds.Add(parentTaskId);
-
     await payloadUploadTasks.WhenAll()
                             .ConfigureAwait(false);
 
-    await taskTable_.CreateTasks(requests.Select(request => new TaskData(sessionData.SessionId,
-                                                                         request.Id,
-                                                                         "",
-                                                                         "",
-                                                                         request.Id,
-                                                                         parentTaskIds,
-                                                                         request.DataDependencies.ToList(),
-                                                                         request.ExpectedOutputKeys.ToList(),
-                                                                         Array.Empty<string>(),
-                                                                         TaskStatus.Creating,
-                                                                         options,
-                                                                         new Storage.Output(false,
-                                                                                            ""))),
-                                 cancellationToken)
-                    .ConfigureAwait(false);
-
-    await resultTable_.SetTaskOwnership(sessionId,
-                                        requests.SelectMany(r => r.ExpectedOutputKeys.Select(key => (key, r.Id)))
-                                                .AsICollection(),
-                                        cancellationToken)
-                      .ConfigureAwait(false);
+    await TaskLifeCycleHelper.CreateTasks(taskTable_,
+                                          resultTable_,
+                                          sessionId,
+                                          sessionId,
+                                          requests,
+                                          logger_,
+                                          cancellationToken)
+                             .ConfigureAwait(false);
 
     return (requests, options.Priority, options.PartitionId);
-  }
-
-  private async Task ChangeResultOwnership(string                           session,
-                                           string                           parentTaskId,
-                                           IEnumerable<Storage.TaskRequest> requests,
-                                           CancellationToken                cancellationToken = default)
-  {
-    using var _        = logger_.LogFunction($"{session}.{parentTaskId}");
-    using var activity = activitySource_.StartActivity($"{nameof(ChangeResultOwnership)}");
-    activity?.AddTag("sessionId",
-                     session);
-    activity?.AddTag("parentTaskId",
-                     parentTaskId);
-
-    var parentExpectedOutputKeys = new List<string>();
-
-    if (!parentTaskId.Equals(session))
-    {
-      parentExpectedOutputKeys.AddRange(await taskTable_.GetTaskExpectedOutputKeys(parentTaskId,
-                                                                                   cancellationToken)
-                                                        .ConfigureAwait(false));
-    }
-
-    var taskDataModels = requests.Select(request => new IResultTable.ChangeResultOwnershipRequest(parentExpectedOutputKeys.Intersect(request.ExpectedOutputKeys),
-                                                                                                  request.Id));
-    await resultTable_.ChangeResultOwnership(session,
-                                             parentTaskId,
-                                             taskDataModels,
-                                             cancellationToken)
-                      .ConfigureAwait(false);
   }
 }

--- a/Common/tests/Auth/AuthenticationIntegrationTest.cs
+++ b/Common/tests/Auth/AuthenticationIntegrationTest.cs
@@ -36,6 +36,7 @@ using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Api.gRPC.V1.Tasks;
+using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
 using ArmoniK.Core.Common.Auth.Authorization.Permissions;
@@ -85,6 +86,9 @@ public class AuthenticationIntegrationTest
                                                 .AddSingleton<IResultTable>(new SimpleResultTable())
                                                 .AddSingleton<IPartitionTable>(new SimplePartitionTable())
                                                 .AddSingleton<ITaskWatcher>(new SimpleTaskWatcher())
+                                                .AddSingleton<IPushQueueStorage>(new SimplePushQueueStorage())
+                                                .AddSingleton<IPullQueueStorage>(new SimplePullQueueStorage())
+                                                .AddSingleton<IObjectStorage>(new SimpleObjectStorage())
                                                 .AddSingleton<IResultWatcher>(new SimpleResultWatcher());
                                              });
   }

--- a/Common/tests/Helpers/SimpleAgent.cs
+++ b/Common/tests/Helpers/SimpleAgent.cs
@@ -58,6 +58,18 @@ public class SimpleAgent : IAgent
                                                                    CancellationToken            cancellationToken)
     => Task.FromResult(new CreateResultsMetaDataResponse());
 
+  public Task<SubmitTasksResponse> SubmitTasks(SubmitTasksRequest request,
+                                               CancellationToken  cancellationToken)
+    => Task.FromResult(new SubmitTasksResponse());
+
+  public Task<UploadResultDataResponse> UploadResultData(IAsyncStreamReader<UploadResultDataRequest> requestStream,
+                                                         CancellationToken                           cancellationToken)
+    => Task.FromResult(new UploadResultDataResponse());
+
+  public Task<CreateResultsResponse> CreateResults(CreateResultsRequest request,
+                                                   CancellationToken    cancellationToken)
+    => Task.FromResult(new CreateResultsResponse());
+
   public void Dispose()
   {
   }

--- a/Common/tests/Helpers/SimpleObjectStorage.cs
+++ b/Common/tests/Helpers/SimpleObjectStorage.cs
@@ -1,0 +1,67 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Common.Storage;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+public class SimpleObjectStorage : IObjectStorage
+{
+  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));
+
+  public Task Init(CancellationToken cancellationToken)
+    => Task.CompletedTask;
+
+  public Task AddOrUpdateAsync(string                   key,
+                               IAsyncEnumerable<byte[]> valueChunks,
+                               CancellationToken        cancellationToken = default)
+    => Task.CompletedTask;
+
+  public Task AddOrUpdateAsync(string                                 key,
+                               IAsyncEnumerable<ReadOnlyMemory<byte>> valueChunks,
+                               CancellationToken                      cancellationToken = default)
+    => Task.CompletedTask;
+
+  public IAsyncEnumerable<byte[]> GetValuesAsync(string            key,
+                                                 CancellationToken cancellationToken = default)
+    => new List<byte[]>
+       {
+         Encoding.UTF8.GetBytes(key),
+       }.ToAsyncEnumerable();
+
+  public Task<bool> TryDeleteAsync(string            key,
+                                   CancellationToken cancellationToken = default)
+    => Task.FromResult(true);
+
+  public IAsyncEnumerable<string> ListKeysAsync(CancellationToken cancellationToken = default)
+    => new List<string>
+       {
+         "key1",
+         "key2",
+       }.ToAsyncEnumerable();
+}

--- a/Common/tests/Helpers/SimpleResultTable.cs
+++ b/Common/tests/Helpers/SimpleResultTable.cs
@@ -147,6 +147,21 @@ public class SimpleResultTable : IResultTable
                         CancellationToken cancellationToken = default)
     => Task.CompletedTask;
 
+  public Task<Result> CompleteResult(string            sessionId,
+                                     string            resultId,
+                                     CancellationToken cancellationToken = default)
+    => Task.FromResult(new Result(SessionId,
+                                  OutputId,
+                                  "",
+                                  TaskId,
+                                  ResultStatus.Completed,
+                                  new List<string>(),
+                                  DateTime.Now.ToUniversalTime(),
+                                  new byte[]
+                                  {
+                                    42,
+                                  }));
+
   public Task<IEnumerable<GetResultStatusReply.Types.IdStatus>> GetResultStatus(IEnumerable<string> ids,
                                                                                 string              sessionId,
                                                                                 CancellationToken   cancellationToken = default)

--- a/Common/tests/Helpers/SimpleSessionTable.cs
+++ b/Common/tests/Helpers/SimpleSessionTable.cs
@@ -27,8 +27,6 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Storage;
 
-using Google.Protobuf.WellKnownTypes;
-
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
@@ -48,13 +46,16 @@ public class SimpleSessionTable : ISessionTable
   public static readonly TaskOptions TaskOptions;
 
   static SimpleSessionTable()
-    => TaskOptions = new Api.gRPC.V1.TaskOptions
-                     {
-                       MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(10)),
-                       MaxRetries  = 4,
-                       Priority    = 2,
-                       PartitionId = PartitionId,
-                     };
+    => TaskOptions = new TaskOptions(new Dictionary<string, string>(),
+                                     TimeSpan.FromSeconds(1),
+                                     5,
+                                     1,
+                                     PartitionId,
+                                     "",
+                                     "",
+                                     "",
+                                     "",
+                                     "");
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
     => Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));

--- a/Common/tests/Helpers/SimpleSubmitter.cs
+++ b/Common/tests/Helpers/SimpleSubmitter.cs
@@ -29,8 +29,8 @@ using ArmoniK.Core.Common.Storage;
 using Grpc.Core;
 
 using Output = ArmoniK.Api.gRPC.V1.Output;
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
-using TaskRequest = ArmoniK.Core.Common.Storage.TaskRequest;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
+using TaskRequest = ArmoniK.Core.Common.gRPC.Services.TaskRequest;
 using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
 
 namespace ArmoniK.Core.Common.Tests.Helpers;
@@ -64,24 +64,37 @@ public class SimpleSubmitter : ISubmitter
                        });
 
 
-  public async Task<(IEnumerable<TaskRequest> requests, int priority, string partitionId)> CreateTasks(string                                      sessionId,
-                                                                                                       string                                      parentTaskId,
-                                                                                                       TaskOptions                                 options,
-                                                                                                       IAsyncEnumerable<gRPC.Services.TaskRequest> taskRequests,
-                                                                                                       CancellationToken                           cancellationToken)
-    => (await taskRequests.Select(r => new TaskRequest(Guid.NewGuid()
-                                                           .ToString(),
-                                                       r.ExpectedOutputKeys,
-                                                       r.DataDependencies))
+  public async Task<(IEnumerable<TaskCreationRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
+                                                                                                               string                        parentTaskId,
+                                                                                                               TaskOptions?                  options,
+                                                                                                               IAsyncEnumerable<TaskRequest> taskRequests,
+                                                                                                               CancellationToken             cancellationToken)
+    => (await taskRequests.Select(r =>
+                                  {
+                                    var id = Guid.NewGuid()
+                                                 .ToString();
+                                    return new TaskCreationRequest(id,
+                                                                   id,
+                                                                   options ?? new TaskOptions(new Dictionary<string, string>(),
+                                                                                              TimeSpan.FromSeconds(1),
+                                                                                              5,
+                                                                                              1,
+                                                                                              "Partition",
+                                                                                              "Application",
+                                                                                              "Version",
+                                                                                              "Namespace",
+                                                                                              "Service",
+                                                                                              "Engine"),
+                                                                   r.ExpectedOutputKeys.ToList(),
+                                                                   r.DataDependencies.ToList());
+                                  })
                           .ToArrayAsync(cancellationToken)
                           .ConfigureAwait(false), 1, "");
 
-  public Task FinalizeTaskCreation(IEnumerable<TaskRequest> requests,
-                                   int                      priority,
-                                   string                   partitionId,
-                                   string                   sessionId,
-                                   string                   parentTaskId,
-                                   CancellationToken        cancellationToken)
+  public Task FinalizeTaskCreation(IEnumerable<TaskCreationRequest> requests,
+                                   string                           sessionId,
+                                   string                           parentTaskId,
+                                   CancellationToken                cancellationToken)
     => Task.CompletedTask;
 
   public Task<Configuration> GetServiceConfiguration(Empty             request,

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -26,14 +26,11 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Storage;
 
-using Google.Protobuf.WellKnownTypes;
-
 using LinqKit;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
 using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
 
 namespace ArmoniK.Core.Common.Tests.Helpers;
@@ -50,13 +47,16 @@ public class SimpleTaskTable : ITaskTable
   public static readonly TaskOptions TaskOptions;
 
   static SimpleTaskTable()
-    => TaskOptions = new TaskOptions
-                     {
-                       MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(10)),
-                       MaxRetries  = 4,
-                       Priority    = 2,
-                       PartitionId = PartitionId,
-                     };
+    => TaskOptions = new TaskOptions(new Dictionary<string, string>(),
+                                     TimeSpan.FromSeconds(1),
+                                     5,
+                                     1,
+                                     PartitionId,
+                                     "",
+                                     "",
+                                     "",
+                                     "",
+                                     "");
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
     => Task.FromResult(new HealthCheckResult(HealthStatus.Healthy));

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -34,8 +34,6 @@ using ArmoniK.Core.Common.Stream.Worker;
 using ArmoniK.Core.Common.Tests.Helpers;
 using ArmoniK.Core.Common.Utils;
 
-using Google.Protobuf.WellKnownTypes;
-
 using Grpc.Core;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
@@ -125,13 +123,16 @@ public class TaskHandlerTest
                                                                          "part1",
                                                                          "part2",
                                                                        },
-                                                                       new Api.gRPC.V1.TaskOptions
-                                                                       {
-                                                                         MaxDuration = Duration.FromTimeSpan(TimeSpan.FromMinutes(2)),
-                                                                         MaxRetries  = 2,
-                                                                         Priority    = 1,
-                                                                         PartitionId = "part1",
-                                                                       },
+                                                                       new TaskOptions(new Dictionary<string, string>(),
+                                                                                       TimeSpan.FromSeconds(1),
+                                                                                       5,
+                                                                                       1,
+                                                                                       "part1",
+                                                                                       "",
+                                                                                       "",
+                                                                                       "",
+                                                                                       "",
+                                                                                       ""),
                                                                        CancellationToken.None)
                                               .ConfigureAwait(false)).SessionId;
 
@@ -214,37 +215,37 @@ public class TaskHandlerTest
 
     var (requestsIEnumerable, priority, whichPartitionId) = await testServiceProvider.Submitter.CreateTasks(sessionId,
                                                                                                             sessionId,
-                                                                                                            new Api.gRPC.V1.TaskOptions
-                                                                                                            {
-                                                                                                              MaxDuration =
-                                                                                                                Duration.FromTimeSpan(TimeSpan.FromMinutes(2)),
-                                                                                                              MaxRetries  = 2,
-                                                                                                              Priority    = 1,
-                                                                                                              PartitionId = "part1",
-                                                                                                            },
+                                                                                                            new TaskOptions(new Dictionary<string, string>(),
+                                                                                                                            TimeSpan.FromSeconds(1),
+                                                                                                                            5,
+                                                                                                                            1,
+                                                                                                                            "part1",
+                                                                                                                            "",
+                                                                                                                            "",
+                                                                                                                            "",
+                                                                                                                            "",
+                                                                                                                            ""),
                                                                                                             taskRequests.ToAsyncEnumerable(),
                                                                                                             CancellationToken.None)
                                                                                      .ConfigureAwait(false);
     var requests = requestsIEnumerable.ToList();
     await testServiceProvider.Submitter.FinalizeTaskCreation(requests,
-                                                             priority,
-                                                             whichPartitionId,
                                                              sessionId,
                                                              sessionId,
                                                              CancellationToken.None)
                              .ConfigureAwait(false);
 
     var taskId = requests.First()
-                         .Id;
+                         .TaskId;
     requests.RemoveAt(0);
 
 
     var taskUnresolvedDepId = requests.First()
-                                      .Id;
+                                      .TaskId;
     requests.RemoveAt(0);
 
     var taskErrorId = requests.First()
-                              .Id;
+                              .TaskId;
 
     var taskErrorData = await testServiceProvider.TaskTable.ReadTaskAsync(taskErrorId,
                                                                           CancellationToken.None)

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -1,4 +1,4 @@
-﻿// This file is part of the ArmoniK project
+// This file is part of the ArmoniK project
 // 
 // Copyright (C) ANEO, 2021-2023. All rights reserved.
 // 
@@ -27,6 +27,7 @@ using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
+using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Helpers;
 
 using Google.Protobuf;
@@ -42,6 +43,7 @@ using Moq;
 
 using NUnit.Framework;
 
+using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
 using TaskRequest = ArmoniK.Core.Common.gRPC.Services.TaskRequest;
 
 // ReSharper disable AccessToModifiedClosure
@@ -90,7 +92,7 @@ internal class ExceptionInterceptorTests
                     DefaultTaskOption = new TaskOptions
                                         {
                                           Priority    = 1,
-                                          MaxDuration = Duration.FromTimeSpan(TimeSpan.MaxValue),
+                                          MaxDuration = Duration.FromTimeSpan(TimeSpan.FromHours(1)),
                                           MaxRetries  = 1,
                                         },
                   };
@@ -100,7 +102,7 @@ internal class ExceptionInterceptorTests
                        };
     var mockSubmitter = new Mock<ISubmitter>();
     mockSubmitter.Setup(submitter => submitter.CreateSession(It.IsAny<IList<string>>(),
-                                                             It.IsAny<TaskOptions>(),
+                                                             It.IsAny<Storage.TaskOptions>(),
                                                              It.IsAny<CancellationToken>()))
                  .Returns(() => ex is null
                                   ? Task.FromResult(noErrorReply)
@@ -173,12 +175,12 @@ internal class ExceptionInterceptorTests
     var        mockSubmitter = new Mock<ISubmitter>();
     mockSubmitter.Setup(submitter => submitter.CreateTasks(It.IsAny<string>(),
                                                            It.IsAny<string>(),
-                                                           It.IsAny<TaskOptions>(),
+                                                           It.IsAny<Storage.TaskOptions>(),
                                                            It.IsAny<IAsyncEnumerable<TaskRequest>>(),
                                                            It.IsAny<CancellationToken>()))
                  .Returns(async (string                        _,
                                  string                        _,
-                                 TaskOptions                   _,
+                                 Storage.TaskOptions           _,
                                  IAsyncEnumerable<TaskRequest> requests,
                                  CancellationToken             cancellationToken) =>
                           {
@@ -204,9 +206,20 @@ internal class ExceptionInterceptorTests
                               throw ex;
                             }
 
-                            return (new List<Storage.TaskRequest>
+                            return (new List<TaskCreationRequest>
                                     {
                                       new("taskId",
+                                          "taskId",
+                                          new Storage.TaskOptions(new Dictionary<string, string>(),
+                                                                  TimeSpan.FromSeconds(2),
+                                                                  5,
+                                                                  1,
+                                                                  "Partition",
+                                                                  "",
+                                                                  "",
+                                                                  "",
+                                                                  "",
+                                                                  ""),
                                           new[]
                                           {
                                             "output",
@@ -245,6 +258,7 @@ internal class ExceptionInterceptorTests
                                                                  {
                                                                    "output",
                                                                  },
+                                                                 PayloadId = "taskId",
                                                                },
                                                   },
                                                 },
@@ -263,7 +277,7 @@ internal class ExceptionInterceptorTests
                                                                      SessionId = "SessionId",
                                                                      TaskOptions = new TaskOptions
                                                                                    {
-                                                                                     MaxDuration = Duration.FromTimeSpan(TimeSpan.MaxValue),
+                                                                                     MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(1)),
                                                                                      MaxRetries  = 1,
                                                                                      PartitionId = "Part",
                                                                                      Priority    = 1,

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -48,8 +48,8 @@ using NUnit.Framework;
 
 using Empty = ArmoniK.Api.gRPC.V1.Empty;
 using Output = ArmoniK.Api.gRPC.V1.Output;
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
-using TaskRequest = ArmoniK.Core.Common.Storage.TaskRequest;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
+using TaskRequest = ArmoniK.Core.Common.gRPC.Services.TaskRequest;
 using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
 
 namespace ArmoniK.Core.Common.Tests.Submitter;
@@ -161,19 +161,17 @@ internal class IntegrationGrpcSubmitterServiceTest
                                                   CancellationToken cancellationToken)
       => Task.FromException<CreateSessionReply>(new T());
 
-    public Task<(IEnumerable<TaskRequest> requests, int priority, string partitionId)> CreateTasks(string                                      sessionId,
-                                                                                                   string                                      parentTaskId,
-                                                                                                   TaskOptions                                 options,
-                                                                                                   IAsyncEnumerable<gRPC.Services.TaskRequest> taskRequests,
-                                                                                                   CancellationToken                           cancellationToken)
-      => Task.FromException<(IEnumerable<TaskRequest>, int, string)>(new T());
+    public Task<(IEnumerable<TaskCreationRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
+                                                                                                           string                        parentTaskId,
+                                                                                                           TaskOptions?                  options,
+                                                                                                           IAsyncEnumerable<TaskRequest> taskRequests,
+                                                                                                           CancellationToken             cancellationToken)
+      => Task.FromException<(IEnumerable<TaskCreationRequest>, int, string)>(new T());
 
-    public Task FinalizeTaskCreation(IEnumerable<TaskRequest> requests,
-                                     int                      priority,
-                                     string                   partitionId,
-                                     string                   sessionId,
-                                     string                   parentTaskId,
-                                     CancellationToken        cancellationToken)
+    public Task FinalizeTaskCreation(IEnumerable<TaskCreationRequest> requests,
+                                     string                           sessionId,
+                                     string                           parentTaskId,
+                                     CancellationToken                cancellationToken)
       => Task.FromException(new T());
 
     public Task<Configuration> GetServiceConfiguration(Empty             request,
@@ -219,19 +217,17 @@ internal class IntegrationGrpcSubmitterServiceTest
                                                   CancellationToken cancellationToken)
       => throw new T();
 
-    public Task<(IEnumerable<TaskRequest> requests, int priority, string partitionId)> CreateTasks(string                                      sessionId,
-                                                                                                   string                                      parentTaskId,
-                                                                                                   TaskOptions                                 options,
-                                                                                                   IAsyncEnumerable<gRPC.Services.TaskRequest> taskRequests,
-                                                                                                   CancellationToken                           cancellationToken)
+    public Task<(IEnumerable<TaskCreationRequest> requests, int priority, string partitionId)> CreateTasks(string                        sessionId,
+                                                                                                           string                        parentTaskId,
+                                                                                                           TaskOptions?                  options,
+                                                                                                           IAsyncEnumerable<TaskRequest> taskRequests,
+                                                                                                           CancellationToken             cancellationToken)
       => throw new T();
 
-    public Task FinalizeTaskCreation(IEnumerable<TaskRequest> requests,
-                                     int                      priority,
-                                     string                   partitionId,
-                                     string                   sessionId,
-                                     string                   parentTaskId,
-                                     CancellationToken        cancellationToken)
+    public Task FinalizeTaskCreation(IEnumerable<TaskCreationRequest> requests,
+                                     string                           sessionId,
+                                     string                           parentTaskId,
+                                     CancellationToken                cancellationToken)
       => throw new T();
 
     public Task<Configuration> GetServiceConfiguration(Empty             request,
@@ -441,7 +437,7 @@ internal class IntegrationGrpcSubmitterServiceTest
     {
       _ = client.CreateSession(new CreateSessionRequest
                                {
-                                 DefaultTaskOption = new TaskOptions
+                                 DefaultTaskOption = new Api.gRPC.V1.TaskOptions
                                                      {
                                                        MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(2)),
                                                        MaxRetries  = 2,
@@ -488,7 +484,7 @@ internal class IntegrationGrpcSubmitterServiceTest
                                         Payload = ByteString.CopyFromUtf8("Payload"),
                                       },
                                     },
-                                    TaskOptions = new TaskOptions
+                                    TaskOptions = new Api.gRPC.V1.TaskOptions
                                                   {
                                                     MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(2)),
                                                     MaxRetries  = 2,
@@ -527,6 +523,12 @@ internal class IntegrationGrpcSubmitterServiceTest
                                                      InitRequest = new CreateLargeTaskRequest.Types.InitRequest
                                                                    {
                                                                      SessionId = "SessionId",
+                                                                     TaskOptions = new Api.gRPC.V1.TaskOptions
+                                                                                   {
+                                                                                     MaxDuration = Duration.FromTimeSpan(TimeSpan.FromMinutes(1)),
+                                                                                     MaxRetries  = 2,
+                                                                                     Priority    = 1,
+                                                                                   },
                                                                    },
                                                    })
                          .ConfigureAwait(false);

--- a/Common/tests/TaskOptionsTests.cs
+++ b/Common/tests/TaskOptionsTests.cs
@@ -1,0 +1,66 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using ArmoniK.Core.Common.gRPC;
+using ArmoniK.Core.Common.Storage;
+
+using Google.Protobuf.Collections;
+
+using NUnit.Framework;
+
+using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
+
+namespace ArmoniK.Core.Common.Tests;
+
+[TestFixture(TestOf = typeof(RpcExt))]
+public class TaskOptionsTests
+{
+  private readonly TaskOptions? options_ = null;
+
+  private readonly Storage.TaskOptions completeOptions_ = new(new MapField<string, string>
+                                                              {
+                                                                {
+                                                                  "key1", "val1"
+                                                                },
+                                                                {
+                                                                  "key2", "val2"
+                                                                },
+                                                              },
+                                                              TimeSpan.FromSeconds(1),
+                                                              5,
+                                                              1,
+                                                              "PartitionId",
+                                                              "ApplicationName",
+                                                              "ApplicationVersion",
+                                                              "ApplicationNamespace",
+                                                              "ApplicationService",
+                                                              "EngineType");
+
+
+  [Test]
+  public void NullTaskOptionsShouldBeEqual()
+    => Assert.AreSame(null,
+                      options_.ToNullableTaskOptions());
+
+  [Test]
+  public void ConversionShouldBeEqual()
+    => Assert.AreEqual(completeOptions_,
+                       completeOptions_.ToGrpcTaskOptions()
+                                       .ToTaskOptions());
+}

--- a/Common/tests/TestBase/ResultTableTestBase.cs
+++ b/Common/tests/TestBase/ResultTableTestBase.cs
@@ -810,4 +810,57 @@ public class ResultTableTestBase
                                                                                 .ConfigureAwait(false));
     }
   }
+
+  [Test]
+  public async Task CompleteResultShouldSucceed()
+  {
+    if (RunTests)
+    {
+      var resultId = Guid.NewGuid()
+                         .ToString();
+      var sessionId = Guid.NewGuid()
+                          .ToString();
+      await ResultTable!.Create(new List<Result>
+                                {
+                                  new(sessionId,
+                                      resultId,
+                                      "Name",
+                                      "",
+                                      ResultStatus.Created,
+                                      new List<string>(),
+                                      DateTime.UtcNow,
+                                      Array.Empty<byte>()),
+                                },
+                                CancellationToken.None)
+                        .ConfigureAwait(false);
+
+      var result = await ResultTable.CompleteResult(sessionId,
+                                                    resultId,
+                                                    CancellationToken.None)
+                                    .ConfigureAwait(false);
+
+      Assert.AreEqual(ResultStatus.Completed,
+                      result.Status);
+
+      result = await ResultTable.GetResult(sessionId,
+                                           resultId,
+                                           CancellationToken.None)
+                                .ConfigureAwait(false);
+
+      Assert.AreEqual(ResultStatus.Completed,
+                      result.Status);
+    }
+  }
+
+  [Test]
+  public void CompleteResultShouldThrow()
+  {
+    if (RunTests)
+    {
+      Assert.ThrowsAsync<ResultNotFoundException>(async () => await ResultTable!.CompleteResult("SessionId",
+                                                                                                "NotExistingResult111",
+                                                                                                CancellationToken.None)
+                                                                                .ConfigureAwait(false));
+    }
+  }
 }

--- a/Common/tests/TestBase/SessionTableTestBase.cs
+++ b/Common/tests/TestBase/SessionTableTestBase.cs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,13 +27,11 @@ using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.Storage;
 
-using Google.Protobuf.WellKnownTypes;
-
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 using NUnit.Framework;
 
-using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
+using TaskOptions = ArmoniK.Core.Common.Storage.TaskOptions;
 
 namespace ArmoniK.Core.Common.Tests.TestBase;
 
@@ -57,15 +56,16 @@ public class SessionTableTestBase
                                                                "part1",
                                                                "part2",
                                                              },
-                                                             new TaskOptions
-                                                             {
-                                                               MaxDuration        = Duration.FromTimeSpan(TimeSpan.FromMinutes(1)),
-                                                               MaxRetries         = 2,
-                                                               Priority           = 1,
-                                                               PartitionId        = "part1",
-                                                               ApplicationName    = "ApplicationName",
-                                                               ApplicationVersion = "ApplicationVersion",
-                                                             },
+                                                             new TaskOptions(new Dictionary<string, string>(),
+                                                                             TimeSpan.FromMinutes(1),
+                                                                             2,
+                                                                             1,
+                                                                             "part1",
+                                                                             "ApplicationName",
+                                                                             "ApplicationVersion",
+                                                                             "",
+                                                                             "",
+                                                                             ""),
                                                              CancellationToken.None)
                                         .ConfigureAwait(false);
 
@@ -74,15 +74,16 @@ public class SessionTableTestBase
                                                                 "part1",
                                                                 "part2",
                                                               },
-                                                              new TaskOptions
-                                                              {
-                                                                MaxDuration        = Duration.FromTimeSpan(TimeSpan.FromMinutes(1)),
-                                                                MaxRetries         = 2,
-                                                                Priority           = 1,
-                                                                PartitionId        = "part1",
-                                                                ApplicationName    = "ApplicationName",
-                                                                ApplicationVersion = "ApplicationVersion",
-                                                              },
+                                                              new TaskOptions(new Dictionary<string, string>(),
+                                                                              TimeSpan.FromMinutes(1),
+                                                                              2,
+                                                                              1,
+                                                                              "part1",
+                                                                              "ApplicationName",
+                                                                              "ApplicationVersion",
+                                                                              "",
+                                                                              "",
+                                                                              ""),
                                                               CancellationToken.None)
                                          .ConfigureAwait(false);
 
@@ -91,15 +92,16 @@ public class SessionTableTestBase
                                                                 "part1",
                                                                 "part2",
                                                               },
-                                                              new TaskOptions
-                                                              {
-                                                                MaxDuration        = Duration.FromTimeSpan(TimeSpan.FromMinutes(1)),
-                                                                MaxRetries         = 2,
-                                                                Priority           = 1,
-                                                                PartitionId        = "part1",
-                                                                ApplicationName    = "ApplicationName",
-                                                                ApplicationVersion = "ApplicationVersion",
-                                                              },
+                                                              new TaskOptions(new Dictionary<string, string>(),
+                                                                              TimeSpan.FromMinutes(1),
+                                                                              2,
+                                                                              1,
+                                                                              "part1",
+                                                                              "ApplicationName",
+                                                                              "ApplicationVersion",
+                                                                              "",
+                                                                              "",
+                                                                              ""),
                                                               CancellationToken.None)
                                          .ConfigureAwait(false);
 
@@ -108,15 +110,16 @@ public class SessionTableTestBase
                                                                 "part1",
                                                                 "part2",
                                                               },
-                                                              new TaskOptions
-                                                              {
-                                                                MaxDuration        = Duration.FromTimeSpan(TimeSpan.FromMinutes(1)),
-                                                                MaxRetries         = 2,
-                                                                Priority           = 1,
-                                                                PartitionId        = "part1",
-                                                                ApplicationName    = "ApplicationName2",
-                                                                ApplicationVersion = "ApplicationVersion2",
-                                                              },
+                                                              new TaskOptions(new Dictionary<string, string>(),
+                                                                              TimeSpan.FromMinutes(1),
+                                                                              2,
+                                                                              1,
+                                                                              "part1",
+                                                                              "ApplicationName2",
+                                                                              "ApplicationVersion2",
+                                                                              "",
+                                                                              "",
+                                                                              ""),
                                                               CancellationToken.None)
                                          .ConfigureAwait(false);
 

--- a/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
+++ b/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-3814g80ad90e.4.80ad90e" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-SNAPSHOT.14.74bbbc4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
   </ItemGroup>
 

--- a/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
+++ b/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-3814g80ad90e.4.80ad90e" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-SNAPSHOT.14.74bbbc4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
+++ b/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-3814g80ad90e.4.80ad90e" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-SNAPSHOT.14.74bbbc4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Htc.Mock" Version="3.0.0-alpha11" />
   </ItemGroup>

--- a/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
+++ b/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-3814g80ad90e.4.80ad90e" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-SNAPSHOT.14.74bbbc4" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/Tests/Stream/Client/TaskSubmissionTests.cs
+++ b/Tests/Stream/Client/TaskSubmissionTests.cs
@@ -1,0 +1,300 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Api.Client;
+using ArmoniK.Api.Client.Options;
+using ArmoniK.Api.Client.Submitter;
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Results;
+using ArmoniK.Api.gRPC.V1.Submitter;
+using ArmoniK.Api.gRPC.V1.Tasks;
+using ArmoniK.Extensions.Common.StreamWrapper.Tests.Common;
+
+using Google.Protobuf;
+using Google.Protobuf.WellKnownTypes;
+
+using Grpc.Core;
+
+using Microsoft.Extensions.Configuration;
+
+using NUnit.Framework;
+
+using TaskStatus = ArmoniK.Api.gRPC.V1.TaskStatus;
+
+namespace ArmoniK.Extensions.Common.StreamWrapper.Tests.Client;
+
+internal class TaskSubmissionTests
+{
+  private ChannelBase? channel_;
+  private string?      partition_;
+
+  [SetUp]
+  public void SetUp()
+  {
+    Dictionary<string, string?> baseConfig = new()
+                                             {
+                                               {
+                                                 "GrpcClient:Endpoint", "http://localhost:5001"
+                                               },
+                                               {
+                                                 "Partition", "TestPartition"
+                                               },
+                                             };
+
+    var builder = new ConfigurationBuilder().AddInMemoryCollection(baseConfig)
+                                            .AddEnvironmentVariables();
+    var configuration = builder.Build();
+    var options = configuration.GetRequiredSection(GrpcClient.SettingSection)
+                               .Get<GrpcClient>();
+
+    partition_ = configuration.GetValue<string>("Partition");
+
+    Console.WriteLine($"endpoint : {options.Endpoint}");
+    channel_ = GrpcChannelFactory.CreateChannel(options);
+  }
+
+  [Test]
+  public async Task CreateResultsAndMetadataShouldSucceed()
+  {
+    var submitterClient = new Submitter.SubmitterClient(channel_);
+    var createSessionReply = await submitterClient.CreateSessionAsync(new CreateSessionRequest
+                                                                      {
+                                                                        DefaultTaskOption = new TaskOptions
+                                                                                            {
+                                                                                              Priority    = 1,
+                                                                                              MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(2)),
+                                                                                              MaxRetries  = 2,
+                                                                                              PartitionId = partition_,
+                                                                                            },
+                                                                        PartitionIds =
+                                                                        {
+                                                                          partition_,
+                                                                        },
+                                                                      });
+
+    var resultsClient = new Results.ResultsClient(channel_);
+    var results = await resultsClient.CreateResultsMetaDataAsync(new CreateResultsMetaDataRequest
+                                                                 {
+                                                                   SessionId = createSessionReply.SessionId,
+                                                                   Results =
+                                                                   {
+                                                                     new CreateResultsMetaDataRequest.Types.ResultCreate
+                                                                     {
+                                                                       Name = "MyResult",
+                                                                     },
+                                                                   },
+                                                                 });
+
+    var payloadBytes = Encoding.ASCII.GetBytes("Payload");
+
+    await resultsClient.UploadResultData(createSessionReply.SessionId,
+                                         results.Results.Single()
+                                                .ResultId,
+                                         payloadBytes)
+                       .ConfigureAwait(false);
+
+    var downloadedPayload = await resultsClient.DownloadResultData(createSessionReply.SessionId,
+                                                                   results.Results.Single()
+                                                                          .ResultId,
+                                                                   CancellationToken.None)
+                                               .ConfigureAwait(false);
+
+    Assert.AreEqual(payloadBytes,
+                    downloadedPayload);
+  }
+
+  [Test]
+  public async Task CreateResultsDirectlyShouldSucceed()
+  {
+    var submitterClient = new Submitter.SubmitterClient(channel_);
+    var createSessionReply = await submitterClient.CreateSessionAsync(new CreateSessionRequest
+                                                                      {
+                                                                        DefaultTaskOption = new TaskOptions
+                                                                                            {
+                                                                                              Priority    = 1,
+                                                                                              MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(2)),
+                                                                                              MaxRetries  = 2,
+                                                                                              PartitionId = partition_,
+                                                                                            },
+                                                                        PartitionIds =
+                                                                        {
+                                                                          partition_,
+                                                                        },
+                                                                      });
+
+    var resultsClient = new Results.ResultsClient(channel_);
+    var payloadBytes  = Encoding.ASCII.GetBytes("Payload");
+
+    var results = await resultsClient.CreateResultsAsync(new CreateResultsRequest
+                                                         {
+                                                           SessionId = createSessionReply.SessionId,
+                                                           Results =
+                                                           {
+                                                             new CreateResultsRequest.Types.ResultCreate
+                                                             {
+                                                               Name = "MyResult",
+                                                               Data = UnsafeByteOperations.UnsafeWrap(payloadBytes),
+                                                             },
+                                                           },
+                                                         });
+
+    var downloadedPayload = await resultsClient.DownloadResultData(createSessionReply.SessionId,
+                                                                   results.Results.Single()
+                                                                          .ResultId,
+                                                                   CancellationToken.None)
+                                               .ConfigureAwait(false);
+
+    Assert.AreEqual(payloadBytes,
+                    downloadedPayload);
+
+    await resultsClient.DeleteResultsDataAsync(new DeleteResultsDataRequest
+                                               {
+                                                 SessionId = createSessionReply.SessionId,
+                                                 ResultId =
+                                                 {
+                                                   results.Results.Select(r => r.ResultId),
+                                                 },
+                                               })
+                       .ConfigureAwait(false);
+  }
+
+  [Test]
+  public async Task SubmitTasksShouldSucceed()
+  {
+    var submitterClient = new Submitter.SubmitterClient(channel_);
+    var createSessionReply = await submitterClient.CreateSessionAsync(new CreateSessionRequest
+                                                                      {
+                                                                        DefaultTaskOption = new TaskOptions
+                                                                                            {
+                                                                                              Priority    = 1,
+                                                                                              MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(2)),
+                                                                                              MaxRetries  = 2,
+                                                                                              PartitionId = partition_,
+                                                                                            },
+                                                                        PartitionIds =
+                                                                        {
+                                                                          partition_,
+                                                                        },
+                                                                      });
+
+    var resultsClient = new Results.ResultsClient(channel_);
+
+    var results = await resultsClient.CreateResultsMetaDataAsync(new CreateResultsMetaDataRequest
+                                                                 {
+                                                                   SessionId = createSessionReply.SessionId,
+                                                                   Results =
+                                                                   {
+                                                                     new CreateResultsMetaDataRequest.Types.ResultCreate
+                                                                     {
+                                                                       Name = "MyResult",
+                                                                     },
+                                                                   },
+                                                                 });
+
+    var payload = new TestPayload
+                  {
+                    Type      = TestPayload.TaskType.Compute,
+                    DataBytes = BitConverter.GetBytes(3),
+                    ResultKey = results.Results.Single()
+                                       .ResultId,
+                  };
+    var payloads = await resultsClient.CreateResultsAsync(new CreateResultsRequest
+                                                          {
+                                                            SessionId = createSessionReply.SessionId,
+                                                            Results =
+                                                            {
+                                                              new CreateResultsRequest.Types.ResultCreate
+                                                              {
+                                                                Name = "MyPayload",
+                                                                Data = UnsafeByteOperations.UnsafeWrap(payload.Serialize()),
+                                                              },
+                                                            },
+                                                          });
+
+
+    var tasksClient = new Tasks.TasksClient(channel_);
+
+    var tasks = await tasksClient.SubmitTasksAsync(new SubmitTasksRequest
+                                                   {
+                                                     SessionId = createSessionReply.SessionId,
+                                                     TaskCreations =
+                                                     {
+                                                       new SubmitTasksRequest.Types.TaskCreation
+                                                       {
+                                                         ExpectedOutputKeys =
+                                                         {
+                                                           results.Results.Select(r => r.ResultId),
+                                                         },
+                                                         PayloadId = payloads.Results.Single()
+                                                                             .ResultId,
+                                                       },
+                                                     },
+                                                   })
+                                 .ConfigureAwait(false);
+
+    var taskData = await tasksClient.GetTaskAsync(new GetTaskRequest
+                                                  {
+                                                    TaskId = tasks.TaskInfos.Single()
+                                                                  .TaskId,
+                                                  })
+                                    .ConfigureAwait(false);
+
+    Assert.Contains(taskData.Task.Status,
+                    new List<TaskStatus>
+                    {
+                      TaskStatus.Completed,
+                      TaskStatus.Submitted,
+                      TaskStatus.Dispatched,
+                      TaskStatus.Processing,
+                    });
+
+    await submitterClient.WaitForAvailabilityAsync(new ResultRequest
+                                                   {
+                                                     ResultId = results.Results.Single()
+                                                                       .ResultId,
+                                                     Session = createSessionReply.SessionId,
+                                                   })
+                         .ConfigureAwait(false);
+
+    taskData = await tasksClient.GetTaskAsync(new GetTaskRequest
+                                              {
+                                                TaskId = tasks.TaskInfos.Single()
+                                                              .TaskId,
+                                              })
+                                .ConfigureAwait(false);
+
+    Assert.AreEqual(TaskStatus.Completed,
+                    taskData.Task.Status);
+
+    var data = await resultsClient.DownloadResultData(createSessionReply.SessionId,
+                                                      results.Results.Single()
+                                                             .ResultId,
+                                                      CancellationToken.None)
+                                  .ConfigureAwait(false);
+
+    Assert.AreEqual(9,
+                    BitConverter.ToInt32(TestPayload.Deserialize(data)
+                                                    ?.DataBytes));
+  }
+}

--- a/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
+++ b/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-3814g80ad90e.4.80ad90e" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-SNAPSHOT.14.74bbbc4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- [x] refactor task creation to extract common code that will be used in both submission ways (task and payload together vs task and payload separately)
- [x] refactor task options conversion between storage and gRPC API version to properly manage nullables
- [x] implement new rpc method to create tasks and payloads separately
- [ ] use the new methods in our bench to validate their implementation (todo in another pr)
- [x] tests new methods in IAgent interface
- [x] tests new methods in IResultTable interface