### PR TITLE
refactor: Allow terraform import for docker network

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,37 +1,37 @@
 module "fluenbit" {
   source  = "./modules/monitoring/fluentbit"
   image   = var.log_driver_image
-  network = docker_network.armonik.name
+  network = docker_network.armonik.id
 }
 
 module "seq" {
   source  = "./modules/monitoring/seq"
   image   = var.seq_image
-  network = docker_network.armonik.name
+  network = docker_network.armonik.id
 }
 
 module "zipkin" {
   source  = "./modules/monitoring/zipkin"
   image   = var.zipkin_image
-  network = docker_network.armonik.name
+  network = docker_network.armonik.id
 }
 
 module "grafana" {
   source  = "./modules/monitoring/grafana"
   image   = var.grafana_image
-  network = docker_network.armonik.name
+  network = docker_network.armonik.id
 }
 
 module "prometheus" {
   source  = "./modules/monitoring/prometheus"
   image   = var.prometheus_image
-  network = docker_network.armonik.name
+  network = docker_network.armonik.id
 }
 
 module "database" {
   source         = "./modules/storage/database/mongo"
   image          = var.database_image
-  network        = docker_network.armonik.name
+  network        = docker_network.armonik.id
   mongodb_params = var.mongodb_params
   partition_list = local.partition_list
 }
@@ -40,7 +40,7 @@ module "object_redis" {
   source  = "./modules/storage/object/redis"
   count   = var.object_storage.name == "redis" ? 1 : 0
   image   = var.object_storage.image
-  network = docker_network.armonik.name
+  network = docker_network.armonik.id
 }
 
 module "object_minio" {
@@ -52,7 +52,7 @@ module "object_minio" {
   login       = var.object_storage.login
   password    = var.object_storage.password
   bucket_name = var.object_storage.bucket_name
-  network     = docker_network.armonik.name
+  network     = docker_network.armonik.id
 }
 
 module "object_local" {
@@ -66,7 +66,7 @@ module "queue_rabbitmq" {
   queue_envs = var.queue_env_vars
   image      = var.queue_storage.image
   protocol   = var.queue_storage.protocol
-  network    = docker_network.armonik.name
+  network    = docker_network.armonik.id
 }
 
 module "queue_activemq" {
@@ -74,7 +74,7 @@ module "queue_activemq" {
   count      = var.queue_storage.name == "activemq" ? 1 : 0
   queue_envs = var.queue_env_vars
   image      = var.queue_storage.image
-  network    = docker_network.armonik.name
+  network    = docker_network.armonik.id
 }
 
 module "queue_artemis" {
@@ -82,7 +82,7 @@ module "queue_artemis" {
   count      = var.queue_storage.name == "artemis" ? 1 : 0
   queue_envs = var.queue_env_vars
   image      = var.queue_storage.image
-  network    = docker_network.armonik.name
+  network    = docker_network.armonik.id
 }
 
 module "queue_none" {
@@ -96,7 +96,7 @@ module "submitter" {
   core_tag           = local.submitter.tag
   use_local_image    = var.use_local_image
   docker_image       = local.submitter.image
-  network            = docker_network.armonik.name
+  network            = docker_network.armonik.id
   generated_env_vars = local.environment
   zipkin_uri         = module.zipkin.zipkin_uri
   log_driver         = module.fluenbit.log_driver
@@ -114,7 +114,7 @@ module "compute_plane" {
   worker             = local.compute_plane.worker
   generated_env_vars = local.environment
   volumes            = local.volumes
-  network            = docker_network.armonik.name
+  network            = docker_network.armonik.id
   zipkin_uri         = module.zipkin.zipkin_uri
   log_driver         = module.fluenbit.log_driver
 }
@@ -124,7 +124,7 @@ module "metrics_exporter" {
   tag                = var.core_tag
   image              = var.armonik_metrics_image
   use_local_image    = var.use_local_image
-  network            = docker_network.armonik.name
+  network            = docker_network.armonik.id
   generated_env_vars = local.environment
   log_driver         = module.fluenbit.log_driver
 }
@@ -134,7 +134,7 @@ module "partition_metrics_exporter" {
   tag                = var.core_tag
   image              = var.armonik_partition_metrics_image
   use_local_image    = var.use_local_image
-  network            = docker_network.armonik.name
+  network            = docker_network.armonik.id
   generated_env_vars = local.environment
   metrics_env_vars   = module.metrics_exporter.metrics_env_vars
   log_driver         = module.fluenbit.log_driver
@@ -151,7 +151,7 @@ module "ingress" {
   tls        = each.value.tls
   mtls       = each.value.mtls
   port       = each.value.port
-  network    = docker_network.armonik.name
+  network    = docker_network.armonik.id
   submitter  = module.submitter
   log_driver = module.fluenbit.log_driver
 }


### PR DESCRIPTION

- Use network id instead of network name in terraform to avoid issues with networks with the same name
- Avoid using length() function in terraform as it is only interpreted during `terraform apply`, not in `terraform import`

```bash
docker network create custom_network
terraform -chdir=./terraform import docker_network.armonik $(docker network inspect custom_network | jq -r '.[].Id')
```

