### PR TITLE
feat: Batched dependency management

### DIFF
--- a/Adaptors/Memory/src/ResultTable.cs
+++ b/Adaptors/Memory/src/ResultTable.cs
@@ -90,18 +90,17 @@ public class ResultTable : IResultTable
   }
 
   /// <inheritdoc />
-  public Task AddTaskDependency(string              sessionId,
-                                ICollection<string> resultIds,
-                                ICollection<string> taskIds,
-                                CancellationToken   cancellationToken)
+  public Task AddTaskDependencies(string                                   sessionId,
+                                  IDictionary<string, ICollection<string>> dependencies,
+                                  CancellationToken                        cancellationToken = default)
   {
     if (!results_.TryGetValue(sessionId,
                               out var session))
     {
-      throw new SessionNotFoundException($"Session '{session}' not found");
+      throw new SessionNotFoundException($"Session '{sessionId}' not found");
     }
 
-    foreach (var resultId in resultIds)
+    foreach (var (resultId, taskIds) in dependencies)
     {
       if (!session.TryGetValue(resultId,
                                out var result))
@@ -110,34 +109,6 @@ public class ResultTable : IResultTable
       }
 
       result.DependentTasks.AddRange(taskIds);
-    }
-
-    return Task.CompletedTask;
-  }
-
-  /// <inheritdoc />
-  public Task AddTaskDependencies(string                                                                    sessionId,
-                                  IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
-                                  CancellationToken                                                         cancellationToken = default)
-  {
-    if (!results_.TryGetValue(sessionId,
-                              out var session))
-    {
-      throw new SessionNotFoundException($"Session '{sessionId}' not found");
-    }
-
-    foreach (var dependency in dependencies)
-    {
-      foreach (var resultId in dependency.resultIds)
-      {
-        if (!session.TryGetValue(resultId,
-                                 out var result))
-        {
-          throw new ResultNotFoundException($"Key '{resultId}' not found");
-        }
-
-        result.DependentTasks.AddRange(dependency.taskIds);
-      }
     }
 
     return Task.CompletedTask;

--- a/Adaptors/Memory/src/ResultTable.cs
+++ b/Adaptors/Memory/src/ResultTable.cs
@@ -116,6 +116,34 @@ public class ResultTable : IResultTable
   }
 
   /// <inheritdoc />
+  public Task AddTaskDependencies(string                                                                    sessionId,
+                                  IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
+                                  CancellationToken                                                         cancellationToken = default)
+  {
+    if (!results_.TryGetValue(sessionId,
+                              out var session))
+    {
+      throw new SessionNotFoundException($"Session '{sessionId}' not found");
+    }
+
+    foreach (var dependency in dependencies)
+    {
+      foreach (var resultId in dependency.resultIds)
+      {
+        if (!session.TryGetValue(resultId,
+                                 out var result))
+        {
+          throw new ResultNotFoundException($"Key '{resultId}' not found");
+        }
+
+        result.DependentTasks.AddRange(dependency.taskIds);
+      }
+    }
+
+    return Task.CompletedTask;
+  }
+
+  /// <inheritdoc />
   public Task DeleteResult(string            session,
                            string            key,
                            CancellationToken cancellationToken = default)

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -86,36 +86,12 @@ public class ResultTable : IResultTable
   }
 
   /// <inheritdoc />
