### PR TITLE
fix: reduce metrics exported

### DIFF
--- a/Adaptors/MongoDB/src/PartitionTable.cs
+++ b/Adaptors/MongoDB/src/PartitionTable.cs
@@ -193,10 +193,9 @@ public class PartitionTable : IPartitionTable
     }
 
     // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
-    var findFluent2 = partitionCollection.Find(sessionHandle,
-                                               filter);
-
-    var partitionCount = findFluent2.CountDocumentsAsync(cancellationToken);
+    var partitionCount = partitionCollection.CountDocumentsAsync(sessionHandle,
+                                                                 filter,
+                                                                 cancellationToken: cancellationToken);
 
     return (await partitionList.ConfigureAwait(false), (int)await partitionCount.ConfigureAwait(false));
   }

--- a/Adaptors/MongoDB/src/PartitionTable.cs
+++ b/Adaptors/MongoDB/src/PartitionTable.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -176,18 +177,56 @@ public class PartitionTable : IPartitionTable
     var       sessionHandle       = sessionProvider_.Get();
     var       partitionCollection = partitionCollectionProvider_.Get();
 
-    var queryable = partitionCollection.AsQueryable(sessionHandle)
-                                       .Where(filter);
+    var partitionList = Task.FromResult(new List<PartitionData>());
+    if (pageSize > 0)
+    {
+      var findFluent1 = partitionCollection.Find(sessionHandle,
+                                                 filter);
 
-    var ordered = ascOrder
-                    ? queryable.OrderBy(orderField)
-                    : queryable.OrderByDescending(orderField);
+      var ordered = ascOrder
+                      ? findFluent1.SortBy(orderField)
+                      : findFluent1.SortByDescending(orderField);
 
-    var partitionResult = ordered.Skip(page * pageSize)
-                                 .Take(pageSize)
-                                 .ToListAsync(cancellationToken);
+      partitionList = ordered.Skip(page * pageSize)
+                             .Limit(pageSize)
+                             .ToListAsync(cancellationToken);
+    }
 
-    return (await partitionResult.ConfigureAwait(false), await ordered.CountAsync(cancellationToken)
-                                                                      .ConfigureAwait(false));
+    // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
+    var findFluent2 = partitionCollection.Find(sessionHandle,
+                                               filter);
+
+    var partitionCount = findFluent2.CountDocumentsAsync(cancellationToken);
+
+    return (await partitionList.ConfigureAwait(false), (int)await partitionCount.ConfigureAwait(false));
+  }
+
+  /// <summary>
+  ///   Find all partitions matching the given filter
+  /// </summary>
+  /// <param name="filter">Filter to select partitions</param>
+  /// <param name="selector">Expression to select part of the returned partition</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   List of partitions that match the filter
+  /// </returns>
+  public async IAsyncEnumerable<T> FindPartitionsAsync<T>(Expression<Func<PartitionData, bool>>      filter,
+                                                          Expression<Func<PartitionData, T>>         selector,
+                                                          [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    using var activity            = activitySource_.StartActivity($"{nameof(FindPartitionsAsync)}");
+    var       sessionHandle       = sessionProvider_.Get();
+    var       partitionCollection = partitionCollectionProvider_.Get();
+
+    await foreach (var partition in partitionCollection.Find(sessionHandle,
+                                                             filter)
+                                                       .Project(selector)
+                                                       .ToAsyncEnumerable(cancellationToken)
+                                                       .ConfigureAwait(false))
+    {
+      yield return partition;
+    }
+
+    ;
   }
 }

--- a/Adaptors/MongoDB/src/PartitionTable.cs
+++ b/Adaptors/MongoDB/src/PartitionTable.cs
@@ -225,7 +225,5 @@ public class PartitionTable : IPartitionTable
     {
       yield return partition;
     }
