### PR TITLE
docs: fix links

### DIFF
--- a/.docs/content/1.concepts/3.authentication.md
+++ b/.docs/content/1.concepts/3.authentication.md
@@ -74,13 +74,13 @@ The following database deployments can be used to handle authentication data :
 
 > **NOTE :** This is the current recommended method
 
-You can define the users' roles and certificates using a json configuration during deployment. Check the [ArmoniK Authentication Configuration Guide](https://github.com/aneoconsulting/ArmoniK/blob/main/docs/authentication-configuration-guide.md) for more details.
+You can define the users' roles and certificates using a json configuration during deployment. Check the [ArmoniK Authentication Configuration Guide](https://github.com/aneoconsulting/ArmoniK/blob/main/.docs/content/2.guide/1.how-to/how-to-configure-authentication.md) for more details.
 
 ### Using MongoDB directly
 
 <!-- TODO: could be converted to ::alert -->
 > **NOTE :** Using a MongoDB instance different from the one used in the rest of ArmoniK is currently not supported
-> **NOTE :** If the deployment used is the internal MongoDB, to send commands to the database you need to use a script like the one available [here](https://github.com/aneoconsulting/ArmoniK/blob/main/tools/access-mongo.sh) to connect to the database.
+> **NOTE :** If the deployment used is the internal MongoDB, to send commands to the database you need to use a script like the one available [here](https://github.com/aneoconsulting/ArmoniK/blob/main/tools/access-mongo-as-user.sh) to connect to the database as a user. Another script to connect to the database as admin is available [here](https://github.com/aneoconsulting/ArmoniK/blob/main/tools/access-mongo-as-admin.sh).
 > **NOTE :** This method is available to anyone having access to the deployed cluster's secrets and an access to the MongoDB host and port. **Use it at your own risk**.
 
 In order to function properly, the MongoDB database needs to have the following collections:

--- a/.docs/content/1.concepts/7.plugins.md
+++ b/.docs/content/1.concepts/7.plugins.md
@@ -2,7 +2,7 @@
 
 ## Queue adaptors as external plugins
 
-We have the possibility to have a queue adaptor as an external project and to use it as a plugin to ArmoniK.Core when needed. More about adaptors is available [here](https://github.com/aneoconsulting/ArmoniK.Core/blob/main/.docs/content/1.concepts/7.adaptors.md). Using a queue adaptor as an external plugin was possible thanks to dynamic loading of adaptors, and the use of docker images.
+We have the possibility to have a queue adaptor as an external project and to use it as a plugin to ArmoniK.Core when needed. More about adaptors is available [here](https://github.com/aneoconsulting/ArmoniK.Core/blob/main/.docs/content/1.concepts/4.adaptors.md). Using a queue adaptor as an external plugin was possible thanks to dynamic loading of adaptors, and the use of docker images.
 
 ### Loading queue adaptor into a C# project
 
@@ -55,7 +55,7 @@ export TF_VAR_custom_env_vars='{ "Components__QueueAdaptorSettings__ClassName" =
 
 ### Deploy Core
 
-If your adaptor uses a queue that can already be deployed by ArmoniK.Core(rabbitmq or activemq), you can specify this queue to the deployment of Core. To know how to deploy ArmoniK.Core and how to specify the queue, see [Local deployment of ArmoniK.Core](https://github.com/aneoconsulting/ArmoniK.Core/blob/main/.docs/content/1.concepts/1.local-deployment.md).
+If your adaptor uses a queue that can already be deployed by ArmoniK.Core(rabbitmq or activemq), you can specify this queue to the deployment of Core. To know how to deploy ArmoniK.Core and how to specify the queue, see [Local deployment of ArmoniK.Core](https://github.com/aneoconsulting/ArmoniK.Core/blob/main/.docs/content/0.installation/1.local-deployment.md).
 
 If you use another queue, you should deploy the corresponding service. First of all, you should create the docker network `armonik_network`
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ To deploy ArmoniK.Core locally, you need first to clone the repository [ArmoniK.
 just
 ```
 
-More about local deployment, see [Local Deployment of ArmoniK.Core](./.docs/content/1.concepts/1.local-deployment.md).
+More about local deployment, see [Local Deployment of ArmoniK.Core](./.docs/content/0.installation/1.local-deployment.md).
 
 ### Tests
 
 There are a number of tests that help to verify the successful installation of ArmoniK.Core. Some of them require a full deployment of ArmoniK.Core, for others a partial deployment is enough.
 
-More about tests, see [Tests of ArmoniK.Core](./.docs/content//1.concepts/2.tests.md).
+More about tests, see [Tests of ArmoniK.Core](./.docs/content/0.installation/2.tests.md).
 
 ## Contribution
 


### PR DESCRIPTION
Some links were no longer valid because of the move done in https://github.com/aneoconsulting/ArmoniK.Core/pull/448 and others because they were updated in ArmoniK repository.