### PR TITLE
refactor: remove LinqKit

### DIFF
--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -30,7 +30,6 @@
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="6.3.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.54.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" />
-    <PackageReference Include="LinqKit.Microsoft.EntityFrameworkCore" Version="7.1.4" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="stateless" Version="5.13.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -1,29 +1,48 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 using System;
 using System.Linq.Expressions;
+
 public static class ExpressionExt
 {
   /// <summary>
-  /// Combines two predicate expressions using a logical AND condition
+  ///   Combines two predicate expressions using a logical AND condition
   /// </summary>
   /// <typeparam name="T"> The type of the input parameter the predicate expressions are evaluated on </typeparam>
   /// <param name="expr1"> The first predicate expression to combine </param>
   /// <param name="expr2"> The second predicate expression to combine </param>
   /// <returns> A new predicate expression that represents the logical AND of the two expressions </returns>
   public static Expression<Func<T, bool>> ExpressionAnd<T>(this Expression<Func<T, bool>> expr1,
-                                                              Expression<Func<T, bool>>   expr2)
+                                                           Expression<Func<T, bool>>      expr2)
     => Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body,
                                                            expr2.Body),
                                         expr2.Parameters);
+
   /// <summary>
-  /// Combines two predicate expressions using a logical OR condition
+  ///   Combines two predicate expressions using a logical OR condition
   /// </summary>
   /// <typeparam name="T"> The type of the input parameter the predicate expressions are evaluated on </typeparam>
   /// <param name="expr1"> The first predicate expression to combine </param>
   /// <param name="expr2"> The second predicate expression to combine </param>
   /// <returns> A new predicate expression that represents the logical OR of the two expressions </returns>
   public static Expression<Func<T, bool>> ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
-                                                          Expression<Func<T, bool>> expr2)
+                                                          Expression<Func<T, bool>>      expr2)
     => Expression.Lambda<Func<T, bool>>(Expression.OrElse(expr1.Body,
                                                           expr2.Body),
                                         expr2.Parameters);
-  }
+}

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -37,8 +37,8 @@ public static class ExpressionExt
     var right = rightVisitor.Visit(expr2.Body);
 
     return Expression.Lambda<Func<T, bool>>(Expression.MakeBinary(expressionType,
-                                                                  left,
-                                                                  right),
+                                                                  left!,
+                                                                  right!),
                                             parameter);
   }
 
@@ -81,7 +81,7 @@ public static class ExpressionExt
       newValue_ = newValue;
     }
 
-    public override Expression Visit(Expression node)
+    public override Expression? Visit(Expression? node)
       => node == oldValue_
            ? newValue_
            : base.Visit(node);

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -81,16 +81,9 @@ public static class ExpressionExt
       newValue_ = newValue;
     }
 
-    public override Expression Visit(Expression? node)
-    {
-      if (node == null)
-      {
-        throw new ArgumentNullException(nameof(node));
-      }
-
-      return node == oldValue_
-               ? newValue_
-               : base.Visit(node);
-    }
+    public override Expression Visit(Expression node)
+      => node == oldValue_
+           ? newValue_
+           : base.Visit(node);
   }
 }

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -42,8 +42,9 @@ public static class ExpressionExt
                                                     parameter);
     var right = rightVisitor.Visit(expr2.Body);
 
-    return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(left,
-                                                               right),
+    return Expression.Lambda<Func<T, bool>>(Expression.MakeBinary(ExpressionType.AndAlso,
+                                                                  left,
+                                                                  right),
                                             parameter);
   }
 
@@ -54,8 +55,8 @@ public static class ExpressionExt
   /// <param name="expr1"> The first predicate expression to combine </param>
   /// <param name="expr2"> The second predicate expression to combine </param>
   /// <returns> A new predicate expression that represents the logical OR of the two expressions </returns>
-  public static Expression<Func<T, bool>> ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
-                                                          Expression<Func<T, bool>>      expr2)
+  public static Expression<Func<T, bool>>? ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
+                                                           Expression<Func<T, bool>>      expr2)
   {
     var parameter = Expression.Parameter(typeof(T));
 
@@ -67,8 +68,9 @@ public static class ExpressionExt
                                                     parameter);
     var right = rightVisitor.Visit(expr2.Body);
 
