### PR TITLE
fix: Task Service CancelTasks throws when ownerPodId is null or empty

### DIFF
--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -234,8 +234,9 @@ public class GrpcTasksService : Task.TasksBase
                                         .ToListAsync()
                                         .ConfigureAwait(false);
       await ownerPodIds.ParallelForEach(new ParallelTaskOptions(10),
-                                        async ownerPodId => await httpClient_.GetAsync("http://" + ownerPodId + ":1080/stopcancelledtask")
-                                                                             .ConfigureAwait(false))
+                                        async ownerPodId => await (string.IsNullOrEmpty(ownerPodId)
+                                                                     ? System.Threading.Tasks.Task.CompletedTask
+                                                                     : httpClient_.GetAsync("http://" + ownerPodId + ":1080/stopcancelledtask")).ConfigureAwait(false))
                        .ConfigureAwait(false);
       return new CancelTasksResponse
              {

--- a/Common/tests/GrpcTasksServiceTests.cs
+++ b/Common/tests/GrpcTasksServiceTests.cs
@@ -15,12 +15,19 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Linq;
 using System.Threading.Tasks;
 
+using ArmoniK.Api.gRPC.V1;
+using ArmoniK.Api.gRPC.V1.Results;
+using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.gRPC.Services;
+using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Helpers;
+
+using Google.Protobuf.WellKnownTypes;
 
 using Grpc.Net.Client;
 
@@ -81,5 +88,113 @@ public class GrpcTasksServiceTests
                 Is.Not.Null);
     Assert.That(response.Tasks.Count,
                 Is.EqualTo(0));
+  }
+
+  [Test]
+  public async Task CancelNonScheduledTaskShouldSucceed()
+  {
+    var helper = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
+                                                                  .AddSingleton<IPushQueueStorage, SimplePushQueueStorage>()
+                                                                  .AddSingleton<IPartitionTable, SimplePartitionTable>()
+                                                                  .AddSingleton<Injection.Options.Submitter>()
+                                                                  .AddHttpClient()
+                                                                  .AddGrpc(),
+                                          builder => builder.UseRouting()
+                                                            .UseAuthorization(),
+                                          builder =>
+                                          {
+                                            builder.MapGrpcService<GrpcTasksService>();
+                                            builder.MapGrpcService<GrpcSessionsService>();
+                                            builder.MapGrpcService<GrpcResultsService>();
+                                          },
+                                          true);
+    await helper.App.StartAsync()
+                .ConfigureAwait(false);
+
+    var server = helper.App.GetTestServer();
+
+    var channel = GrpcChannel.ForAddress("http://localhost:9999",
+                                         new GrpcChannelOptions
+                                         {
+                                           HttpHandler = server.CreateHandler(),
+                                         });
+
+    var session_id = new Sessions.SessionsClient(channel).CreateSession(new CreateSessionRequest
+                                                                        {
+                                                                          DefaultTaskOption = new TaskOptions
+                                                                                              {
+                                                                                                MaxRetries = 1,
+                                                                                                Priority   = 2,
+                                                                                                MaxDuration = new Duration
+                                                                                                              {
+                                                                                                                Seconds = 500,
+                                                                                                                Nanos   = 0,
+                                                                                                              },
+                                                                                              },
+                                                                        })
+                                                         .SessionId;
+    var result_client = new Results.ResultsClient(channel);
+    var result_id = result_client.CreateResultsMetaData(new CreateResultsMetaDataRequest
+                                                        {
+                                                          SessionId = session_id,
+                                                          Results =
+                                                          {
+                                                            new CreateResultsMetaDataRequest.Types.ResultCreate
+                                                            {
+                                                              Name = "result_id",
+                                                            },
+                                                          },
+                                                        })
+                                 .Results.Single()
+                                 .ResultId;
+    var payload_id = result_client.CreateResults(new CreateResultsRequest
+                                                 {
+                                                   SessionId = session_id,
+                                                   Results =
+                                                   {
+                                                     new CreateResultsRequest.Types.ResultCreate
+                                                     {
+                                                       Name = "payload",
+                                                     },
+                                                   },
+                                                 })
+                                  .Results.Single()
+                                  .ResultId;
+
+    var client = new Tasks.TasksClient(channel);
+    // Submit an unschedulable task
+    var task_id = client.SubmitTasks(new SubmitTasksRequest
+                                     {
+                                       SessionId = session_id,
+                                       TaskCreations =
+                                       {
+                                         new SubmitTasksRequest.Types.TaskCreation
+                                         {
+                                           PayloadId = payload_id,
+                                           DataDependencies =
+                                           {
+                                             result_id,
+                                           },
+                                         },
+                                       },
+                                     })
+                        .TaskInfos.Single()
+                        .TaskId;
+
+    var response = client.CancelTasks(new CancelTasksRequest
+                                      {
+                                        TaskIds =
+                                        {
+                                          task_id,
+                                        },
+                                      });
+
+    Assert.That(response,
+                Is.Not.Null);
+    Assert.That(response.Tasks.Count,
+                Is.EqualTo(1));
+    Assert.That(response.Tasks.Single()
+                        .Id,
+                Is.EqualTo(task_id));
   }
 }


### PR DESCRIPTION
fixes #523 