-  public async Task AddTaskDependency(string              sessionId,
-                                      ICollection<string> resultIds,
-                                      ICollection<string> taskIds,
-                                      CancellationToken   cancellationToken)
+  public async Task AddTaskDependencies(string                                   sessionId,
+                                        IDictionary<string, ICollection<string>> dependencies,
+                                        CancellationToken                        cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(AddTaskDependency)}");
-    activity?.SetTag($"{nameof(AddTaskDependency)}_sessionId",
-                     sessionId);
-
-    var resultCollection = resultCollectionProvider_.Get();
-
-    var result = await resultCollection.UpdateManyAsync(Builders<Result>.Filter.Where(model => resultIds.Contains(model.ResultId)),
-                                                        Builders<Result>.Update.AddToSetEach(model => model.DependentTasks,
-                                                                                             taskIds),
-                                                        cancellationToken: cancellationToken)
-                                       .ConfigureAwait(false);
-
-    if (result.ModifiedCount != resultIds.Count)
-    {
-      throw new ResultNotFoundException("One of the input result was not found");
-    }
-  }
-
-  /// <inheritdoc />
-  public async Task AddTaskDependencies(string                                                                    sessionId,
-                                        IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
-                                        CancellationToken                                                         cancellationToken = default)
-  {
-    using var activity = activitySource_.StartActivity($"{nameof(AddTaskDependency)}");
-    activity?.SetTag($"{nameof(AddTaskDependency)}_sessionId",
+    using var activity = activitySource_.StartActivity($"{nameof(AddTaskDependencies)}");
+    activity?.SetTag($"{nameof(AddTaskDependencies)}_sessionId",
                      sessionId);
 
     var resultCollection = resultCollectionProvider_.Get();
@@ -125,14 +101,22 @@ public class ResultTable : IResultTable
       return;
     }
 
-    await resultCollection.BulkWriteAsync(dependencies.Select(dependency
-                                                                => new UpdateManyModel<Result>(Builders<Result>.Filter.Where(result
-                                                                                                                               => dependency.resultIds
-                                                                                                                                            .Contains(result.ResultId)),
-                                                                                               Builders<Result>.Update.AddToSetEach(result => result.DependentTasks,
-                                                                                                                                    dependency.taskIds))),
-                                          cancellationToken: cancellationToken)
-                          .ConfigureAwait(false);
+    var dependencyRequests = dependencies.Select(dependency => new UpdateManyModel<Result>(Builders<Result>.Filter.Where(result => dependency.Key == result.ResultId),
+                                                                                           Builders<Result>.Update.AddToSetEach(result => result.DependentTasks,
+                                                                                                                                dependency.Value)));
+
+    var writeResult = await resultCollection.BulkWriteAsync(dependencyRequests,
+                                                            new BulkWriteOptions
+                                                            {
+                                                              IsOrdered = false,
+                                                            },
+                                                            cancellationToken)
+                                            .ConfigureAwait(false);
+
+    if (writeResult.ModifiedCount != dependencies.Count)
+    {
+      throw new ResultNotFoundException($"One of the input result was not found: expected: {dependencies.Count}, found: {writeResult.ModifiedCount}");
+    }
   }
 
   async Task<Result> IResultTable.GetResult(string            sessionId,

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -69,29 +69,14 @@ public interface IResultTable : IInitializable
   ///   Add the tasks Ids to the list of reverse dependencies of the given results
   /// </summary>
   /// <param name="sessionId">Id of the session containing the result</param>
-  /// <param name="resultIds">List of result Id to update</param>
-  /// <param name="taskIds">List of task Id to add to each result dependents</param>
+  /// <param name="dependencies">Dictionary of the dependant tasks for each result</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
   ///   Task representing the asynchronous execution of the method
   /// </returns>
-  Task AddTaskDependency(string              sessionId,
-                         ICollection<string> resultIds,
-                         ICollection<string> taskIds,
-                         CancellationToken   cancellationToken = default);
-
-  /// <summary>
-  ///   Add the tasks Ids to the list of reverse dependencies of the given results
-  /// </summary>
-  /// <param name="sessionId">Id of the session containing the result</param>
-  /// <param name="dependencies">Enumeration of dependencies between results and tasks</param>
-  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
-  /// <returns>
-  ///   Task representing the asynchronous execution of the method
-  /// </returns>
-  Task AddTaskDependencies(string                                                                    sessionId,
-                           IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
-                           CancellationToken                                                         cancellationToken = default);
+  Task AddTaskDependencies(string                                   sessionId,
+                           IDictionary<string, ICollection<string>> dependencies,
+                           CancellationToken                        cancellationToken = default);
 
   /// <summary>
   ///   Delete the results from the database

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -81,6 +81,19 @@ public interface IResultTable : IInitializable
                          CancellationToken   cancellationToken = default);
 
   /// <summary>