-
-    ;
   }
 }

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -145,18 +145,28 @@ public class ResultTable : IResultTable
     var       resultCollection = resultCollectionProvider_.Get();
 
 
-    var queryable = resultCollection.AsQueryable(sessionHandle)
-                                    .Where(filter);
+    var resultList = Task.FromResult(new List<Result>());
+    if (pageSize > 0)
+    {
+      var findFluent1 = resultCollection.Find(sessionHandle,
+                                              filter);
 
-    var ordered = ascOrder
-                    ? queryable.OrderBy(orderField)
-                    : queryable.OrderByDescending(orderField);
+      var ordered = ascOrder
+                      ? findFluent1.SortBy(orderField)
+                      : findFluent1.SortByDescending(orderField);
 
-    return (await ordered.Skip(page * pageSize)
-                         .Take(pageSize)
-                         .ToListAsync(cancellationToken) // todo : do not create list there but pass cancellation token
-                         .ConfigureAwait(false), await ordered.CountAsync(cancellationToken)
-                                                              .ConfigureAwait(false));
+      resultList = ordered.Skip(page * pageSize)
+                          .Limit(pageSize)
+                          .ToListAsync(cancellationToken);
+    }
+
+    // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
+    var findFluent2 = resultCollection.Find(sessionHandle,
+                                            filter);
+
+    var resultCount = findFluent2.CountDocumentsAsync(cancellationToken);
+
+    return (await resultList.ConfigureAwait(false), (int)await resultCount.ConfigureAwait(false));
   }
 
   /// <inheritdoc />

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -161,10 +161,9 @@ public class ResultTable : IResultTable
     }
 
     // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
-    var findFluent2 = resultCollection.Find(sessionHandle,
-                                            filter);
-
-    var resultCount = findFluent2.CountDocumentsAsync(cancellationToken);
+    var resultCount = resultCollection.CountDocumentsAsync(sessionHandle,
+                                                           filter,
+                                                           cancellationToken: cancellationToken);
 
     return (await resultList.ConfigureAwait(false), (int)await resultCount.ConfigureAwait(false));
   }

--- a/Adaptors/MongoDB/src/SessionTable.cs
+++ b/Adaptors/MongoDB/src/SessionTable.cs
@@ -181,10 +181,9 @@ public class SessionTable : ISessionTable
     }
 
     // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
-    var findFluent2 = sessionCollection.Find(sessionHandle,
-                                             filter);
-
-    var sessionCount = findFluent2.CountDocumentsAsync(cancellationToken);
+    var sessionCount = sessionCollection.CountDocumentsAsync(sessionHandle,
+                                                             filter,
+                                                             cancellationToken: cancellationToken);
 
     return (await sessionList.ConfigureAwait(false), await sessionCount.ConfigureAwait(false));
   }

--- a/Adaptors/MongoDB/src/Table/DataModel/IndexHelper.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/IndexHelper.cs
@@ -116,6 +116,24 @@ public class IndexHelper
            });
 
   /// <summary>
+  ///   Creates a combined index model from expression
+  /// </summary>
+  /// <typeparam name="T">Type stored in database</typeparam>
+  /// <param name="first">Expression to select the field for the first index</param>
+  /// <param name="second">Expression to select the field for the second index</param>
+  /// <returns>
+  ///   The combined index model
+  /// </returns>
+  public static CreateIndexModel<T> CreateCombinedIndex<T>(Expression<Func<T, object?>> first,
+                                                           Expression<Func<T, object?>> second)
+    => new(Builders<T>.IndexKeys.Combine(Builders<T>.IndexKeys.Ascending(new ExpressionFieldDefinition<T>(first)),
+                                         Builders<T>.IndexKeys.Ascending(new ExpressionFieldDefinition<T>(second))),
+           new CreateIndexOptions
+           {
+             Name = $"{first.GetMember().Name}_1_{second.GetMember().Name}_1",
+           });
+
+  /// <summary>
   ///   Creates a combined index model (hashed + ascending) from expression
   /// </summary>
   /// <typeparam name="T">Type stored in database</typeparam>
