### PR TITLE
feat: update to new sorting messages from API

### DIFF
--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -326,12 +326,12 @@ public class TaskTable : ITaskTable
   }
 
   /// <inheritdoc />
-  public Task<(IEnumerable<TaskData> tasks, int totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
-                                                                            Expression<Func<TaskData, object?>> orderField,
-                                                                            bool                                ascOrder,
-                                                                            int                                 page,
-                                                                            int                                 pageSize,
-                                                                            CancellationToken                   cancellationToken = default)
+  public Task<(IEnumerable<TaskData> tasks, long totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
+                                                                             Expression<Func<TaskData, object?>> orderField,
+                                                                             bool                                ascOrder,
+                                                                             int                                 page,
+                                                                             int                                 pageSize,
+                                                                             CancellationToken                   cancellationToken = default)
   {
     var queryable = taskId2TaskData_.AsQueryable()
                                     .Select(pair => pair.Value)
@@ -341,8 +341,8 @@ public class TaskTable : ITaskTable
                     ? queryable.OrderBy(orderField)
                     : queryable.OrderByDescending(orderField);
 
-    return Task.FromResult<(IEnumerable<TaskData> tasks, int totalCount)>((ordered.Skip(page * pageSize)
-                                                                                  .Take(pageSize), ordered.Count()));
+    return Task.FromResult<(IEnumerable<TaskData> tasks, long totalCount)>((ordered.Skip(page * pageSize)
+                                                                                   .Take(pageSize), ordered.Count()));
   }
 
   /// <inheritdoc />

--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -26,7 +26,7 @@
 
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Core" Version="3.9.0-edge.60.de40d5c" />
+    <PackageReference Include="ArmoniK.Api.Core" Version="3.9.0-edge.89.b9b77a3" />
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.2.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.50.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -225,18 +225,18 @@ public interface ITaskTable : IInitializable
   /// <param name="filter">Filter to select tasks</param>
   /// <param name="orderField">Select the field that will be used to order the tasks</param>
   /// <param name="ascOrder">Is the order ascending</param>
-  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <param name="page">The page of results to retrieve</param>
   /// <param name="pageSize">The number of results pages</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
   ///   Collection of task metadata matching the request and total number of results without paging
   /// </returns>
-  Task<(IEnumerable<TaskData> tasks, int totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
-                                                                     Expression<Func<TaskData, object?>> orderField,
-                                                                     bool                                ascOrder,
-                                                                     int                                 page,
-                                                                     int                                 pageSize,
-                                                                     CancellationToken                   cancellationToken = default);
+  Task<(IEnumerable<TaskData> tasks, long totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
+                                                                      Expression<Func<TaskData, object?>> orderField,
+                                                                      bool                                ascOrder,
+                                                                      int                                 page,
+                                                                      int                                 pageSize,
+                                                                      CancellationToken                   cancellationToken = default);
 
   /// <summary>
   ///   Find all tasks matching the given filter and ordering