-    return Expression.Lambda<Func<T, bool>>(Expression.OrElse(left,
-                                                              right),
+    return Expression.Lambda<Func<T, bool>>(Expression.MakeBinary(ExpressionType.OrElse,
+                                                                  left,
+                                                                  right),
                                             parameter);
   }
 

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -1,0 +1,29 @@
+using System;
+using System.Linq.Expressions;
+public static class ExpressionExt
+{
+  /// <summary>
+  /// Combines two predicate expressions using a logical AND condition
+  /// </summary>
+  /// <typeparam name="T"> The type of the input parameter the predicate expressions are evaluated on </typeparam>
+  /// <param name="expr1"> The first predicate expression to combine </param>
+  /// <param name="expr2"> The second predicate expression to combine </param>
+  /// <returns> A new predicate expression that represents the logical AND of the two expressions </returns>
+  public static Expression<Func<T, bool>> ExpressionAnd<T>(this Expression<Func<T, bool>> expr1,
+                                                              Expression<Func<T, bool>>   expr2)
+    => Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body,
+                                                           expr2.Body),
+                                        expr2.Parameters);
+  /// <summary>
+  /// Combines two predicate expressions using a logical OR condition
+  /// </summary>
+  /// <typeparam name="T"> The type of the input parameter the predicate expressions are evaluated on </typeparam>
+  /// <param name="expr1"> The first predicate expression to combine </param>
+  /// <param name="expr2"> The second predicate expression to combine </param>
+  /// <returns> A new predicate expression that represents the logical OR of the two expressions </returns>
+  public static Expression<Func<T, bool>> ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
+                                                          Expression<Func<T, bool>> expr2)
+    => Expression.Lambda<Func<T, bool>>(Expression.OrElse(expr1.Body,
+                                                          expr2.Body),
+                                        expr2.Parameters);
+  }

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -30,8 +30,9 @@ public static class ExpressionExt
   public static Expression<Func<T, bool>> ExpressionAnd<T>(this Expression<Func<T, bool>> expr1,
                                                            Expression<Func<T, bool>>      expr2)
     => Expression.Lambda<Func<T, bool>>(Expression.AndAlso(expr1.Body,
-                                                           expr2.Body),
-                                        expr2.Parameters);
+                                                           Expression.Invoke(expr2,
+                                                                             expr1.Parameters)),
+                                        expr1.Parameters);
 
   /// <summary>
   ///   Combines two predicate expressions using a logical OR condition
@@ -43,6 +44,7 @@ public static class ExpressionExt
   public static Expression<Func<T, bool>> ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
                                                           Expression<Func<T, bool>>      expr2)
     => Expression.Lambda<Func<T, bool>>(Expression.OrElse(expr1.Body,
-                                                          expr2.Body),
-                                        expr2.Parameters);
+                                                          Expression.Invoke(expr2,
+                                                                            expr1.Parameters)),
+                                        expr1.Parameters);
 }

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -81,9 +81,16 @@ public static class ExpressionExt
       newValue_ = newValue;
     }
 
-    public override Expression Visit(Expression node)
-      => node == oldValue_
-           ? newValue_
-           : base.Visit(node);
+    public override Expression Visit(Expression? node)
+    {
+      if (node == null)
+      {
+        throw new ArgumentNullException(nameof(node));
+      }
+
+      return node == oldValue_
+               ? newValue_
+               : base.Visit(node);
+    }
   }
 }

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -63,8 +63,8 @@ public static class ExpressionExt
   /// <param name="expr1"> The first predicate expression to combine </param>
   /// <param name="expr2"> The second predicate expression to combine </param>
   /// <returns> A new predicate expression that represents the logical OR of the two expressions </returns>
-  public static Expression<Func<T, bool>>? ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
-                                                           Expression<Func<T, bool>>      expr2)
+  public static Expression<Func<T, bool>> ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
+                                                          Expression<Func<T, bool>>      expr2)
     => MakeBinaryExpression(ExpressionType.OrElse,
                             expr1,
                             expr2);

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -18,6 +18,8 @@
 using System;
 using System.Linq.Expressions;
 