+  ///   Add the tasks Ids to the list of reverse dependencies of the given results
+  /// </summary>
+  /// <param name="sessionId">Id of the session containing the result</param>
+  /// <param name="dependencies">Enumeration of dependencies between results and tasks</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Task representing the asynchronous execution of the method
+  /// </returns>
+  Task AddTaskDependencies(string                                                                    sessionId,
+                           IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
+                           CancellationToken                                                         cancellationToken = default);
+
+  /// <summary>
   ///   Delete the results from the database
   /// </summary>
   /// <param name="session">id of the session containing the result</param>

--- a/Common/tests/Helpers/SimpleResultTable.cs
+++ b/Common/tests/Helpers/SimpleResultTable.cs
@@ -63,6 +63,11 @@ public class SimpleResultTable : IResultTable
                                 CancellationToken   cancellationToken = default)
     => Task.CompletedTask;
 
+  public Task AddTaskDependencies(string                                                                    sessionId,
+                                  IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
+                                  CancellationToken                                                         cancellationToken = default)
+    => Task.CompletedTask;
+
   public Task DeleteResult(string            session,
                            string            key,
                            CancellationToken cancellationToken = default)

--- a/Common/tests/Helpers/SimpleResultTable.cs
+++ b/Common/tests/Helpers/SimpleResultTable.cs
@@ -57,15 +57,9 @@ public class SimpleResultTable : IResultTable
                      CancellationToken   cancellationToken = default)
     => Task.CompletedTask;
 
-  public Task AddTaskDependency(string              sessionId,
-                                ICollection<string> resultIds,
-                                ICollection<string> taskIds,
-                                CancellationToken   cancellationToken = default)
-    => Task.CompletedTask;
-
-  public Task AddTaskDependencies(string                                                                    sessionId,
-                                  IEnumerable<(ICollection<string> resultIds, ICollection<string> taskIds)> dependencies,
-                                  CancellationToken                                                         cancellationToken = default)
+  public Task AddTaskDependencies(string                                   sessionId,
+                                  IDictionary<string, ICollection<string>> dependencies,
+                                  CancellationToken                        cancellationToken = default)
     => Task.CompletedTask;
 
   public Task DeleteResult(string            session,

--- a/Common/tests/TestBase/ResultTableTestBase.cs
+++ b/Common/tests/TestBase/ResultTableTestBase.cs
@@ -653,16 +653,17 @@ public class ResultTableTestBase
                         .ConfigureAwait(false);
 
 
-      await ResultTable.AddTaskDependency(sessionId,
-                                          new List<string>
-                                          {
-                                            resultId,
-                                          },
-                                          new List<string>
-                                          {
-                                            "Task1",
-                                            "Task2",
-                                          })
+      await ResultTable.AddTaskDependencies(sessionId,
+                                            new Dictionary<string, ICollection<string>>
+                                            {
+                                              {
+                                                resultId, new[]
+                                                          {
+                                                            "Task1",
+                                                            "Task2",
+                                                          }
+                                              },
+                                            })
                        .ConfigureAwait(false);
 
       var dependents = await ResultTable.GetDependents(sessionId,
@@ -683,16 +684,17 @@ public class ResultTableTestBase
   {
     if (RunTests)
     {
-      Assert.ThrowsAsync<ResultNotFoundException>(async () => await ResultTable!.AddTaskDependency("SessionId",
-                                                                                                   new List<string>
-                                                                                                   {
-                                                                                                     "resultDoesNotExist",
-                                                                                                   },
-                                                                                                   new List<string>
-                                                                                                   {
-                                                                                                     "Task1",
-                                                                                                     "Task2",
-                                                                                                   })
+      Assert.ThrowsAsync<ResultNotFoundException>(async () => await ResultTable!.AddTaskDependencies("SessionId",
+                                                                                                     new Dictionary<string, ICollection<string>>
+                                                                                                     {
+                                                                                                       {
+                                                                                                         "resultDoesNotExist", new[]
+                                                                                                                               {
+                                                                                                                                 "Task1",
+                                                                                                                                 "Task2",
+                                                                                                                               }
+                                                                                                       },
+                                                                                                     })
                                                                                 .ConfigureAwait(false));
     }
   }


### PR DESCRIPTION
When creating many tasks, the dependency management is slow because it consists of many requests. This PR batch the requests to make this much faster.

Before this, HTCmock generates 10000 subtasks in one go took 2 minutes, now it takes 7s.