### PR TITLE
perf: improve mongodb requests using native mongodb find instead of linq queries

### DIFF
--- a/Adaptors/MongoDB/src/IMongoQueryableExt.cs
+++ b/Adaptors/MongoDB/src/IMongoQueryableExt.cs
@@ -46,11 +46,11 @@ internal static class IMongoQueryableExt
   }
 
 
-  public static async IAsyncEnumerable<U> ToAsyncEnumerable<T,U>(this                     IFindFluent<T, U>    queryable,
-                                                               [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  public static async IAsyncEnumerable<U> ToAsyncEnumerable<T, U>(this                     IFindFluent<T, U> findFluent,
+                                                                  [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
-    var cursor = await queryable.ToCursorAsync(cancellationToken)
-                                .ConfigureAwait(false);
+    var cursor = await findFluent.ToCursorAsync(cancellationToken)
+                                 .ConfigureAwait(false);
     while (await cursor.MoveNextAsync(cancellationToken)
                        .ConfigureAwait(false))
     {

--- a/Adaptors/MongoDB/src/IMongoQueryableExt.cs
+++ b/Adaptors/MongoDB/src/IMongoQueryableExt.cs
@@ -22,6 +22,7 @@ using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
+using MongoDB.Driver;
 using MongoDB.Driver.Linq;
 
 namespace ArmoniK.Core.Adapters.MongoDB;
@@ -43,6 +44,24 @@ internal static class IMongoQueryableExt
       }
     }
   }
+
+
+  public static async IAsyncEnumerable<U> ToAsyncEnumerable<T,U>(this                     IFindFluent<T, U>    queryable,
+                                                               [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    var cursor = await queryable.ToCursorAsync(cancellationToken)
+                                .ConfigureAwait(false);
+    while (await cursor.MoveNextAsync(cancellationToken)
+                       .ConfigureAwait(false))
+    {
+      foreach (var item in cursor.Current)
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return item;
+      }
+    }
+  }
+
 
   public static IOrderedMongoQueryable<T> OrderByList<T>(this IMongoQueryable<T>                   queryable,
                                                          ICollection<Expression<Func<T, object?>>> orderFields,

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -416,7 +416,7 @@ public class ResultTable : IResultTable
 
     await foreach (var result in resultCollection.Find(model => model.SessionId == sessionId)
                                                  .Project(model => model.ResultId)
-                                                 .ToAsyncEnumerable()
+                                                 .ToAsyncEnumerable(cancellationToken)
                                                  .WithCancellation(cancellationToken)
                                                  .ConfigureAwait(false))
     {

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -414,9 +414,8 @@ public class ResultTable : IResultTable
     var sessionHandle    = sessionProvider_.Get();
     var resultCollection = resultCollectionProvider_.Get();
 
-    await foreach (var result in resultCollection.AsQueryable(sessionHandle)
-                                                 .Where(model => model.SessionId == sessionId)
-                                                 .Select(model => model.ResultId)
+    await foreach (var result in resultCollection.Find(model => model.SessionId == sessionId)
+                                                 .Project(model => model.ResultId)
                                                  .ToAsyncEnumerable()
                                                  .WithCancellation(cancellationToken)
                                                  .ConfigureAwait(false))

--- a/Adaptors/MongoDB/src/SessionTable.cs
+++ b/Adaptors/MongoDB/src/SessionTable.cs
@@ -105,9 +105,8 @@ public class SessionTable : ISessionTable
 
     try
     {
-      return await sessionCollection.AsQueryable(sessionHandle)
-                                    .Where(sdm => sdm.SessionId == sessionId)
-                                    .SingleAsync(cancellationToken)
+      return await sessionCollection.Find(session => session.SessionId == sessionId)
+                                    .SingleAsync()
                                     .ConfigureAwait(false);
     }
     catch (InvalidOperationException e)

--- a/Adaptors/MongoDB/src/SessionTable.cs
+++ b/Adaptors/MongoDB/src/SessionTable.cs
@@ -106,7 +106,7 @@ public class SessionTable : ISessionTable
     try
     {
       return await sessionCollection.Find(session => session.SessionId == sessionId)
-                                    .SingleAsync()
+                                    .SingleAsync(cancellationToken)
                                     .ConfigureAwait(false);
     }
     catch (InvalidOperationException e)
@@ -143,9 +143,8 @@ public class SessionTable : ISessionTable
 
     try
     {
-      return await sessionCollection.AsQueryable(sessionHandle)
-                                    .Where(sdm => sdm.SessionId == sessionId)
-                                    .Select(sdm => sdm.Options)
+      return await sessionCollection.Find(sdm => sdm.SessionId == sessionId)
+                                    .Project(sdm => sdm.Options)
                                     .SingleAsync(cancellationToken)
                                     .ConfigureAwait(false);
     }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -94,8 +94,7 @@ public class TaskTable : ITaskTable
 
     try
     {
-      return await taskCollection.AsQueryable(sessionHandle)
-                                 .Where(tdm => tdm.TaskId == taskId)
+      return await taskCollection.Find(tdm => tdm.TaskId == taskId)
                                  .SingleAsync(cancellationToken)
                                  .ConfigureAwait(false);
     }
@@ -179,9 +178,8 @@ public class TaskTable : ITaskTable
 
     try
     {
-      return await taskCollection.AsQueryable(sessionHandle)
-                                 .Where(model => model.TaskId == taskId)
-                                 .Select(model => model.Status == TaskStatus.Cancelled || model.Status == TaskStatus.Cancelling)
+      return await taskCollection.Find(model => model.TaskId == taskId)
+                                 .Project(model => model.Status == TaskStatus.Cancelled || model.Status == TaskStatus.Cancelling)
                                  .SingleAsync(cancellationToken)
                                  .ConfigureAwait(false);
     }
@@ -795,9 +793,8 @@ public class TaskTable : ITaskTable
 
     try
     {
-      return await taskCollection.AsQueryable(sessionHandle)
-                                 .Where(tdm => tdm.TaskId == taskId)
-                                 .Select(model => model.ExpectedOutputIds)
+      return await taskCollection.Find(tdm => tdm.TaskId == taskId)
+                                 .Project(model => model.ExpectedOutputIds)
                                  .SingleAsync(cancellationToken)
                                  .ConfigureAwait(false);
     }
@@ -818,9 +815,8 @@ public class TaskTable : ITaskTable
 
     try
     {
-      return await taskCollection.AsQueryable(sessionHandle)
-                                 .Where(tdm => tdm.TaskId == taskId)
-                                 .Select(model => model.ParentTaskIds)
+      return await taskCollection.Find(tdm => tdm.TaskId == taskId)
+                                 .Project(model => model.ParentTaskIds)
                                  .SingleAsync(cancellationToken)
                                  .ConfigureAwait(false);
     }


### PR DESCRIPTION
[retlated CR](https://github.com/aneoconsulting/ArmoniK/issues/1057)
idea here is to use dottrace to check if we can improve mongo db requests

basically we can replace :
```
AsQueryable(sessionHandle).Where(sdm => sdm.SessionId == sessionId)
```
by :
`.Find(session => session.SessionId == sessionId)
`

You can notice 2x to 3x perfs in the mongoDB calls :
![image](https://user-images.githubusercontent.com/113617172/236185531-e4492db4-21f8-44f8-a9e8-ed25180cc0a9.png)

we are always performing the same requests with different parameters so :
=> I think further improvements may be to use directly mongo syntax with prebuilt requests
=> seems ugly ok but it could be good to check perf diff with this