@@ -124,8 +142,8 @@ public class IndexHelper
   /// <returns>
   ///   The combined index model
   /// </returns>
-  public static CreateIndexModel<T> CreateCombinedIndex<T>(Expression<Func<T, object?>> hashed,
-                                                           Expression<Func<T, object?>> ascending)
+  public static CreateIndexModel<T> CreateHashedCombinedIndex<T>(Expression<Func<T, object?>> hashed,
+                                                                 Expression<Func<T, object?>> ascending)
     => new(Builders<T>.IndexKeys.Combine(Builders<T>.IndexKeys.Hashed(new ExpressionFieldDefinition<T>(hashed)),
                                          Builders<T>.IndexKeys.Ascending(new ExpressionFieldDefinition<T>(ascending))),
            new CreateIndexOptions

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -190,6 +190,8 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                         IndexHelper.CreateAscendingIndex<TaskData>(model => model.EndDate),
                         IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationToEndDuration),
                         IndexHelper.CreateAscendingIndex<TaskData>(model => model.ProcessingToEndDuration),
+                        IndexHelper.CreateCombinedIndex<TaskData>(model => model.Options.PartitionId,
+                                                                  model => model.Status),
                       };
 
     await collection.Indexes.CreateManyAsync(sessionHandle,

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -270,10 +270,9 @@ public class TaskTable : ITaskTable
     }
 
     // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
-    var findFluent2 = taskCollection.Find(sessionHandle,
-                                          filter);
-
-    var taskCount = findFluent2.CountDocumentsAsync(cancellationToken);
+    var taskCount = taskCollection.CountDocumentsAsync(sessionHandle,
+                                                       filter,
+                                                       cancellationToken: cancellationToken);
 
     return (await taskList.ConfigureAwait(false), await taskCount.ConfigureAwait(false));
   }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -253,20 +253,25 @@ public class TaskTable : ITaskTable
     var       sessionHandle  = sessionProvider_.Get();
     var       taskCollection = taskCollectionProvider_.Get();
 
+    var taskList = Task.FromResult(new List<T>());
+    if (pageSize > 0)
+    {
+      var findFluent1 = taskCollection.Find(sessionHandle,
+                                            filter);
+
+      var ordered = ascOrder
+                      ? findFluent1.SortBy(orderField)
+                      : findFluent1.SortByDescending(orderField);
+
+      taskList = ordered.Skip(page * pageSize)
+                        .Limit(pageSize)
+                        .Project(selector)
+                        .ToListAsync(cancellationToken);
+    }
+
     // Find needs to be duplicated, otherwise, the count is computed on a single page, and not the whole collection
-    var findFluent1 = taskCollection.Find(sessionHandle,
-                                          filter);
     var findFluent2 = taskCollection.Find(sessionHandle,
                                           filter);
-
-    var ordered = ascOrder
-                    ? findFluent1.SortBy(orderField)
-                    : findFluent1.SortByDescending(orderField);
-
-    var taskList = ordered.Skip(page * pageSize)
-                          .Limit(pageSize)
-                          .Project(selector)
-                          .ToListAsync(cancellationToken);
 
     var taskCount = findFluent2.CountDocumentsAsync(cancellationToken);
 

--- a/Adaptors/MongoDB/tests/IndexTest.cs
+++ b/Adaptors/MongoDB/tests/IndexTest.cs
@@ -214,6 +214,8 @@ internal class IndexTest
                                                                   model => model.SessionId),
                         IndexHelper.CreateCombinedIndex<TaskData>(model => model.TaskId,
                                                                   model => model.Status),
+                        IndexHelper.CreateHashedCombinedIndex<TaskData>(model => model.TaskId,
+                                                                        model => model.Status),
                       };
 
     collection.Indexes.CreateMany(indexModels);

