### PR TITLE
fix: fix path of logs in S3

### DIFF
--- a/tools/logs2seq.py
+++ b/tools/logs2seq.py
@@ -26,13 +26,14 @@ import gzip
 
 parser = argparse.ArgumentParser(description="Download ArmoniK logs in JSON CLEF format from S3 bucket then send them to Seq.", formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument("bucket_name", help="S3 bucket", type=str)
+parser.add_argument("folder_name_core", help="Folder where core logs are located", type=str)
 parser.add_argument("run_number", help="GitHub workflow run_number", type=str)
 parser.add_argument("run_attempt", help="GitHub workflow run_attempt", type=str)
 parser.add_argument("file_name", help="file to download from the bucket", type=str)
 parser.add_argument("--url", dest="url", help="Seq url", type=str, default="http://localhost:9341/api/events/raw?clef")
 args = parser.parse_args()
 
-dir_name = args.run_number + "/" + args.run_attempt + "/"
+dir_name = args.folder_name_core + "/" + args.run_number + "/" + args.run_attempt + "/"
 tmp_dir = "./tmp/"
 obj_name = dir_name + args.file_name
 file_name = tmp_dir + obj_name


### PR DESCRIPTION
Linked to: https://github.com/aneoconsulting/ArmoniK.Core/pull/300
We put logs of core in one folder in S3, we need to change the path in this file to download logs from the right folder. 