--- a/Common/src/gRPC/ListApplicationsRequestExt.cs
+++ b/Common/src/gRPC/ListApplicationsRequestExt.cs
@@ -27,23 +27,22 @@ namespace ArmoniK.Core.Common.gRPC;
 
 public static class ListApplicationsRequestExt
 {
-  public static Expression<Func<Application, object?>> ToApplicationField(this ListApplicationsRequest.Types.OrderByField field)
+  public static Expression<Func<Application, object?>> ToApplicationField(this ApplicationField field)
   {
-    switch (field)
+    switch (field.FieldCase)
     {
-      case ListApplicationsRequest.Types.OrderByField.Name:
-        return taskData => taskData.Name;
+      case ApplicationField.FieldOneofCase.ApplicationField_:
+        return field.ApplicationField_ switch
+               {
+                 ApplicationRawField.Name        => taskData => taskData.Name,
+                 ApplicationRawField.Version     => taskData => taskData.Version,
+                 ApplicationRawField.Namespace   => taskData => taskData.Namespace,
+                 ApplicationRawField.Service     => taskData => taskData.Service,
+                 ApplicationRawField.Unspecified => throw new ArgumentOutOfRangeException(),
+                 _                               => throw new ArgumentOutOfRangeException(),
+               };
 
-      case ListApplicationsRequest.Types.OrderByField.Version:
-        return taskData => taskData.Version;
-
-      case ListApplicationsRequest.Types.OrderByField.Namespace:
-        return taskData => taskData.Namespace;
-
-      case ListApplicationsRequest.Types.OrderByField.Service:
-        return taskData => taskData.Service;
-
-      case ListApplicationsRequest.Types.OrderByField.Unspecified:
+      case ApplicationField.FieldOneofCase.None:
       default:
         throw new ArgumentOutOfRangeException();
     }

--- a/Common/src/gRPC/ListPartitionsRequestExt.cs
+++ b/Common/src/gRPC/ListPartitionsRequestExt.cs
@@ -30,27 +30,22 @@ public static class ListPartitionsRequestExt
 {
   public static Expression<Func<PartitionData, object?>> ToPartitionField(this ListPartitionsRequest.Types.Sort sort)
   {
-    switch (sort.Field)
+    switch (sort.Field.FieldCase)
     {
-      case ListPartitionsRequest.Types.OrderByField.Id:
-        return partitionData => partitionData.PartitionId;
+      case PartitionField.FieldOneofCase.PartitionRawField:
+        return sort.Field.PartitionRawField switch
+               {
+                 PartitionRawField.Id                   => partitionData => partitionData.PartitionId,
+                 PartitionRawField.ParentPartitionIds   => partitionData => partitionData.ParentPartitionIds,
+                 PartitionRawField.PodReserved          => partitionData => partitionData.PodReserved,
+                 PartitionRawField.PodMax               => partitionData => partitionData.PodMax,
+                 PartitionRawField.PreemptionPercentage => partitionData => partitionData.PreemptionPercentage,
+                 PartitionRawField.Priority             => partitionData => partitionData.Priority,
+                 PartitionRawField.Unspecified          => throw new ArgumentOutOfRangeException(),
+                 _                                      => throw new ArgumentOutOfRangeException(),
+               };
 
-      case ListPartitionsRequest.Types.OrderByField.ParentPartitionIds:
-        return partitionData => partitionData.ParentPartitionIds;
-
-      case ListPartitionsRequest.Types.OrderByField.PodReserved:
-        return partitionData => partitionData.PodReserved;
-
-      case ListPartitionsRequest.Types.OrderByField.PodMax:
-        return partitionData => partitionData.PodMax;
-
-      case ListPartitionsRequest.Types.OrderByField.PreemptionPercentage:
-        return partitionData => partitionData.PreemptionPercentage;
-
-      case ListPartitionsRequest.Types.OrderByField.Priority:
-        return partitionData => partitionData.Priority;
-
-      case ListPartitionsRequest.Types.OrderByField.Unspecified:
+      case PartitionField.FieldOneofCase.None:
       default:
         throw new ArgumentOutOfRangeException();
     }

--- a/Common/src/gRPC/ListResultsRequestExt.cs
+++ b/Common/src/gRPC/ListResultsRequestExt.cs
@@ -30,26 +30,24 @@ public static class ListResultsRequestExt
 {
   public static Expression<Func<Result, object?>> ToResultField(this ListResultsRequest.Types.Sort sort)
   {
-    switch (sort.Field)
+    switch (sort.Field.FieldCase)
     {
-      case ListResultsRequest.Types.OrderByField.SessionId:
-        return result => result.SessionId;
-
-      case ListResultsRequest.Types.OrderByField.Name:
-        return result => result.Name;
-
-      case ListResultsRequest.Types.OrderByField.OwnerTaskId:
-        return result => result.OwnerTaskId;
-
-      case ListResultsRequest.Types.OrderByField.Status:
-        return result => result.Status;
-
-      case ListResultsRequest.Types.OrderByField.CreatedAt:
-        return result => result.CreationDate;
-
-      case ListResultsRequest.Types.OrderByField.Unspecified:
+      case ResultField.FieldOneofCase.ResultRawField:
+        return sort.Field.ResultRawField switch
+               {
+                 ResultRawField.SessionId   => result => result.SessionId,
+                 ResultRawField.Name        => result => result.Name,
+                 ResultRawField.OwnerTaskId => result => result.OwnerTaskId,
+                 ResultRawField.Status      => result => result.Status,
+                 ResultRawField.CreatedAt   => result => result.CreationDate,
+                 ResultRawField.ResultId    => result => result.ResultId,
+                 ResultRawField.CompletedAt => throw new ArgumentOutOfRangeException(),
+                 ResultRawField.Unspecified => throw new ArgumentOutOfRangeException(),
+                 _                          => throw new ArgumentOutOfRangeException(),
+               };
+      case ResultField.FieldOneofCase.None:
       default:
-        throw new InvalidOperationException();
+        throw new ArgumentOutOfRangeException();
     }
   }
 

--- a/Common/src/gRPC/ListSessionsRequestExt.cs
+++ b/Common/src/gRPC/ListSessionsRequestExt.cs
@@ -30,23 +30,24 @@ public static class ListSessionsRequestExt
 {
   public static Expression<Func<SessionData, object?>> ToSessionDataField(this ListSessionsRequest.Types.Sort sort)
   {
-    switch (sort.Field)
+    switch (sort.Field.FieldCase)
     {
-      case ListSessionsRequest.Types.OrderByField.SessionId:
-        return session => session.SessionId;
-
-      case ListSessionsRequest.Types.OrderByField.Status:
-        return session => session.Status;
-
-      case ListSessionsRequest.Types.OrderByField.CreatedAt:
-        return session => session.CreationDate;
-
-      case ListSessionsRequest.Types.OrderByField.CancelledAt:
-        return session => session.CancellationDate;
-
-      case ListSessionsRequest.Types.OrderByField.Unspecified:
+      case SessionField.FieldOneofCase.SessionRawField:
+        return sort.Field.SessionRawField switch
+               {
+                 SessionRawField.SessionId    => session => session.SessionId,
+                 SessionRawField.Status       => session => session.Status,
+                 SessionRawField.PartitionIds => session => session.PartitionIds,
+                 SessionRawField.Options      => session => session.Options,
+                 SessionRawField.CreatedAt    => session => session.CreationDate,
+                 SessionRawField.CancelledAt  => session => session.CancellationDate,
+                 SessionRawField.Duration     => throw new ArgumentOutOfRangeException(),
+                 SessionRawField.Unspecified  => throw new ArgumentOutOfRangeException(),
+                 _                            => throw new ArgumentOutOfRangeException(),
+               };
+      case SessionField.FieldOneofCase.None:
       default:
-        throw new InvalidOperationException();
+        throw new ArgumentOutOfRangeException();
     }
   }
 

--- a/Common/src/gRPC/ListTasksRequestExt.cs
+++ b/Common/src/gRPC/ListTasksRequestExt.cs
@@ -30,29 +30,50 @@ public static class ListTasksRequestExt
 {
   public static Expression<Func<TaskData, object?>> ToTaskDataField(this ListTasksRequest.Types.Sort sort)
   {
-    switch (sort.Field)
+    switch (sort.Field.FieldCase)
     {
-      case ListTasksRequest.Types.OrderByField.TaskId:
-        return data => data.TaskId;
-
-      case ListTasksRequest.Types.OrderByField.SessionId:
-        return data => data.SessionId;
-
-      case ListTasksRequest.Types.OrderByField.Status:
-        return data => data.Status;
-
-      case ListTasksRequest.Types.OrderByField.CreatedAt:
-        return data => data.CreationDate;
-
-      case ListTasksRequest.Types.OrderByField.StartedAt:
-        return data => data.StartDate;
-
-      case ListTasksRequest.Types.OrderByField.EndedAt:
-        return data => data.EndDate;
-
-      case ListTasksRequest.Types.OrderByField.Unspecified:
+      case TaskField.FieldOneofCase.TaskSummaryField:
+        return sort.Field.TaskSummaryField switch
+               {
+                 TaskSummaryField.TaskId                  => data => data.TaskId,
+                 TaskSummaryField.SessionId               => data => data.SessionId,
+                 TaskSummaryField.OwnerPodId              => data => data.OwnerPodId,
+                 TaskSummaryField.InitialTaskId           => data => data.InitialTaskId,
+                 TaskSummaryField.Status                  => data => data.Status,
+                 TaskSummaryField.CreatedAt               => data => data.CreationDate,
+                 TaskSummaryField.SubmittedAt             => data => data.SubmittedDate,
+                 TaskSummaryField.StartedAt               => data => data.StartDate,
+                 TaskSummaryField.EndedAt                 => data => data.EndDate,
+                 TaskSummaryField.CreationToEndDuration   => data => data.CreationToEndDuration,
+                 TaskSummaryField.ProcessingToEndDuration => data => data.ProcessingToEndDuration,
+                 TaskSummaryField.PodTtl                  => data => data.PodTtl,
+                 TaskSummaryField.PodHostname             => data => data.OwnerPodName,
+                 TaskSummaryField.ReceivedAt              => data => data.ReceptionDate,
+                 TaskSummaryField.AcquiredAt              => data => data.AcquisitionDate,
+                 TaskSummaryField.Error                   => data => data.Output.Error,
+                 TaskSummaryField.Unspecified             => throw new ArgumentOutOfRangeException(),
+                 _                                        => throw new ArgumentOutOfRangeException(),
+               };
+      case TaskField.FieldOneofCase.TaskOptionField:
+        return sort.Field.TaskOptionField switch
+               {
+                 TaskOptionField.MaxDuration          => data => data.Options.MaxDuration,
+                 TaskOptionField.MaxRetries           => data => data.Options.MaxRetries,
+                 TaskOptionField.Priority             => data => data.Options.Priority,
+                 TaskOptionField.PartitionId          => data => data.Options.PartitionId,
+                 TaskOptionField.ApplicationName      => data => data.Options.ApplicationName,
+                 TaskOptionField.ApplicationVersion   => data => data.Options.ApplicationVersion,
+                 TaskOptionField.ApplicationNamespace => data => data.Options.ApplicationNamespace,
+                 TaskOptionField.ApplicationService   => data => data.Options.ApplicationService,
+                 TaskOptionField.EngineType           => data => data.Options.EngineType,
+                 TaskOptionField.Unspecified          => throw new ArgumentOutOfRangeException(),
+                 _                                    => throw new ArgumentOutOfRangeException(),
+               };
+      case TaskField.FieldOneofCase.TaskOptionGenericField:
+        return data => data.Options.Options[sort.Field.TaskOptionGenericField.Field];
+      case TaskField.FieldOneofCase.None:
       default:
-        throw new InvalidOperationException();
+        throw new ArgumentOutOfRangeException();
     }
   }
 

--- a/Common/src/gRPC/Services/GrpcApplicationsService.cs
+++ b/Common/src/gRPC/Services/GrpcApplicationsService.cs
@@ -21,6 +21,9 @@ using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Applications;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
 using ArmoniK.Core.Common.Exceptions;
@@ -54,7 +57,7 @@ public class GrpcApplicationsService : Applications.ApplicationsBase
     var tasks = await taskTable_.ListApplicationsAsync(request.Filter.ToApplicationFilter(),
                                                        request.Sort.Fields.Select(field => field.ToApplicationField())
                                                               .ToList(),
-                                                       request.Sort.Direction == ListApplicationsRequest.Types.OrderDirection.Asc,
+                                                       request.Sort.Direction == SortDirection.Asc,
                                                        request.Page,
                                                        request.PageSize,
                                                        context.CancellationToken)

--- a/Common/src/gRPC/Services/GrpcPartitionsService.cs
+++ b/Common/src/gRPC/Services/GrpcPartitionsService.cs
@@ -20,6 +20,7 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using Armonik.Api.Grpc.V1.Partitions;
+using Armonik.Api.Grpc.V1.SortDirection;
 
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
@@ -82,7 +83,7 @@ public class GrpcPartitionsService : Partitions.PartitionsBase
   {
     var partitions = await partitionTable_.ListPartitionsAsync(request.Filter.ToPartitionFilter(),
                                                                request.Sort.ToPartitionField(),
-                                                               request.Sort.Direction == ListPartitionsRequest.Types.OrderDirection.Asc,
+                                                               request.Sort.Direction == SortDirection.Asc,
                                                                request.Page,
                                                                request.PageSize,
                                                                context.CancellationToken)

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -23,6 +23,9 @@ using System.Threading.Tasks;
 using ArmoniK.Api.Common.Utils;
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Results;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
 using ArmoniK.Core.Common.Storage;
@@ -86,7 +89,7 @@ public class GrpcResultsService : Results.ResultsBase
   {
     var results = await resultTable_.ListResultsAsync(request.Filter.ToResultFilter(),
                                                       request.Sort.ToResultField(),
-                                                      request.Sort.Direction == ListResultsRequest.Types.OrderDirection.Asc,
+                                                      request.Sort.Direction == SortDirection.Asc,
                                                       request.Page,
                                                       request.PageSize,
                                                       context.CancellationToken)

--- a/Common/src/gRPC/Services/GrpcSessionsService.cs
+++ b/Common/src/gRPC/Services/GrpcSessionsService.cs
@@ -21,6 +21,9 @@ using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Sessions;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
 using ArmoniK.Core.Common.Exceptions;
@@ -132,7 +135,7 @@ public class GrpcSessionsService : Sessions.SessionsBase
     {
       var sessionData = await sessionTable_.ListSessionsAsync(request.Filter.ToSessionDataFilter(),
                                                               request.Sort.ToSessionDataField(),
-                                                              request.Sort.Direction == ListSessionsRequest.Types.OrderDirection.Asc,
+                                                              request.Sort.Direction == SortDirection.Asc,
                                                               request.Page,
                                                               request.PageSize,
                                                               context.CancellationToken)

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -20,6 +20,9 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Auth.Authentication;
@@ -105,7 +108,7 @@ public class GrpcTasksService : Task.TasksBase
     {
       var taskData = await taskTable_.ListTasksAsync(request.Filter.ToTaskDataFilter(),
                                                      request.Sort.ToTaskDataField(),
-                                                     request.Sort.Direction == ListTasksRequest.Types.OrderDirection.Asc,
+                                                     request.Sort.Direction == SortDirection.Asc,
                                                      request.Page,
                                                      request.PageSize,
                                                      context.CancellationToken)
@@ -119,7 +122,7 @@ public class GrpcTasksService : Task.TasksBase
                {
                  taskData.tasks.Select(data => new TaskSummary(data)),
                },
-               Total = taskData.totalCount,
+               Total = (int)taskData.totalCount,
              };
     }
     catch (ArmoniKException e)
@@ -259,7 +262,7 @@ public class GrpcTasksService : Task.TasksBase
     {
       var taskData = await taskTable_.ListTasksAsync(request.Filter.ToTaskDataFilter(),
                                                      request.Sort.ToTaskDataField(),
-                                                     request.Sort.Direction == ListTasksRequest.Types.OrderDirection.Asc,
+                                                     request.Sort.Direction == SortDirection.Asc,
                                                      request.Page,
                                                      request.PageSize,
                                                      context.CancellationToken)
@@ -273,7 +276,7 @@ public class GrpcTasksService : Task.TasksBase
                {
                  taskData.tasks.Select(data => new TaskRaw(data)),
                },
-               Total = taskData.totalCount,
+               Total = (int)taskData.totalCount,
              };
     }
     catch (ArmoniKException e)

--- a/Common/src/gRPC/Services/WatchToGrpc.cs
+++ b/Common/src/gRPC/Services/WatchToGrpc.cs
@@ -77,9 +77,9 @@ public class WatchToGrpc
 
     Task.Factory.StartNew(async () =>
                           {
-                            var                                           read = 0;
-                            var                                           page = 0;
-                            (IEnumerable<TaskData> tasks, int totalCount) res;
+                            var                                            read = 0;
+                            var                                            page = 0;
+                            (IEnumerable<TaskData> tasks, long totalCount) res;
                             while ((res = await taskTable_.ListTasksAsync(data => data.SessionId == sessionId,
                                                                           data => data.CreationDate,
                                                                           false,

--- a/Common/tests/Auth/AuthenticationIntegrationTest.cs
+++ b/Common/tests/Auth/AuthenticationIntegrationTest.cs
@@ -34,6 +34,9 @@ using Armonik.Api.Grpc.V1.Partitions;
 
 using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.Sessions;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
@@ -272,8 +275,11 @@ public class AuthenticationIntegrationTest
                             PageSize = 10,
                             Sort = new ListSessionsRequest.Types.Sort
                                    {
-                                     Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                                     Field     = ListSessionsRequest.Types.OrderByField.SessionId,
+                                     Direction = SortDirection.Asc,
+                                     Field = new SessionField
+                                             {
+                                               SessionRawField = SessionRawField.SessionId,
+                                             },
                                    },
                           };
 
@@ -293,8 +299,11 @@ public class AuthenticationIntegrationTest
                          PageSize = 10,
                          Sort = new ListTasksRequest.Types.Sort
                                 {
-                                  Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                                  Field     = ListTasksRequest.Types.OrderByField.SessionId,
+                                  Direction = SortDirection.Asc,
+                                  Field = new TaskField
+                                          {
+                                            TaskSummaryField = TaskSummaryField.SessionId,
+                                          },
                                 },
                        };
     GetOwnerTaskIdRequest = new GetOwnerTaskIdRequest
@@ -313,10 +322,13 @@ public class AuthenticationIntegrationTest
                                 PageSize = 10,
                                 Sort = new ListApplicationsRequest.Types.Sort
                                        {
-                                         Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
+                                         Direction = SortDirection.Asc,
                                          Fields =
                                          {
-                                           ListApplicationsRequest.Types.OrderByField.Name,
+                                           new ApplicationField
+                                           {
+                                             ApplicationField_ = ApplicationRawField.Name,
+                                           },
                                          },
                                        },
                               };
@@ -334,8 +346,11 @@ public class AuthenticationIntegrationTest
                            PageSize = 10,
                            Sort = new ListResultsRequest.Types.Sort
                                   {
-                                    Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                                    Field     = ListResultsRequest.Types.OrderByField.Name,
+                                    Direction = SortDirection.Asc,
+                                    Field = new ResultField
+                                            {
+                                              ResultRawField = ResultRawField.Name,
+                                            },
                                   },
                          };
     GetCurrentUserRequest = new GetCurrentUserRequest();
@@ -353,8 +368,11 @@ public class AuthenticationIntegrationTest
                                        },
                               Sort = new ListPartitionsRequest.Types.Sort
                                      {
-                                       Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                                       Field     = ListPartitionsRequest.Types.OrderByField.Id,
+                                       Direction = SortDirection.Asc,
+                                       Field = new PartitionField
+                                               {
+                                                 PartitionRawField = PartitionRawField.Id,
+                                               },
                                      },
                               PageSize = 10,
                               Page     = 0,

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -169,31 +169,31 @@ public class SimpleTaskTable : ITaskTable
          TaskId,
        }.ToAsyncEnumerable();
 
-  public Task<(IEnumerable<TaskData> tasks, int totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
-                                                                            Expression<Func<TaskData, object?>> orderField,
-                                                                            bool                                ascOrder,
-                                                                            int                                 page,
-                                                                            int                                 pageSize,
-                                                                            CancellationToken                   cancellationToken = default)
-    => Task.FromResult<(IEnumerable<TaskData> tasks, int totalCount)>((new[]
-                                                                       {
-                                                                         new TaskData(SessionId,
-                                                                                      TaskId,
-                                                                                      OwnerPodId,
-                                                                                      PodName,
-                                                                                      PayloadId,
-                                                                                      new List<string>(),
-                                                                                      new List<string>(),
-                                                                                      new List<string>
-                                                                                      {
-                                                                                        OutputId,
-                                                                                      },
-                                                                                      new List<string>(),
-                                                                                      TaskStatus.Completed,
-                                                                                      TaskOptions,
-                                                                                      new Output(true,
-                                                                                                 "")),
-                                                                       }, 1));
+  public Task<(IEnumerable<TaskData> tasks, long totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
+                                                                             Expression<Func<TaskData, object?>> orderField,
+                                                                             bool                                ascOrder,
+                                                                             int                                 page,
+                                                                             int                                 pageSize,
+                                                                             CancellationToken                   cancellationToken = default)
+    => Task.FromResult<(IEnumerable<TaskData> tasks, long totalCount)>((new[]
+                                                                        {
+                                                                          new TaskData(SessionId,
+                                                                                       TaskId,
+                                                                                       OwnerPodId,
+                                                                                       PodName,
+                                                                                       PayloadId,
+                                                                                       new List<string>(),
+                                                                                       new List<string>(),
+                                                                                       new List<string>
+                                                                                       {
+                                                                                         OutputId,
+                                                                                       },
+                                                                                       new List<string>(),
+                                                                                       TaskStatus.Completed,
+                                                                                       TaskOptions,
+                                                                                       new Output(true,
+                                                                                                  "")),
+                                                                        }, 1));
 
   public Task<IEnumerable<T>> FindTasksAsync<T>(Expression<Func<TaskData, bool>> filter,
                                                 Expression<Func<TaskData, T>>    selector,

--- a/Common/tests/ListApplicationsRequestExt/ToApplicationFieldTest.cs
+++ b/Common/tests/ListApplicationsRequestExt/ToApplicationFieldTest.cs
@@ -21,6 +21,9 @@ using System.Linq;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Applications;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
 
@@ -74,30 +77,27 @@ public class ToApplicationFieldTest
                                                        ""));
 
 
-  [Test]
-  public void InvokeShouldReturnName()
+  public static IEnumerable<TestCaseData> TestCasesInvoke()
   {
-    var func = new ListApplicationsRequest
-               {
-                 Filter = new ListApplicationsRequest.Types.Filter(),
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.Fields.Single()
-                .ToApplicationField()
-                .Compile();
+    TestCaseData Case(ApplicationRawField field,
+                      object?             expected)
+      => new TestCaseData(field,
+                          expected).SetArgDisplayNames(field.ToString());
 
-    Assert.AreEqual(Options.ApplicationName,
-                    func.Invoke(taskData_));
+    yield return Case(ApplicationRawField.Service,
+                      Options.ApplicationService);
+    yield return Case(ApplicationRawField.Name,
+                      Options.ApplicationName);
+    yield return Case(ApplicationRawField.Namespace,
+                      Options.ApplicationNamespace);
+    yield return Case(ApplicationRawField.Version,
+                      Options.ApplicationVersion);
   }
 
   [Test]
-  public void InvokeShouldReturnNamespace()
+  [TestCaseSource(nameof(TestCasesInvoke))]
+  public void InvokeShouldReturnExpectedValue(ApplicationRawField field,
+                                              object?             expected)
   {
     var func = new ListApplicationsRequest
                {
@@ -106,59 +106,18 @@ public class ToApplicationFieldTest
                         {
                           Fields =
                           {
-                            ListApplicationsRequest.Types.OrderByField.Namespace,
+                            new ApplicationField
+                            {
+                              ApplicationField_ = field,
+                            },
                           },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
+                          Direction = SortDirection.Asc,
                         },
                }.Sort.Fields.Single()
                 .ToApplicationField()
                 .Compile();
 
-    Assert.AreEqual(Options.ApplicationNamespace,
-                    func.Invoke(taskData_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnVersion()
-  {
-    var func = new ListApplicationsRequest
-               {
-                 Filter = new ListApplicationsRequest.Types.Filter(),
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Version,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.Fields.Single()
-                .ToApplicationField()
-                .Compile();
-
-    Assert.AreEqual(Options.ApplicationVersion,
-                    func.Invoke(taskData_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnService()
-  {
-    var func = new ListApplicationsRequest
-               {
-                 Filter = new ListApplicationsRequest.Types.Filter(),
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Service,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.Fields.Single()
-                .ToApplicationField()
-                .Compile();
-
-    Assert.AreEqual(Options.ApplicationService,
+    Assert.AreEqual(expected,
                     func.Invoke(taskData_));
   }
 
@@ -172,10 +131,16 @@ public class ToApplicationFieldTest
                          {
                            Fields =
                            {
-                             ListApplicationsRequest.Types.OrderByField.Service,
-                             ListApplicationsRequest.Types.OrderByField.Name,
+                             new ApplicationField
+                             {
+                               ApplicationField_ = ApplicationRawField.Service,
+                             },
+                             new ApplicationField
+                             {
+                               ApplicationField_ = ApplicationRawField.Name,
+                             },
                            },
-                           Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
+                           Direction = SortDirection.Asc,
                          },
                 }.Sort.Fields;
 

--- a/Common/tests/ListApplicationsRequestExt/ToApplicationFilterTest.cs
+++ b/Common/tests/ListApplicationsRequestExt/ToApplicationFilterTest.cs
@@ -20,6 +20,9 @@ using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Applications;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
 
@@ -72,6 +75,18 @@ public class ToApplicationFilterTest
                                             new Output(true,
                                                        ""));
 
+  private static readonly ListApplicationsRequest.Types.Sort Sort = new()
+                                                                    {
+                                                                      Fields =
+                                                                      {
+                                                                        new ApplicationField
+                                                                        {
+                                                                          ApplicationField_ = ApplicationRawField.Name,
+                                                                        },
+                                                                      },
+                                                                      Direction = SortDirection.Asc,
+                                                                    };
+
   [Test]
   public void FilterNameShouldSucceed()
   {
@@ -81,14 +96,7 @@ public class ToApplicationFilterTest
                           {
                             Name = ApplicationName,
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -104,14 +112,7 @@ public class ToApplicationFilterTest
                           {
                             Name = ApplicationName + "bad",
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -127,14 +128,7 @@ public class ToApplicationFilterTest
                           {
                             Namespace = ApplicationNamespace,
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -150,14 +144,7 @@ public class ToApplicationFilterTest
                           {
                             Namespace = ApplicationNamespace + "bad",
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -173,14 +160,7 @@ public class ToApplicationFilterTest
                           {
                             Version = ApplicationVersion,
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -196,14 +176,7 @@ public class ToApplicationFilterTest
                           {
                             Version = ApplicationVersion + "bad",
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -219,14 +192,7 @@ public class ToApplicationFilterTest
                           {
                             Service = ApplicationService,
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 
@@ -242,14 +208,7 @@ public class ToApplicationFilterTest
                           {
                             Service = ApplicationService + "bad",
                           },
-                 Sort = new ListApplicationsRequest.Types.Sort
-                        {
-                          Fields =
-                          {
-                            ListApplicationsRequest.Types.OrderByField.Name,
-                          },
-                          Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToApplicationFilter()
                 .Compile();
 

--- a/Common/tests/ListPartitionsRequestExt/ToPartitionDataFieldTest.cs
+++ b/Common/tests/ListPartitionsRequestExt/ToPartitionDataFieldTest.cs
@@ -18,6 +18,7 @@
 using System.Collections.Generic;
 
 using Armonik.Api.Grpc.V1.Partitions;
+using Armonik.Api.Grpc.V1.SortDirection;
 
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
@@ -29,40 +30,43 @@ namespace ArmoniK.Core.Common.Tests.ListPartitionsRequestExt;
 [TestFixture(TestOf = typeof(ToPartitionDataFieldTest))]
 public class ToPartitionDataFieldTest
 {
-  private readonly PartitionData partitionData_ = new("PartitionId",
-                                                      new List<string>
-                                                      {
-                                                        "ParentPartitionId",
-                                                      },
-                                                      1,
-                                                      10,
-                                                      15,
-                                                      2,
-                                                      new PodConfiguration(new Dictionary<string, string>()));
+  private static readonly PartitionData PartitionData = new("PartitionId",
+                                                            new List<string>
+                                                            {
+                                                              "ParentPartitionId",
+                                                            },
+                                                            1,
+                                                            10,
+                                                            15,
+                                                            2,
+                                                            new PodConfiguration(new Dictionary<string, string>()));
 
-  [Test]
-  public void InvokeShouldReturnPriority()
+
+  public static IEnumerable<TestCaseData> TestCasesInvoke()
   {
-    var func = new ListPartitionsRequest
-               {
-                 Filter = new ListPartitionsRequest.Types.Filter
-                          {
-                            Id = "PartitionId",
-                          },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Priority,
-                        },
-               }.Sort.ToPartitionField()
-                .Compile();
+    TestCaseData Case(PartitionRawField field,
+                      object?           expected)
+      => new TestCaseData(field,
+                          expected).SetArgDisplayNames(field.ToString());
 
-    Assert.AreEqual(partitionData_.Priority,
-                    func.Invoke(partitionData_));
+    yield return Case(PartitionRawField.ParentPartitionIds,
+                      PartitionData.ParentPartitionIds);
+    yield return Case(PartitionRawField.Id,
+                      PartitionData.PartitionId);
+    yield return Case(PartitionRawField.PodMax,
+                      PartitionData.PodMax);
+    yield return Case(PartitionRawField.PodReserved,
+                      PartitionData.PodReserved);
+    yield return Case(PartitionRawField.Priority,
+                      PartitionData.Priority);
+    yield return Case(PartitionRawField.PreemptionPercentage,
+                      PartitionData.PreemptionPercentage);
   }
 
   [Test]
-  public void InvokeShouldReturnPodMax()
+  [TestCaseSource(nameof(TestCasesInvoke))]
+  public void InvokeShouldReturnExpectedValue(PartitionRawField field,
+                                              object?           expected)
   {
     var func = new ListPartitionsRequest
                {
@@ -72,97 +76,16 @@ public class ToPartitionDataFieldTest
                           },
                  Sort = new ListPartitionsRequest.Types.Sort
                         {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.PodMax,
+                          Direction = SortDirection.Asc,
+                          Field = new PartitionField
+                                  {
+                                    PartitionRawField = field,
+                                  },
                         },
                }.Sort.ToPartitionField()
                 .Compile();
 
-    Assert.AreEqual(partitionData_.PodMax,
-                    func.Invoke(partitionData_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnParentPartitionIds()
-  {
-    var func = new ListPartitionsRequest
-               {
-                 Filter = new ListPartitionsRequest.Types.Filter
-                          {
-                            Id = "PartitionId",
-                          },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.ParentPartitionIds,
-                        },
-               }.Sort.ToPartitionField()
-                .Compile();
-
-    Assert.AreEqual(partitionData_.ParentPartitionIds,
-                    func.Invoke(partitionData_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnParentPodReserved()
-  {
-    var func = new ListPartitionsRequest
-               {
-                 Filter = new ListPartitionsRequest.Types.Filter
-                          {
-                            Id = "PartitionId",
-                          },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.PodReserved,
-                        },
-               }.Sort.ToPartitionField()
-                .Compile();
-
-    Assert.AreEqual(partitionData_.PodReserved,
-                    func.Invoke(partitionData_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnId()
-  {
-    var func = new ListPartitionsRequest
-               {
-                 Filter = new ListPartitionsRequest.Types.Filter
-                          {
-                            Id = "PartitionId",
-                          },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
-               }.Sort.ToPartitionField()
-                .Compile();
-
-    Assert.AreEqual(partitionData_.PartitionId,
-                    func.Invoke(partitionData_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnPreemptionPercentage()
-  {
-    var func = new ListPartitionsRequest
-               {
-                 Filter = new ListPartitionsRequest.Types.Filter
-                          {
-                            Id = "PartitionId",
-                          },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.PreemptionPercentage,
-                        },
-               }.Sort.ToPartitionField()
-                .Compile();
-
-    Assert.AreEqual(partitionData_.PreemptionPercentage,
-                    func.Invoke(partitionData_));
+    Assert.AreEqual(expected,
+                    func.Invoke(PartitionData));
   }
 }

--- a/Common/tests/ListPartitionsRequestExt/ToTaskDataFilterTest.cs
+++ b/Common/tests/ListPartitionsRequestExt/ToTaskDataFilterTest.cs
@@ -18,6 +18,7 @@
 using System.Collections.Generic;
 
 using Armonik.Api.Grpc.V1.Partitions;
+using Armonik.Api.Grpc.V1.SortDirection;
 
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
@@ -41,6 +42,15 @@ public class ToPartitionDataFilterTest
                                                       2,
                                                       new PodConfiguration(new Dictionary<string, string>()));
 
+  private static readonly ListPartitionsRequest.Types.Sort Sort = new()
+                                                                  {
+                                                                    Direction = SortDirection.Asc,
+                                                                    Field = new PartitionField
+                                                                            {
+                                                                              PartitionRawField = PartitionRawField.Id,
+                                                                            },
+                                                                  };
+
   [Test]
   public void FilterIdShouldSucceed()
   {
@@ -50,11 +60,7 @@ public class ToPartitionDataFilterTest
                           {
                             Id = "PartitionId",
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -70,11 +76,7 @@ public class ToPartitionDataFilterTest
                           {
                             Id = "PartitionId",
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -93,11 +95,7 @@ public class ToPartitionDataFilterTest
                           {
                             PodReserved = 1,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -113,11 +111,7 @@ public class ToPartitionDataFilterTest
                           {
                             PodReserved = 1,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -136,11 +130,7 @@ public class ToPartitionDataFilterTest
                           {
                             PodMax = 10,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -156,11 +146,7 @@ public class ToPartitionDataFilterTest
                           {
                             PodMax = 10,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -179,11 +165,7 @@ public class ToPartitionDataFilterTest
                           {
                             PreemptionPercentage = 15,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -199,11 +181,7 @@ public class ToPartitionDataFilterTest
                           {
                             PreemptionPercentage = 15,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -222,11 +200,7 @@ public class ToPartitionDataFilterTest
                           {
                             Priority = 2,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -242,11 +216,7 @@ public class ToPartitionDataFilterTest
                           {
                             Priority = 2,
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -265,11 +235,7 @@ public class ToPartitionDataFilterTest
                           {
                             ParentPartitionId = "ParentPartitionId1",
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 
@@ -285,11 +251,7 @@ public class ToPartitionDataFilterTest
                           {
                             ParentPartitionId = "ParentPartitionId1",
                           },
-                 Sort = new ListPartitionsRequest.Types.Sort
-                        {
-                          Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListPartitionsRequest.Types.OrderByField.Id,
-                        },
+                 Sort = Sort,
                }.Filter.ToPartitionFilter()
                 .Compile();
 

--- a/Common/tests/ListResultsRequestExt/ToResultFieldTest.cs
+++ b/Common/tests/ListResultsRequestExt/ToResultFieldTest.cs
@@ -20,6 +20,9 @@ using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Results;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
 
@@ -30,102 +33,58 @@ namespace ArmoniK.Core.Common.Tests.ListResultsRequestExt;
 [TestFixture(TestOf = typeof(ToResultFieldTest))]
 public class ToResultFieldTest
 {
-  private readonly Result result_ = new("SessionId",
-                                        "ResultId",
-                                        "Name",
-                                        "OwnerTaskId",
-                                        ResultStatus.Created,
-                                        new List<string>(),
-                                        DateTime.UtcNow,
-                                        Array.Empty<byte>());
+  private static readonly Result Result = new("SessionId",
+                                              "ResultId",
+                                              "Name",
+                                              "OwnerTaskId",
+                                              ResultStatus.Created,
+                                              new List<string>(),
+                                              DateTime.UtcNow,
+                                              Array.Empty<byte>());
 
-  [Test]
-  public void InvokeShouldReturnCreationDate()
+  public static IEnumerable<TestCaseData> TestCasesInvoke()
   {
-    var func = new ListResultsRequest
-               {
-                 Filter = new ListResultsRequest.Types.Filter(),
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.ToResultField()
-                .Compile();
+    TestCaseData Case(ResultRawField field,
+                      object?        expected)
+      => new TestCaseData(field,
+                          expected).SetArgDisplayNames(field.ToString());
 
-    Assert.AreEqual(result_.CreationDate,
-                    func.Invoke(result_));
+
+    // TODO add completedDate
+    yield return Case(ResultRawField.Status,
+                      Result.Status);
+    yield return Case(ResultRawField.CreatedAt,
+                      Result.CreationDate);
+    yield return Case(ResultRawField.Name,
+                      Result.Name);
+    yield return Case(ResultRawField.OwnerTaskId,
+                      Result.OwnerTaskId);
+    yield return Case(ResultRawField.ResultId,
+                      Result.ResultId);
+    yield return Case(ResultRawField.SessionId,
+                      Result.SessionId);
   }
 
   [Test]
-  public void InvokeShouldReturnSessionId()
+  [TestCaseSource(nameof(TestCasesInvoke))]
+  public void InvokeShouldReturnExpectedValue(ResultRawField field,
+                                              object?        expected)
   {
     var func = new ListResultsRequest
                {
                  Filter = new ListResultsRequest.Types.Filter(),
                  Sort = new ListResultsRequest.Types.Sort
                         {
-                          Field     = ListResultsRequest.Types.OrderByField.SessionId,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
+                          Field = new ResultField
+                                  {
+                                    ResultRawField = field,
+                                  },
+                          Direction = SortDirection.Asc,
                         },
                }.Sort.ToResultField()
                 .Compile();
 
-    Assert.AreEqual(result_.SessionId,
-                    func.Invoke(result_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnStatus()
-  {
-    var func = new ListResultsRequest
-               {
-                 Filter = new ListResultsRequest.Types.Filter(),
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.Status,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.ToResultField()
-                .Compile();
-
-    Assert.AreEqual(result_.Status,
-                    func.Invoke(result_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnName()
-  {
-    var func = new ListResultsRequest
-               {
-                 Filter = new ListResultsRequest.Types.Filter(),
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.Name,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.ToResultField()
-                .Compile();
-
-    Assert.AreEqual(result_.Name,
-                    func.Invoke(result_));
-  }
-
-  [Test]
-  public void InvokeShouldReturnOwnerTaskId()
-  {
-    var func = new ListResultsRequest
-               {
-                 Filter = new ListResultsRequest.Types.Filter(),
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.OwnerTaskId,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
-               }.Sort.ToResultField()
-                .Compile();
-
-    Assert.AreEqual(result_.OwnerTaskId,
-                    func.Invoke(result_));
+    Assert.AreEqual(expected,
+                    func.Invoke(Result));
   }
 }

--- a/Common/tests/ListResultsRequestExt/ToResultFilterTest.cs
+++ b/Common/tests/ListResultsRequestExt/ToResultFilterTest.cs
@@ -20,6 +20,9 @@ using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Results;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
 
@@ -41,6 +44,15 @@ public class ToResultFilterTest
                                         DateTime.UtcNow,
                                         Array.Empty<byte>());
 
+  private static readonly ListResultsRequest.Types.Sort Sort = new()
+                                                               {
+                                                                 Field = new ResultField
+                                                                         {
+                                                                           ResultRawField = ResultRawField.CreatedAt,
+                                                                         },
+                                                                 Direction = SortDirection.Asc,
+                                                               };
+
   [Test]
   public void FilterStatusShouldSucceed()
   {
@@ -50,11 +62,7 @@ public class ToResultFilterTest
                           {
                             Status = ResultStatus.Created,
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -70,11 +78,7 @@ public class ToResultFilterTest
                           {
                             Status = ResultStatus.Aborted,
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -90,11 +94,7 @@ public class ToResultFilterTest
                           {
                             SessionId = "SessionId",
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -110,11 +110,7 @@ public class ToResultFilterTest
                           {
                             SessionId = "BadSessionId",
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -130,11 +126,7 @@ public class ToResultFilterTest
                           {
                             Name = "Name",
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -150,11 +142,7 @@ public class ToResultFilterTest
                           {
                             Name = "BadName",
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -170,11 +158,7 @@ public class ToResultFilterTest
                           {
                             OwnerTaskId = "OwnerTaskId",
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -190,11 +174,7 @@ public class ToResultFilterTest
                           {
                             OwnerTaskId = "BadOwnerTaskId",
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -210,11 +190,7 @@ public class ToResultFilterTest
                           {
                             CreatedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -230,11 +206,7 @@ public class ToResultFilterTest
                           {
                             CreatedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -253,11 +225,7 @@ public class ToResultFilterTest
                           {
                             CreatedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 
@@ -276,11 +244,7 @@ public class ToResultFilterTest
                           {
                             CreatedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListResultsRequest.Types.Sort
-                        {
-                          Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
-                          Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                        },
+                 Sort = Sort,
                }.Filter.ToResultFilter()
                 .Compile();
 

--- a/Common/tests/ListSessionsRequestExt/ToSessionDataFilterTest.cs
+++ b/Common/tests/ListSessionsRequestExt/ToSessionDataFilterTest.cs
@@ -20,6 +20,9 @@ using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Sessions;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
 
@@ -52,6 +55,15 @@ public class ToSessionDataFilterTest
                                                   new List<string>(),
                                                   Options);
 
+  private static readonly ListSessionsRequest.Types.Sort Sort = new()
+                                                                {
+                                                                  Direction = SortDirection.Asc,
+                                                                  Field = new SessionField
+                                                                          {
+                                                                            SessionRawField = SessionRawField.CreatedAt,
+                                                                          },
+                                                                };
+
   [Test]
   public void FilterStatusShouldSucceed()
   {
@@ -61,11 +73,7 @@ public class ToSessionDataFilterTest
                           {
                             Status = SessionStatus.Running,
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -81,11 +89,7 @@ public class ToSessionDataFilterTest
                           {
                             Status = SessionStatus.Cancelled,
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -101,11 +105,7 @@ public class ToSessionDataFilterTest
                           {
                             SessionId = "SessionId",
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -121,11 +121,7 @@ public class ToSessionDataFilterTest
                           {
                             SessionId = "BadSessionId",
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -141,11 +137,7 @@ public class ToSessionDataFilterTest
                           {
                             ApplicationName = "applicationName",
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -161,11 +153,7 @@ public class ToSessionDataFilterTest
                           {
                             ApplicationName = "badname",
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -181,11 +169,7 @@ public class ToSessionDataFilterTest
                           {
                             ApplicationVersion = "applicationVersion",
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -201,11 +185,7 @@ public class ToSessionDataFilterTest
                           {
                             ApplicationVersion = "badname",
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -221,11 +201,7 @@ public class ToSessionDataFilterTest
                           {
                             CreatedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -241,11 +217,7 @@ public class ToSessionDataFilterTest
                           {
                             CreatedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -264,11 +236,7 @@ public class ToSessionDataFilterTest
                           {
                             CreatedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -287,11 +255,7 @@ public class ToSessionDataFilterTest
                           {
                             CreatedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -307,11 +271,7 @@ public class ToSessionDataFilterTest
                           {
                             CancelledBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -327,11 +287,7 @@ public class ToSessionDataFilterTest
                           {
                             CancelledBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -350,11 +306,7 @@ public class ToSessionDataFilterTest
                           {
                             CancelledAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 
@@ -373,11 +325,7 @@ public class ToSessionDataFilterTest
                           {
                             CancelledAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListSessionsRequest.Types.Sort
-                        {
-                          Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                          Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToSessionDataFilter()
                 .Compile();
 

--- a/Common/tests/ListTasksRequestExt/ToTaskDataFilterTest.cs
+++ b/Common/tests/ListTasksRequestExt/ToTaskDataFilterTest.cs
@@ -19,6 +19,9 @@ using System;
 using System.Collections.Generic;
 
 using ArmoniK.Api.gRPC.V1;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Storage;
@@ -69,6 +72,15 @@ public class ToTaskDataFilterTest
                                             new Output(true,
                                                        ""));
 
+  private static readonly ListTasksRequest.Types.Sort Sort = new()
+                                                             {
+                                                               Direction = SortDirection.Asc,
+                                                               Field = new TaskField
+                                                                       {
+                                                                         TaskSummaryField = TaskSummaryField.StartedAt,
+                                                                       },
+                                                             };
+
   [Test]
   public void FilterSessionIdShouldSucceed()
   {
@@ -78,11 +90,7 @@ public class ToTaskDataFilterTest
                           {
                             SessionId = "SessionId",
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -98,11 +106,7 @@ public class ToTaskDataFilterTest
                           {
                             SessionId = "SessionId",
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -121,11 +125,7 @@ public class ToTaskDataFilterTest
                           {
                             CreatedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -144,11 +144,7 @@ public class ToTaskDataFilterTest
                           {
                             CreatedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -167,11 +163,7 @@ public class ToTaskDataFilterTest
                           {
                             CreatedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -190,11 +182,7 @@ public class ToTaskDataFilterTest
                           {
                             CreatedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -213,11 +201,7 @@ public class ToTaskDataFilterTest
                           {
                             EndedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -236,11 +220,7 @@ public class ToTaskDataFilterTest
                           {
                             EndedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -259,11 +239,7 @@ public class ToTaskDataFilterTest
                           {
                             EndedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -282,11 +258,7 @@ public class ToTaskDataFilterTest
                           {
                             EndedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -305,11 +277,7 @@ public class ToTaskDataFilterTest
                           {
                             StartedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -328,11 +296,7 @@ public class ToTaskDataFilterTest
                           {
                             StartedAfter = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -351,11 +315,7 @@ public class ToTaskDataFilterTest
                           {
                             StartedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -374,11 +334,7 @@ public class ToTaskDataFilterTest
                           {
                             StartedBefore = FromDateTime(DateTime.UtcNow),
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -402,11 +358,7 @@ public class ToTaskDataFilterTest
                               TaskStatus.Error,
                             },
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 
@@ -429,11 +381,7 @@ public class ToTaskDataFilterTest
                               TaskStatus.Error,
                             },
                           },
-                 Sort = new ListTasksRequest.Types.Sort
-                        {
-                          Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                          Field     = ListTasksRequest.Types.OrderByField.StartedAt,
-                        },
+                 Sort = Sort,
                }.Filter.ToTaskDataFilter()
                 .Compile();
 

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -563,12 +563,12 @@ public class TaskHandlerTest
                                                    CancellationToken cancellationToken)
       => throw new NotImplementedException();
 
-    public Task<(IEnumerable<TaskData> tasks, int totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
-                                                                              Expression<Func<TaskData, object?>> orderField,
-                                                                              bool                                ascOrder,
-                                                                              int                                 page,
-                                                                              int                                 pageSize,
-                                                                              CancellationToken                   cancellationToken = default)
+    public Task<(IEnumerable<TaskData> tasks, long totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
+                                                                               Expression<Func<TaskData, object?>> orderField,
+                                                                               bool                                ascOrder,
+                                                                               int                                 page,
+                                                                               int                                 pageSize,
+                                                                               CancellationToken                   cancellationToken = default)
       => throw new NotImplementedException();
 
     public Task<IEnumerable<T>> FindTasksAsync<T>(Expression<Func<TaskData, bool>> filter,

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -903,12 +903,12 @@ internal class IntegrationGrpcSubmitterServiceTest
                                                    CancellationToken cancellationToken = default)
       => throw new T();
 
-    public Task<(IEnumerable<TaskData> tasks, int totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
-                                                                              Expression<Func<TaskData, object?>> orderField,
-                                                                              bool                                ascOrder,
-                                                                              int                                 page,
-                                                                              int                                 pageSize,
-                                                                              CancellationToken                   cancellationToken = default)
+    public Task<(IEnumerable<TaskData> tasks, long totalCount)> ListTasksAsync(Expression<Func<TaskData, bool>>    filter,
+                                                                               Expression<Func<TaskData, object?>> orderField,
+                                                                               bool                                ascOrder,
+                                                                               int                                 page,
+                                                                               int                                 pageSize,
+                                                                               CancellationToken                   cancellationToken = default)
       => throw new T();
 
     public Task<IEnumerable<TData>> FindTasksAsync<TData>(Expression<Func<TaskData, bool>>  filter,

--- a/Common/tests/Validators/ListApplicationsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListApplicationsRequestValidatorTest.cs
@@ -18,6 +18,9 @@
 using System;
 
 using ArmoniK.Api.gRPC.V1.Applications;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
@@ -34,10 +37,13 @@ public class ListApplicationsRequestValidatorTest
                                          Filter = new ListApplicationsRequest.Types.Filter(),
                                          Sort = new ListApplicationsRequest.Types.Sort
                                                 {
-                                                  Direction = ListApplicationsRequest.Types.OrderDirection.Asc,
+                                                  Direction = SortDirection.Asc,
                                                   Fields =
                                                   {
-                                                    ListApplicationsRequest.Types.OrderByField.Name,
+                                                    new ApplicationField
+                                                    {
+                                                      ApplicationField_ = ApplicationRawField.Name,
+                                                    },
                                                   },
                                                 },
                                          Page     = 0,
@@ -80,7 +86,7 @@ public class ListApplicationsRequestValidatorTest
   {
     validListApplicationsRequest_!.Sort = new ListApplicationsRequest.Types.Sort
                                           {
-                                            Direction = ListApplicationsRequest.Types.OrderDirection.Desc,
+                                            Direction = SortDirection.Desc,
                                           };
     foreach (var error in validator_.Validate(validListApplicationsRequest_)
                                     .Errors)
@@ -99,7 +105,10 @@ public class ListApplicationsRequestValidatorTest
                                           {
                                             Fields =
                                             {
-                                              ListApplicationsRequest.Types.OrderByField.Name,
+                                              new ApplicationField
+                                              {
+                                                ApplicationField_ = ApplicationRawField.Name,
+                                              },
                                             },
                                           };
     foreach (var error in validator_.Validate(validListApplicationsRequest_)

--- a/Common/tests/Validators/ListPartitionsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListPartitionsRequestValidatorTest.cs
@@ -18,6 +18,7 @@
 using System;
 
 using Armonik.Api.Grpc.V1.Partitions;
+using Armonik.Api.Grpc.V1.SortDirection;
 
 using ArmoniK.Core.Common.gRPC.Validators;
 
@@ -35,8 +36,11 @@ public class ListPartitionsRequestValidatorTest
                                        Filter = new ListPartitionsRequest.Types.Filter(),
                                        Sort = new ListPartitionsRequest.Types.Sort
                                               {
-                                                Direction = ListPartitionsRequest.Types.OrderDirection.Asc,
-                                                Field     = ListPartitionsRequest.Types.OrderByField.Id,
+                                                Direction = SortDirection.Asc,
+                                                Field = new PartitionField
+                                                        {
+                                                          PartitionRawField = PartitionRawField.Id,
+                                                        },
                                               },
                                        Page     = 0,
                                        PageSize = 1,
@@ -78,7 +82,7 @@ public class ListPartitionsRequestValidatorTest
   {
     validListPartitionsRequest_!.Sort = new ListPartitionsRequest.Types.Sort
                                         {
-                                          Direction = ListPartitionsRequest.Types.OrderDirection.Desc,
+                                          Direction = SortDirection.Desc,
                                         };
     foreach (var error in validator_.Validate(validListPartitionsRequest_)
                                     .Errors)
@@ -95,7 +99,10 @@ public class ListPartitionsRequestValidatorTest
   {
     validListPartitionsRequest_!.Sort = new ListPartitionsRequest.Types.Sort
                                         {
-                                          Field = ListPartitionsRequest.Types.OrderByField.Id,
+                                          Field = new PartitionField
+                                                  {
+                                                    PartitionRawField = PartitionRawField.Id,
+                                                  },
                                         };
     foreach (var error in validator_.Validate(validListPartitionsRequest_)
                                     .Errors)

--- a/Common/tests/Validators/ListResultsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListResultsRequestValidatorTest.cs
@@ -18,6 +18,9 @@
 using System;
 
 using ArmoniK.Api.gRPC.V1.Results;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
@@ -34,8 +37,11 @@ public class ListResultsRequestValidatorTest
                                     Filter = new ListResultsRequest.Types.Filter(),
                                     Sort = new ListResultsRequest.Types.Sort
                                            {
-                                             Direction = ListResultsRequest.Types.OrderDirection.Asc,
-                                             Field     = ListResultsRequest.Types.OrderByField.CreatedAt,
+                                             Direction = SortDirection.Asc,
+                                             Field = new ResultField
+                                                     {
+                                                       ResultRawField = ResultRawField.CreatedAt,
+                                                     },
                                            },
                                     Page     = 0,
                                     PageSize = 1,
@@ -77,7 +83,7 @@ public class ListResultsRequestValidatorTest
   {
     validListResultsRequest_!.Sort = new ListResultsRequest.Types.Sort
                                      {
-                                       Direction = ListResultsRequest.Types.OrderDirection.Desc,
+                                       Direction = SortDirection.Desc,
                                      };
     foreach (var error in validator_.Validate(validListResultsRequest_)
                                     .Errors)
@@ -94,7 +100,10 @@ public class ListResultsRequestValidatorTest
   {
     validListResultsRequest_!.Sort = new ListResultsRequest.Types.Sort
                                      {
-                                       Field = ListResultsRequest.Types.OrderByField.Name,
+                                       Field = new ResultField
+                                               {
+                                                 ResultRawField = ResultRawField.Name,
+                                               },
                                      };
     foreach (var error in validator_.Validate(validListResultsRequest_)
                                     .Errors)

--- a/Common/tests/Validators/ListSessionsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListSessionsRequestValidatorTest.cs
@@ -18,6 +18,9 @@
 using System;
 
 using ArmoniK.Api.gRPC.V1.Sessions;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Core.Common.gRPC.Validators;
 
 using NUnit.Framework;
@@ -34,8 +37,11 @@ public class ListSessionsRequestValidatorTest
                                      Filter = new ListSessionsRequest.Types.Filter(),
                                      Sort = new ListSessionsRequest.Types.Sort
                                             {
-                                              Direction = ListSessionsRequest.Types.OrderDirection.Asc,
-                                              Field     = ListSessionsRequest.Types.OrderByField.CreatedAt,
+                                              Direction = SortDirection.Asc,
+                                              Field = new SessionField
+                                                      {
+                                                        SessionRawField = SessionRawField.CreatedAt,
+                                                      },
                                             },
                                      Page     = 0,
                                      PageSize = 1,
@@ -77,7 +83,7 @@ public class ListSessionsRequestValidatorTest
   {
     validListSessionsRequest_!.Sort = new ListSessionsRequest.Types.Sort
                                       {
-                                        Direction = ListSessionsRequest.Types.OrderDirection.Desc,
+                                        Direction = SortDirection.Desc,
                                       };
     foreach (var error in validator_.Validate(validListSessionsRequest_)
                                     .Errors)
@@ -94,7 +100,10 @@ public class ListSessionsRequestValidatorTest
   {
     validListSessionsRequest_!.Sort = new ListSessionsRequest.Types.Sort
                                       {
-                                        Field = ListSessionsRequest.Types.OrderByField.SessionId,
+                                        Field = new SessionField
+                                                {
+                                                  SessionRawField = SessionRawField.SessionId,
+                                                },
                                       };
     foreach (var error in validator_.Validate(validListSessionsRequest_)
                                     .Errors)

--- a/Common/tests/Validators/ListTasksRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListTasksRequestValidatorTest.cs
@@ -17,6 +17,8 @@
 
 using System;
 
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Common.gRPC.Validators;
 
@@ -34,8 +36,11 @@ public class ListTasksRequestValidatorTest
                                   Filter = new ListTasksRequest.Types.Filter(),
                                   Sort = new ListTasksRequest.Types.Sort
                                          {
-                                           Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                                           Field     = ListTasksRequest.Types.OrderByField.CreatedAt,
+                                           Direction = SortDirection.Asc,
+                                           Field = new TaskField
+                                                   {
+                                                     TaskSummaryField = TaskSummaryField.CreatedAt,
+                                                   },
                                          },
                                   Page     = 0,
                                   PageSize = 1,
@@ -77,7 +82,7 @@ public class ListTasksRequestValidatorTest
   {
     validListTasksRequest_!.Sort = new ListTasksRequest.Types.Sort
                                    {
-                                     Direction = ListTasksRequest.Types.OrderDirection.Desc,
+                                     Direction = SortDirection.Desc,
                                    };
     foreach (var error in validator_.Validate(validListTasksRequest_)
                                     .Errors)
@@ -94,7 +99,10 @@ public class ListTasksRequestValidatorTest
   {
     validListTasksRequest_!.Sort = new ListTasksRequest.Types.Sort
                                    {
-                                     Field = ListTasksRequest.Types.OrderByField.SessionId,
+                                     Field = new TaskField
+                                             {
+                                               TaskSummaryField = TaskSummaryField.SessionId,
+                                             },
                                    };
     foreach (var error in validator_.Validate(validListTasksRequest_)
                                     .Errors)

--- a/Tests/Bench/Client/src/Program.cs
+++ b/Tests/Bench/Client/src/Program.cs
@@ -31,6 +31,9 @@ using ArmoniK.Api.gRPC.V1.Events;
 using Armonik.Api.Grpc.V1.Partitions;
 
 using ArmoniK.Api.gRPC.V1.Results;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Common.Tests.Client;
 using ArmoniK.Samples.Bench.Client.Options;
@@ -117,8 +120,11 @@ internal static class Program
                                                                            },
                                                                   Sort = new ListPartitionsRequest.Types.Sort
                                                                          {
-                                                                           Direction = ListPartitionsRequest.Types.OrderDirection.Desc,
-                                                                           Field     = ListPartitionsRequest.Types.OrderByField.Id,
+                                                                           Direction = SortDirection.Desc,
+                                                                           Field = new PartitionField
+                                                                                   {
+                                                                                     PartitionRawField = PartitionRawField.Id,
+                                                                                   },
                                                                          },
                                                                   PageSize = 10,
                                                                   Page     = 0,

--- a/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
+++ b/Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-edge.60.de40d5c" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-edge.89.b9b77a3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
   </ItemGroup>
 

--- a/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
+++ b/Tests/Common/Client/src/ArmoniK.Core.Common.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-edge.60.de40d5c" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-edge.89.b9b77a3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/Tests/Common/Client/src/GrpcChannelExt.cs
+++ b/Tests/Common/Client/src/GrpcChannelExt.cs
@@ -21,6 +21,9 @@ using System.Linq;
 using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1.Results;
+
+using Armonik.Api.Grpc.V1.SortDirection;
+
 using ArmoniK.Api.gRPC.V1.Tasks;
 
 using Google.Protobuf.WellKnownTypes;
@@ -86,8 +89,11 @@ public static class GrpcChannelExt
                                                          },
                                                          new ListTasksRequest.Types.Sort
                                                          {
-                                                           Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                                                           Field     = ListTasksRequest.Types.OrderByField.TaskId,
+                                                           Direction = SortDirection.Asc,
+                                                           Field = new TaskField
+                                                                   {
+                                                                     TaskSummaryField = TaskSummaryField.TaskId,
+                                                                   },
                                                          })
                                          .ConfigureAwait(false))
     {
@@ -221,8 +227,11 @@ public static class GrpcChannelExt
                                                    },
                                                    new ListTasksRequest.Types.Sort
                                                    {
-                                                     Direction = ListTasksRequest.Types.OrderDirection.Asc,
-                                                     Field     = ListTasksRequest.Types.OrderByField.TaskId,
+                                                     Direction = SortDirection.Asc,
+                                                     Field = new TaskField
+                                                             {
+                                                               TaskSummaryField = TaskSummaryField.TaskId,
+                                                             },
                                                    })
                                    .ConfigureAwait(false))
     {

--- a/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
+++ b/Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-edge.60.de40d5c" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-edge.89.b9b77a3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Htc.Mock" Version="3.0.0-alpha11" />
   </ItemGroup>

--- a/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
+++ b/Tests/Stream/Client/ArmoniK.Extensions.Common.StreamWrapper.Tests.Client.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-edge.60.de40d5c" />
+    <PackageReference Include="ArmoniK.Api.Client" Version="3.9.0-edge.89.b9b77a3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />

--- a/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
+++ b/Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
-    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-edge.60.de40d5c" />
+    <PackageReference Include="ArmoniK.Api.Worker" Version="3.9.0-edge.89.b9b77a3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update core to use new sorting messages proposed in https://github.com/aneoconsulting/ArmoniK.Api/pull/249

It uses the new messages and simplifies some of the tests by using test parameters.

TODO:

- [x] Test ToTaskDataField with keys from TaskOptions dictionary