--- a/Common/src/Storage/IPartitionTable.cs
+++ b/Common/src/Storage/IPartitionTable.cs
@@ -99,10 +99,27 @@ public interface IPartitionTable : IInitializable
   /// <returns>
   ///   Collection of partition metadata matching the request and total number of results without paging
   /// </returns>
+  /// <remarks>
+  ///   If <paramref name="pageSize" /> is 0, this function can be used to count the number of partitions
+  ///   satisfying the condition specified by <paramref name="filter" />
+  /// </remarks>
   Task<(IEnumerable<PartitionData> partitions, int totalCount)> ListPartitionsAsync(Expression<Func<PartitionData, bool>>    filter,
                                                                                     Expression<Func<PartitionData, object?>> orderField,
                                                                                     bool                                     ascOrder,
                                                                                     int                                      page,
                                                                                     int                                      pageSize,
                                                                                     CancellationToken                        cancellationToken = default);
+
+  /// <summary>
+  ///   Find all partitions matching the given filter
+  /// </summary>
+  /// <param name="filter">Filter to select partitions</param>
+  /// <param name="selector">Expression to select part of the returned partition</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   List of partitions that match the filter
+  /// </returns>
+  IAsyncEnumerable<T> FindPartitionsAsync<T>(Expression<Func<PartitionData, bool>> filter,
+                                             Expression<Func<PartitionData, T>>    selector,
+                                             CancellationToken                     cancellationToken = default);
 }

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -129,6 +129,10 @@ public interface IResultTable : IInitializable
   /// <returns>
   ///   Collection of results metadata that matched the filter and total number of results without paging
   /// </returns>
+  /// <remarks>
+  ///   If <paramref name="pageSize" /> is 0, this function can be used to count the number of results
+  ///   satisfying the condition specified by <paramref name="filter" />
+  /// </remarks>
   Task<(IEnumerable<Result> results, int totalCount)> ListResultsAsync(Expression<Func<Result, bool>>    filter,
                                                                        Expression<Func<Result, object?>> orderField,
                                                                        bool                              ascOrder,

--- a/Common/src/Storage/ISessionTable.cs
+++ b/Common/src/Storage/ISessionTable.cs
@@ -99,6 +99,10 @@ public interface ISessionTable : IInitializable
   /// <returns>
   ///   Collection of sessions metadata that matched the filter and total number of results without paging
   /// </returns>
+  /// <remarks>
+  ///   If <paramref name="pageSize" /> is 0, this function can be used to count the number of sessions
+  ///   satisfying the condition specified by <paramref name="filter" />
+  /// </remarks>
   Task<(IEnumerable<SessionData> sessions, long totalCount)> ListSessionsAsync(Expression<Func<SessionData, bool>>    filter,
                                                                                Expression<Func<SessionData, object?>> orderField,
                                                                                bool                                   ascOrder,

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -162,6 +162,10 @@ public interface ITaskTable : IInitializable
   /// <returns>
   ///   Collection of task metadata matching the request and total number of results without paging
   /// </returns>
+  /// <remarks>
+  ///   If <paramref name="pageSize" /> is 0, this function can be used to count the number of tasks
+  ///   satisfying the condition specified by <paramref name="filter" />
+  /// </remarks>
   Task<(IEnumerable<T> tasks, long totalCount)> ListTasksAsync<T>(Expression<Func<TaskData, bool>>    filter,
                                                                   Expression<Func<TaskData, object?>> orderField,
                                                                   Expression<Func<TaskData, T>>       selector,

--- a/Common/tests/Helpers/SimplePartitionTable.cs
+++ b/Common/tests/Helpers/SimplePartitionTable.cs
@@ -77,4 +77,9 @@ public class SimplePartitionTable : IPartitionTable
                         {
                           PartitionData,
                         }.AsEnumerable(), 1));
+
+  public IAsyncEnumerable<T> FindPartitionsAsync<T>(Expression<Func<PartitionData, bool>> filter,
+                                                    Expression<Func<PartitionData, T>>    selector,
+                                                    CancellationToken                     cancellationToken = default)
+    => AsyncEnumerable.Empty<T>();
 }

