### PR TITLE
build: support for external queue

### DIFF
--- a/justfile
+++ b/justfile
@@ -31,8 +31,10 @@ export TF_VAR_queue_storage := if queue == "rabbitmq" {
   '{ name = "rabbitmq", image = "rabbitmq:3-management", protocol = "amqp0_9_1" }'
 } else if queue == "artemis" {
   '{ name = "artemis", image = "quay.io/artemiscloud/activemq-artemis-broker:artemis.2.28.0" }'
-} else {
+} else if queue == "activemq" {
   '{ name = "activemq", image = "symptoma/activemq:5.16.3" }'
+} else {
+  '{ name = "none" }'
 }
 
 # Sets the object storage

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -8,10 +8,10 @@ locals {
     "ASPNETCORE_ENVIRONMENT"                                                           = "${var.aspnet_core_env}"
   }
   worker         = merge(var.compute_plane.worker, { image = var.worker_image, docker_file_path = var.worker_docker_file_path })
-  queue          = one(concat(module.queue_activemq, module.queue_rabbitmq, module.queue_artemis))
+  queue          = one(concat(module.queue_activemq, module.queue_rabbitmq, module.queue_artemis, module.queue_none))
   database       = module.database
   object         = one(concat(module.object_redis, module.object_minio, module.object_local))
-  environment    = merge(local.queue.generated_env_vars, local.object.generated_env_vars, local.database.generated_env_vars, local.logging_env_vars)
+  environment    = merge(local.queue.generated_env_vars, local.object.generated_env_vars, local.database.generated_env_vars, local.logging_env_vars, var.custom_env_vars)
   volumes        = local.object.volumes
   submitter      = merge(var.submitter, { tag = var.core_tag })
   compute_plane  = merge(var.compute_plane, { tag = var.core_tag }, { worker = local.worker })

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,6 +85,11 @@ module "queue_artemis" {
   network    = docker_network.armonik.name
 }
 
+module "queue_none" {
+  source = "./modules/storage/queue/none"
+  count  = var.queue_storage.name == "none" ? 1 : 0
+}
+
 module "submitter" {
   source             = "./modules/submitter"
   container_name     = local.submitter.name

--- a/terraform/modules/storage/queue/none/outputs.tf
+++ b/terraform/modules/storage/queue/none/outputs.tf
@@ -1,0 +1,4 @@
+output "generated_env_vars" {
+  value = ({
+  })
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -84,8 +84,8 @@ variable "queue_storage" {
     error_message = "Protocol must be amqp1_0|amqp0_9_1"
   }
   validation {
-    condition     = can(regex("^(activemq|rabbitmq|artemis)$", var.queue_storage.name))
-    error_message = "Must be activemq, rabbitmq or artemis"
+    condition     = can(regex("^(activemq|rabbitmq|artemis|none)$", var.queue_storage.name))
+    error_message = "Must be activemq, rabbitmq, artemis or none"
   }
   default = {}
 }
@@ -218,4 +218,10 @@ variable "ingress" {
         mtls = true
       }
   } }
+}
+
+variable "custom_env_vars" {
+  type = map(string)
+  default = {
+  }
 }


### PR DESCRIPTION
Arbitrary configuration can be passed to terraform through the variable `TF_VAR_custom_env_vars`. The queue can also be set up to none meaning that configurations for an external queue can be passed with the `TF_VAR_custom_env_vars` env var.

example:

```bash
TF_VAR_custom_env_vars='{ "MyQueueEndpoint" = "endpoint", "MyQueuePass" = "pass", "MyQueueUser" = "user" }' just queue=none plan
```