+namespace ArmoniK.Core.Common.gRPC;
+
 public static class ExpressionExt
 {
   /// <summary>

--- a/Common/src/gRPC/ExpressionExt.cs
+++ b/Common/src/gRPC/ExpressionExt.cs
@@ -22,15 +22,9 @@ namespace ArmoniK.Core.Common.gRPC;
 
 public static class ExpressionExt
 {
-  /// <summary>
-  ///   Combines two predicate expressions using a logical AND condition
-  /// </summary>
-  /// <typeparam name="T"> The type of the input parameter the predicate expressions are evaluated on </typeparam>
-  /// <param name="expr1"> The first predicate expression to combine </param>
-  /// <param name="expr2"> The second predicate expression to combine </param>
-  /// <returns> A new predicate expression that represents the logical AND of the two expressions </returns>
-  public static Expression<Func<T, bool>> ExpressionAnd<T>(this Expression<Func<T, bool>> expr1,
-                                                           Expression<Func<T, bool>>      expr2)
+  private static Expression<Func<T, bool>> MakeBinaryExpression<T>(ExpressionType            expressionType,
+                                                                   Expression<Func<T, bool>> expr1,
+                                                                   Expression<Func<T, bool>> expr2)
   {
     var parameter = Expression.Parameter(typeof(T));
 
@@ -42,11 +36,25 @@ public static class ExpressionExt
                                                     parameter);
     var right = rightVisitor.Visit(expr2.Body);
 
-    return Expression.Lambda<Func<T, bool>>(Expression.MakeBinary(ExpressionType.AndAlso,
+    return Expression.Lambda<Func<T, bool>>(Expression.MakeBinary(expressionType,
                                                                   left,
                                                                   right),
                                             parameter);
   }
+
+  /// <summary>
+  ///   Combines two predicate expressions using a logical AND condition
+  /// </summary>
+  /// <typeparam name="T"> The type of the input parameter the predicate expressions are evaluated on </typeparam>
+  /// <param name="expr1"> The first predicate expression to combine </param>
+  /// <param name="expr2"> The second predicate expression to combine </param>
+  /// <returns> A new predicate expression that represents the logical AND of the two expressions </returns>
+  public static Expression<Func<T, bool>> ExpressionAnd<T>(this Expression<Func<T, bool>> expr1,
+                                                           Expression<Func<T, bool>>      expr2)
+    => MakeBinaryExpression(ExpressionType.AndAlso,
+                            expr1,
+                            expr2);
+
 
   /// <summary>
   ///   Combines two predicate expressions using a logical OR condition
@@ -57,22 +65,9 @@ public static class ExpressionExt
   /// <returns> A new predicate expression that represents the logical OR of the two expressions </returns>
   public static Expression<Func<T, bool>>? ExpressionOr<T>(this Expression<Func<T, bool>> expr1,
                                                            Expression<Func<T, bool>>      expr2)
-  {
-    var parameter = Expression.Parameter(typeof(T));
-
-    var leftVisitor = new ReplaceExpressionVisitor(expr1.Parameters[0],
-                                                   parameter);
-    var left = leftVisitor.Visit(expr1.Body);
-
-    var rightVisitor = new ReplaceExpressionVisitor(expr2.Parameters[0],
-                                                    parameter);
-    var right = rightVisitor.Visit(expr2.Body);
-
-    return Expression.Lambda<Func<T, bool>>(Expression.MakeBinary(ExpressionType.OrElse,
-                                                                  left,
-                                                                  right),
-                                            parameter);
-  }
+    => MakeBinaryExpression(ExpressionType.OrElse,
+                            expr1,
+                            expr2);
 
   private class ReplaceExpressionVisitor : ExpressionVisitor
   {

--- a/Common/src/gRPC/ListSessionsRequestExt.cs
+++ b/Common/src/gRPC/ListSessionsRequestExt.cs
@@ -22,8 +22,6 @@ using System.Linq.Expressions;
 using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Core.Common.Storage;
 
-using LinqKit;
-
 namespace ArmoniK.Core.Common.gRPC;
 
 public static class ListSessionsRequestExt
@@ -72,7 +70,7 @@ public static class ListSessionsRequestExt
   /// <exception cref="ArgumentOutOfRangeException">the given message is not recognized</exception>
   public static Expression<Func<SessionData, bool>> ToSessionDataFilter(this Filters filters)
   {
-    var predicate = PredicateBuilder.New<SessionData>();
+    Expression<Func<SessionData, bool>> expr = data => false;
 
     if (filters.Or == null || !filters.Or.Any())
     {
@@ -81,33 +79,33 @@ public static class ListSessionsRequestExt
 
     foreach (var filtersAnd in filters.Or)
     {
-      var predicateAnd = PredicateBuilder.New<SessionData>(data => true);
+      Expression<Func<SessionData, bool>> exprAnd = data => true;
       foreach (var filterField in filtersAnd.And)
       {
         switch (filterField.ValueConditionCase)
         {
           case FilterField.ValueConditionOneofCase.FilterString:
-            predicateAnd = predicateAnd.And(filterField.FilterString.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterString.Operator.ToFilter(filterField.Field.ToField(),
                                                                                        filterField.FilterString.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterNumber:
-            predicateAnd = predicateAnd.And(filterField.FilterNumber.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterNumber.Operator.ToFilter(filterField.Field.ToField(),
                                                                                        filterField.FilterNumber.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterBoolean:
-            predicateAnd = predicateAnd.And(filterField.FilterBoolean.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterBoolean.Operator.ToFilter(filterField.Field.ToField(),
                                                                                         filterField.FilterBoolean.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterStatus:
-            predicateAnd = predicateAnd.And(filterField.FilterStatus.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterStatus.Operator.ToFilter(filterField.Field.ToField(),
                                                                                        filterField.FilterStatus.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterDate:
-            predicateAnd = predicateAnd.And(filterField.FilterDate.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterDate.Operator.ToFilter(filterField.Field.ToField(),
                                                                                      filterField.FilterDate.Value.ToDateTime()));
             break;
           case FilterField.ValueConditionOneofCase.FilterArray:
-            predicateAnd = predicateAnd.And(filterField.FilterArray.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterArray.Operator.ToFilter(filterField.Field.ToField(),
                                                                                       filterField.FilterArray.Value));
             break;
           case FilterField.ValueConditionOneofCase.None:
@@ -116,9 +114,9 @@ public static class ListSessionsRequestExt
         }
       }
 
-      predicate = predicate.Or(predicateAnd);
+      expr = expr.ExpressionOr(exprAnd);
     }
 
-    return predicate;
+    return expr;
   }
 }

--- a/Common/src/gRPC/ListTasksRequestExt.cs
+++ b/Common/src/gRPC/ListTasksRequestExt.cs
@@ -24,8 +24,6 @@ using Armonik.Api.gRPC.V1.Tasks;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Common.Storage;
 
-using LinqKit;
-
 namespace ArmoniK.Core.Common.gRPC;
 
 public static class ListTasksRequestExt
@@ -74,7 +72,7 @@ public static class ListTasksRequestExt
   /// <exception cref="ArgumentOutOfRangeException">the given message is not recognized</exception>
   public static Expression<Func<TaskData, bool>> ToTaskDataFilter(this Filters filters)
   {
-    var predicate = PredicateBuilder.New<TaskData>();
+    Expression<Func<TaskData, bool>> expr = data => false;
 
     if (filters.Or == null || !filters.Or.Any())
     {
@@ -83,36 +81,36 @@ public static class ListTasksRequestExt
 
     foreach (var filtersAnd in filters.Or)
     {
-      var predicateAnd = PredicateBuilder.New<TaskData>(data => true);
+      Expression<Func<TaskData, bool>> exprAnd = data => true;
       foreach (var filterField in filtersAnd.And)
       {
         switch (filterField.ValueConditionCase)
         {
           case FilterField.ValueConditionOneofCase.FilterString:
-            predicateAnd = predicateAnd.And(filterField.FilterString.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterString.Operator.ToFilter(filterField.Field.ToField(),
                                                                                        filterField.FilterString.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterNumber:
-            predicateAnd = predicateAnd.And(filterField.FilterNumber.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterNumber.Operator.ToFilter(filterField.Field.ToField(),
                                                                                        filterField.FilterNumber.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterBoolean:
-            predicateAnd = predicateAnd.And(filterField.FilterBoolean.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterBoolean.Operator.ToFilter(filterField.Field.ToField(),
                                                                                         filterField.FilterBoolean.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterStatus:
-            predicateAnd = predicateAnd.And(filterField.FilterStatus.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterStatus.Operator.ToFilter(filterField.Field.ToField(),
                                                                                        filterField.FilterStatus.Value));
             break;
           case FilterField.ValueConditionOneofCase.FilterDate:
             var val = filterField.FilterDate.Value;
-            predicateAnd = predicateAnd.And(filterField.FilterDate.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterDate.Operator.ToFilter(filterField.Field.ToField(),
                                                                                      val == null
                                                                                        ? null
                                                                                        : val.ToDateTime()));
             break;
           case FilterField.ValueConditionOneofCase.FilterArray:
-            predicateAnd = predicateAnd.And(filterField.FilterArray.Operator.ToFilter(filterField.Field.ToField(),
+            exprAnd = exprAnd.ExpressionAnd(filterField.FilterArray.Operator.ToFilter(filterField.Field.ToField(),
                                                                                       filterField.FilterArray.Value));
             break;
           case FilterField.ValueConditionOneofCase.None:
@@ -121,9 +119,9 @@ public static class ListTasksRequestExt
         }
       }
 
-      predicate = predicate.Or(predicateAnd);
+      expr = expr.ExpressionOr(exprAnd);
     }
 
-    return predicate;
+    return expr;
   }
 }

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -26,8 +26,6 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.Storage;
 
-using LinqKit;
-
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
@@ -186,7 +184,9 @@ public class SimpleTaskTable : ITaskTable
                              TaskOptions,
                              new Output(true,
                                         "")),
-                       }.Select(selector.Invoke));
+                       }.Where(filter.Compile())
+                        .Select(selector.Compile()));
+
 
   public Task<TaskData> UpdateOneTask(string                                                                        taskId,
                                       ICollection<(Expression<Func<TaskData, object?>> selector, object? newValue)> updates,


### PR DESCRIPTION
Some functions of LinqKit were used to generate predicate expressions for filters. We don't want to use this package anymore.