--- a/Control/Metrics/src/ArmoniKMeter.cs
+++ b/Control/Metrics/src/ArmoniKMeter.cs
@@ -225,7 +225,7 @@ public class ArmoniKMeter : Meter, IHostedService
     return count;
   }
 
-  private class MeasurementReader<T>
+  private sealed class MeasurementReader<T>
     where T : struct
   {
     private readonly ExecutionSingleizer<T>           exec_;

--- a/Control/Metrics/src/Options/MetricsExporter.cs
+++ b/Control/Metrics/src/Options/MetricsExporter.cs
@@ -1,0 +1,33 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2023. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using JetBrains.Annotations;
+
+// ReSharper disable InconsistentNaming
+
+namespace ArmoniK.Core.Control.Metrics.Options;
+
+[PublicAPI]
+public class MetricsExporter
+{
+  public const string SettingSection = nameof(MetricsExporter);
+
+  public string   Metrics       { get; set; } = "";
+  public TimeSpan CacheValidity { get; set; } = TimeSpan.FromSeconds(5);
+}

--- a/Control/Metrics/src/Program.cs
+++ b/Control/Metrics/src/Program.cs
@@ -105,13 +105,16 @@ public static class Program
                          endpoints.MapControllers();
                        });
 
-      var sessionProvider        = app.Services.GetRequiredService<SessionProvider>();
-      var taskCollectionProvider = app.Services.GetRequiredService<MongoCollectionProvider<TaskData, TaskDataModelMapping>>();
+      var sessionProvider             = app.Services.GetRequiredService<SessionProvider>();
+      var taskCollectionProvider      = app.Services.GetRequiredService<MongoCollectionProvider<TaskData, TaskDataModelMapping>>();
+      var partitionCollectionProvider = app.Services.GetRequiredService<MongoCollectionProvider<PartitionData, PartitionDataModelMapping>>();
 
       await sessionProvider.Init(CancellationToken.None)
                            .ConfigureAwait(false);
       await taskCollectionProvider.Init(CancellationToken.None)
                                   .ConfigureAwait(false);
+      await partitionCollectionProvider.Init(CancellationToken.None)
+                                       .ConfigureAwait(false);
       await app.RunAsync()
                .ConfigureAwait(false);
 

--- a/Control/Metrics/src/Program.cs
+++ b/Control/Metrics/src/Program.cs
@@ -26,6 +26,8 @@ using ArmoniK.Core.Adapters.MongoDB.Table.DataModel;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Utils;
+using ArmoniK.Core.Control.Metrics.Options;
+using ArmoniK.Core.Utils;
 
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -63,6 +65,7 @@ public static class Program
       builder.Services.AddLogging(logger.Configure)
              .AddMongoComponents(builder.Configuration,
                                  logger.GetLogger())
+             .AddSingleton(builder.Configuration.GetInitializedValue<MetricsExporter>(MetricsExporter.SettingSection))
              .AddHostedService<ArmoniKMeter>()
              .AddControllers();
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -219,6 +219,7 @@ variable "ingress" {
 variable "custom_env_vars" {
   type = map(string)
   default = {
+    MetricsExporter__Metrics = "completed,error,retried"
   }
 }
 


### PR DESCRIPTION
Revamp how the metrics are computed and exported.

This enables to filter out some metrics that are not useful in order to reduce the load on the database.
It also improves the database query to avoid scanning all documents, only the indexed keys are scanned now.

For a database with 1.5M tasks, here are the performance to count all the tasks:
- Before: 1000ms
- After, without proper index: 2000ms
- After, with proper (combined) index: 450ms