### PR TITLE
ci: build arm images on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -251,6 +251,7 @@ jobs:
       run: docker push ${{ matrix.img }}:$VERSION
 
   buildImagesCross:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs:
       - versionning


### PR DESCRIPTION
Building ARM images is taking a lot of time during our regular runs so this PR changes when they are built. They will be built on main.
