### PR TITLE
feat: Add options to enable GCS support

### DIFF
--- a/Adaptors/S3/src/ObjectStorage.cs
+++ b/Adaptors/S3/src/ObjectStorage.cs
@@ -69,7 +69,7 @@ public class ObjectStorage : IObjectStorage
     }
 
     logger_.LogInformation("ObjectStorage has correctly been initialized with options {@Options}",
-                           options_);
+                           options_.Confidential());
     isInitialized_ = true;
   }
 
@@ -95,7 +95,7 @@ public class ObjectStorage : IObjectStorage
     var       objectStorageFullName = $"{objectStorageName_}{key}";
     using var loggerFunction        = logger_.LogFunction(objectStorageFullName);
     using var loggerContext = logger_.BeginPropertyScope(("objectKey", key),
-                                                         ("@S3Options", options_));
+                                                         ("@S3Options", options_.Confidential()));
     try
     {
       await s3Client_.GetObjectAsync(options_.BucketName,
@@ -162,7 +162,7 @@ public class ObjectStorage : IObjectStorage
     var       objectStorageFullName = $"{objectStorageName_}{key}";
     using var loggerFunction        = logger_.LogFunction(objectStorageFullName);
     using var loggerContext = logger_.BeginPropertyScope(("objectKey", key),
-                                                         ("@S3Options", options_));
+                                                         ("@S3Options", options_.Confidential()));
     try
     {
       var objectDeleteRequest = new DeleteObjectRequest
@@ -198,7 +198,7 @@ public class ObjectStorage : IObjectStorage
     var       objectStorageFullName = $"{objectStorageName_}{key}";
     using var loggerFunction        = logger_.LogFunction(objectStorageFullName);
     using var loggerContext = logger_.BeginPropertyScope(("objectKey", key),
-                                                         ("@S3Options", options_));
+                                                         ("@S3Options", options_.Confidential()));
     logger_.LogDebug("Upload object");
     var initRequest = new InitiateMultipartUploadRequest
                       {

--- a/Adaptors/S3/src/ObjectStorage.cs
+++ b/Adaptors/S3/src/ObjectStorage.cs
@@ -202,6 +202,7 @@ public class ObjectStorage : IObjectStorage
     using var _                     = logger_.LogFunction(objectStorageFullName);
     using var loggerContext         = logger_.BeginPropertyScope(("key", key), ("chunkEncoding", useChunkEncoding_),
                                                                  ("md5Stream", useMd5Stream_));
+    logger_.LogDebug("Upload object");
     var initRequest = new InitiateMultipartUploadRequest
                       {
                         BucketName = bucketName_,

--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -40,4 +40,6 @@ public class S3
   ///   Use Chunk Encoding during upload
   /// </summary>
   public bool UseChunkEncoding { get; set; } = true;
+
+  public bool UseMd5Stream { get; set; } = true;
 }

--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -35,4 +35,9 @@ public class S3
   ///   Size of one chunk when downloading an object by chunks
   /// </summary>
   public int ChunkDownloadSize { get; set; } = 65536;
+
+  /// <summary>
+  ///   Use Chunk Encoding during upload
+  /// </summary>
+  public bool UseChunkEncoding { get; set; } = true;
 }

--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -41,5 +41,8 @@ public class S3
   /// </summary>
   public bool UseChunkEncoding { get; set; } = true;
 
-  public bool UseMd5Stream { get; set; } = true;
+  /// <summary>
+  ///   If true, checksum will be verified by the client during upload
+  /// </summary>
+  public bool UseChecksum { get; set; } = true;
 }

--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -38,6 +38,7 @@ public class S3
 
   /// <summary>
   ///   Use Chunk Encoding during upload
+  ///   Should be disabled for GCS
   /// </summary>
   public bool UseChunkEncoding { get; set; } = true;
 

--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -23,13 +23,13 @@ public class S3
   public       string EndpointUrl        { get; set; } = "";
   public       string Login              { get; set; } = "";
   public       string Password           { get; set; } = "";
-  public       bool   MustForcePathStyle { get; set; } = false;
+  public       bool   MustForcePathStyle { get; set; }
   public       string BucketName         { get; set; } = "";
 
   /// <summary>
   ///   Number of tasks to be used in parallel execution
   /// </summary>
-  public int DegreeOfParallelism { get; set; } = 0;
+  public int DegreeOfParallelism { get; set; }
 
   /// <summary>
   ///   Size of one chunk when downloading an object by chunks
@@ -46,4 +46,22 @@ public class S3
   ///   If true, checksum will be verified by the client during upload
   /// </summary>
   public bool UseChecksum { get; set; } = true;
+
+  /// <summary>
+  ///   Get a copy of the options with confidential fields removed
+  /// </summary>
+  /// <returns>Confidential copy</returns>
+  public S3 Confidential()
+    => new()
+       {
+         BucketName          = BucketName,
+         ChunkDownloadSize   = ChunkDownloadSize,
+         DegreeOfParallelism = DegreeOfParallelism,
+         EndpointUrl         = EndpointUrl,
+         Login               = Login,
+         MustForcePathStyle  = MustForcePathStyle,
+         Password            = "[CONFIDENTIAL]",
+         UseChecksum         = UseChecksum,
+         UseChunkEncoding    = UseChunkEncoding,
+       };
 }


### PR DESCRIPTION
Add `UseChunkEncoding` and `UseChecksum` options to S3 to make the client compatible with GCS