### PR TITLE
feat: use dotnet 8 azurelinux3.0 distroless docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 ARG TARGETARCH
 ADD --chmod=755 https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-${TARGETARCH} /tini
 USER $APP_UID

--- a/Dockerfile
+++ b/Dockerfile
@@ -104,6 +104,8 @@ RUN dotnet publish "ArmoniK.Core.Control.Submitter.csproj" -a "${TARGETARCH}" --
 
 
 FROM base-${TARGETOS} AS polling_agent
+WORKDIR /adapters/queue/sqs
+COPY --from=build /app/publish/sqs .
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
 WORKDIR /adapters/queue/amqp
@@ -142,6 +144,8 @@ CMD ["ArmoniK.Core.Control.PartitionMetrics.dll"]
 
 
 FROM base-${TARGETOS} AS submitter
+WORKDIR /adapters/queue/sqs
+COPY --from=build /app/publish/sqs .
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
 WORKDIR /adapters/queue/amqp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled as base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
 ARG TARGETARCH
 ADD --chmod=755 https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-${TARGETARCH} /tini
 USER $APP_UID
@@ -103,7 +103,7 @@ WORKDIR /src/Control/Submitter/src
 RUN dotnet publish "ArmoniK.Core.Control.Submitter.csproj" -a "${TARGETARCH}" --no-restore -o /app/publish/submitter /p:UseAppHost=false -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion=$VERSION -p:Version=$VERSION
 
 
-FROM base-${TARGETOS} as polling_agent
+FROM base-${TARGETOS} AS polling_agent
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
 WORKDIR /adapters/queue/amqp
@@ -125,7 +125,7 @@ EXPOSE 1080
 CMD ["ArmoniK.Core.Compute.PollingAgent.dll"]
 
 
-FROM base-${TARGETOS} as metrics
+FROM base-${TARGETOS} AS metrics
 WORKDIR /app
 COPY --from=build /app/publish/metrics .
 ENV ASPNETCORE_URLS http://+:1080
@@ -133,7 +133,7 @@ EXPOSE 1080
 CMD ["ArmoniK.Core.Control.Metrics.dll"]
 
 
-FROM base-${TARGETOS} as partition_metrics
+FROM base-${TARGETOS} AS partition_metrics
 WORKDIR /app
 COPY --from=build /app/publish/partition_metrics .
 ENV ASPNETCORE_URLS http://+:1080
@@ -141,7 +141,7 @@ EXPOSE 1080
 CMD ["ArmoniK.Core.Control.PartitionMetrics.dll"]
 
 
-FROM base-${TARGETOS} as submitter
+FROM base-${TARGETOS} AS submitter
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
 WORKDIR /adapters/queue/amqp

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ ARG VERSION=1.0.0.0
 ARG TARGETARCH
 ARG TARGETOS
 
-RUN mkdir /cache /local_storage /comm
-
 WORKDIR /src
 # git ls-tree -r HEAD --name-only --full-tree | grep "csproj$" | xargs -I % sh -c "export D=\$(dirname %) ; echo COPY [\\\"%\\\", \\\"\$D/\\\"]"
 COPY ["Adaptors/Amqp/src/ArmoniK.Core.Adapters.Amqp.csproj", "Adaptors/Amqp/src/"]
@@ -106,10 +104,6 @@ RUN dotnet publish "ArmoniK.Core.Control.Submitter.csproj" -a "${TARGETARCH}" --
 
 
 FROM base-${TARGETOS} as polling_agent
-WORKDIR /
-COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
-COPY --from=build --chown=$APP_UID:$APP_UID /local_storage /local_storage
-COPY --from=build --chown=$APP_UID:$APP_UID /comm /comm
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
 WORKDIR /adapters/queue/amqp
@@ -148,8 +142,6 @@ CMD ["ArmoniK.Core.Control.PartitionMetrics.dll"]
 
 
 FROM base-${TARGETOS} as submitter
-WORKDIR /
-COPY --from=build --chown=$APP_UID:$APP_UID /local_storage /local_storage
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
 WORKDIR /adapters/queue/amqp

--- a/Tests/Bench/Client/src/Dockerfile
+++ b/Tests/Bench/Client/src/Dockerfile
@@ -1,8 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-USER armonikuser
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS base-windows

--- a/Tests/Bench/Client/src/Dockerfile
+++ b/Tests/Bench/Client/src/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/Bench/Server/src/Dockerfile
+++ b/Tests/Bench/Server/src/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/Bench/Server/src/Dockerfile
+++ b/Tests/Bench/Server/src/Dockerfile
@@ -12,8 +12,6 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0
 
-RUN mkdir /cache
-
 WORKDIR /src
 COPY ["Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj", "Tests/Bench/Server/src/"]
 RUN dotnet restore -a "${TARGETARCH}" "Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj"
@@ -22,8 +20,6 @@ WORKDIR "/src/Tests/Bench/Server/src"
 RUN dotnet publish -a "${TARGETARCH}" "ArmoniK.Samples.Bench.Server.csproj" -o /app/publish -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion="$VERSION" -p:Version="$VERSION"
 
 FROM base-${TARGETOS} AS final
-WORKDIR /
-COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 1080

--- a/Tests/Bench/Server/src/Dockerfile
+++ b/Tests/Bench/Server/src/Dockerfile
@@ -1,9 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-RUN mkdir /cache && chown armonikuser: /cache
-USER armonikuser
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS base-windows
@@ -14,6 +12,8 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0
 
+RUN mkdir /cache
+
 WORKDIR /src
 COPY ["Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj", "Tests/Bench/Server/src/"]
 RUN dotnet restore -a "${TARGETARCH}" "Tests/Bench/Server/src/ArmoniK.Samples.Bench.Server.csproj"
@@ -22,6 +22,8 @@ WORKDIR "/src/Tests/Bench/Server/src"
 RUN dotnet publish -a "${TARGETARCH}" "ArmoniK.Samples.Bench.Server.csproj" -o /app/publish -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion="$VERSION" -p:Version="$VERSION"
 
 FROM base-${TARGETOS} AS final
+WORKDIR /
+COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 1080

--- a/Tests/CrashingWorker/Client/src/Dockerfile
+++ b/Tests/CrashingWorker/Client/src/Dockerfile
@@ -1,8 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-USER armonikuser
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS base-windows

--- a/Tests/CrashingWorker/Client/src/Dockerfile
+++ b/Tests/CrashingWorker/Client/src/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/CrashingWorker/Server/src/Dockerfile
+++ b/Tests/CrashingWorker/Server/src/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/CrashingWorker/Server/src/Dockerfile
+++ b/Tests/CrashingWorker/Server/src/Dockerfile
@@ -1,9 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-RUN mkdir /cache && chown armonikuser: /cache
-USER armonikuser
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS base-windows

--- a/Tests/HtcMock/Client/src/Dockerfile
+++ b/Tests/HtcMock/Client/src/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/HtcMock/Client/src/Dockerfile
+++ b/Tests/HtcMock/Client/src/Dockerfile
@@ -1,8 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-USER armonikuser
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-windowsservercore-ltsc2022 AS base-windows

--- a/Tests/HtcMock/Server/src/Dockerfile
+++ b/Tests/HtcMock/Server/src/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/HtcMock/Server/src/Dockerfile
+++ b/Tests/HtcMock/Server/src/Dockerfile
@@ -12,8 +12,6 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0
 
-RUN mkdir /cache
-
 WORKDIR /src
 COPY ["Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj", "Tests/HtcMock/Server/src/"]
 RUN dotnet restore -a "${TARGETARCH}" "Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj"
@@ -22,8 +20,6 @@ WORKDIR "/src/Tests/HtcMock/Server/src"
 RUN dotnet publish -a "${TARGETARCH}" "ArmoniK.Samples.HtcMock.Server.csproj" -o /app/publish -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion="$VERSION" -p:Version="$VERSION"
 
 FROM base-${TARGETOS} AS final
-WORKDIR /
-COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 1080

--- a/Tests/HtcMock/Server/src/Dockerfile
+++ b/Tests/HtcMock/Server/src/Dockerfile
@@ -1,9 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-RUN mkdir /cache && chown armonikuser: /cache
-USER armonikuser
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS base-windows
@@ -14,6 +12,8 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0
 
+RUN mkdir /cache
+
 WORKDIR /src
 COPY ["Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj", "Tests/HtcMock/Server/src/"]
 RUN dotnet restore -a "${TARGETARCH}" "Tests/HtcMock/Server/src/ArmoniK.Samples.HtcMock.Server.csproj"
@@ -22,6 +22,8 @@ WORKDIR "/src/Tests/HtcMock/Server/src"
 RUN dotnet publish -a "${TARGETARCH}" "ArmoniK.Samples.HtcMock.Server.csproj" -o /app/publish -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion="$VERSION" -p:Version="$VERSION"
 
 FROM base-${TARGETOS} AS final
+WORKDIR /
+COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
 WORKDIR /app
 COPY --from=build /app/publish .
 EXPOSE 1080

--- a/Tests/Stream/Client/Dockerfile
+++ b/Tests/Stream/Client/Dockerfile
@@ -1,11 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser \
- && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser \ 
- && mkdir /app \
- && chown -R armonikuser: /app
-USER armonikuser
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022 AS base-windows

--- a/Tests/Stream/Server/Dockerfile
+++ b/Tests/Stream/Server/Dockerfile
@@ -1,6 +1,6 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless AS base-linux
 USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 

--- a/Tests/Stream/Server/Dockerfile
+++ b/Tests/Stream/Server/Dockerfile
@@ -12,8 +12,6 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0
 
-RUN mkdir /cache
-
 WORKDIR /src
 COPY ["Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj", "Tests/Stream/Server/"]
 COPY ["Tests/Stream/Common/ArmoniK.Extensions.Common.StreamWrapper.Tests.Common.csproj", "Tests/Stream/Common/"]
@@ -24,8 +22,6 @@ WORKDIR "/src/Tests/Stream/Server"
 RUN dotnet publish -a "${TARGETARCH}" "ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj" --no-restore -o /app/publish -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion="$VERSION" -p:Version="$VERSION"
 
 FROM base-${TARGETOS} AS final
-WORKDIR /
-COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
 WORKDIR /app
 COPY --from=build /app/publish .
 CMD ["ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.dll"]

--- a/Tests/Stream/Server/Dockerfile
+++ b/Tests/Stream/Server/Dockerfile
@@ -1,12 +1,7 @@
 #See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base-linux
-RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
-RUN mkdir /cache && chown armonikuser: /cache
-USER armonikuser
-ENV ASPNETCORE_URLS http://+:1080;https://+1443
-EXPOSE 1080
-EXPOSE 1443
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-jammy-chiseled AS base-linux
+USER $APP_UID
 ENTRYPOINT [ "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/sdk:8.0-nanoserver-ltsc2022 AS base-windows
@@ -16,6 +11,8 @@ FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 ARG TARGETARCH
 ARG TARGETOS
 ARG VERSION=1.0.0.0
+
+RUN mkdir /cache
 
 WORKDIR /src
 COPY ["Tests/Stream/Server/ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj", "Tests/Stream/Server/"]
@@ -27,6 +24,8 @@ WORKDIR "/src/Tests/Stream/Server"
 RUN dotnet publish -a "${TARGETARCH}" "ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.csproj" --no-restore -o /app/publish -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion="$VERSION" -p:Version="$VERSION"
 
 FROM base-${TARGETOS} AS final
+WORKDIR /
+COPY --from=build --chown=$APP_UID:$APP_UID /cache /cache
 WORKDIR /app
 COPY --from=build /app/publish .
 CMD ["ArmoniK.Extensions.Common.StreamWrapper.Tests.Server.dll"]

--- a/justfile
+++ b/justfile
@@ -134,10 +134,10 @@ export TF_VAR_log_driver_image:= if os_family() == "windows" {
   "fluent/fluent-bit:latest"
 }
 
-export TF_VAR_mongodb_params:= if os_family() == "windows" {
-  '{"windows": "true"}'
+export TF_VAR_windows:= if os_family() == "windows" {
+  "true"
 } else {
-  '{}'
+  "false"
 }
 
 export TF_VAR_compute_plane:= if os_family() == "windows" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -32,6 +32,7 @@ module "database" {
   image          = var.database_image
   network        = docker_network.armonik.id
   mongodb_params = var.mongodb_params
+  windows        = var.windows
 }
 
 module "object_redis" {
@@ -138,6 +139,7 @@ module "compute_plane" {
   log_driver         = module.fluenbit.log_driver
   mounts             = local.mounts
   container_init     = var.container_init
+  windows            = var.windows
 }
 
 module "metrics_exporter" {

--- a/terraform/modules/compute_plane/inputs.tf
+++ b/terraform/modules/compute_plane/inputs.tf
@@ -62,3 +62,7 @@ variable "log_driver" {
 variable "container_init" {
   type = bool
 }
+
+variable "windows" {
+  type = bool
+}

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -6,6 +6,11 @@ resource "docker_volume" "socket_vol" {
 
 resource "docker_volume" "comm_vol" {
   name = "comm_vol${var.replica_counter}"
+  driver_opts = {
+    o : "uid=3333"
+    device : "tmpfs"
+    type : "tmpfs"
+  }
 }
 
 resource "docker_image" "worker" {
@@ -64,6 +69,7 @@ resource "docker_container" "polling_agent" {
 
   env = concat(local.env, local.gen_env, local.common_env)
 
+  user       = 3333
   log_driver = var.log_driver.name
   log_opts   = var.log_driver.log_opts
 

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -32,7 +32,6 @@ resource "docker_container" "worker" {
 
   env = concat(["Serilog__Properties__Application=${var.worker.serilog_application_name}"], local.gen_env, local.common_env)
 
-  user       = 3333
   log_driver = var.log_driver.name
   log_opts   = var.log_driver.log_opts
 
@@ -74,7 +73,6 @@ resource "docker_container" "polling_agent" {
 
   env = concat(local.env, local.gen_env, local.common_env)
 
-  user       = 3333
   log_driver = var.log_driver.name
   log_opts   = var.log_driver.log_opts
 

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -1,7 +1,7 @@
 resource "docker_volume" "socket_vol" {
   count = var.socket_type == "tcp" ? 0 : 1
   name  = "socket_vol${var.replica_counter}"
-  driver_opts = {
+  driver_opts = var.windows ? {} : {
     o : "mode=0777"
     device : "tmpfs"
     type : "tmpfs"
@@ -10,7 +10,7 @@ resource "docker_volume" "socket_vol" {
 
 resource "docker_volume" "comm_vol" {
   name = "comm_vol${var.replica_counter}"
-  driver_opts = {
+  driver_opts = var.windows ? {} : {
     o : "mode=0777"
     device : "tmpfs"
     type : "tmpfs"

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -7,7 +7,7 @@ resource "docker_volume" "socket_vol" {
 resource "docker_volume" "comm_vol" {
   name = "comm_vol${var.replica_counter}"
   driver_opts = {
-    o : "uid=3333"
+    o : "uid=3333,gid=3333,mode=0777"
     device : "tmpfs"
     type : "tmpfs"
   }

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -1,7 +1,11 @@
 resource "docker_volume" "socket_vol" {
   count = var.socket_type == "tcp" ? 0 : 1
   name  = "socket_vol${var.replica_counter}"
-
+  driver_opts = {
+    o : "mode=0777"
+    device : "tmpfs"
+    type : "tmpfs"
+  }
 }
 
 resource "docker_volume" "comm_vol" {
@@ -28,6 +32,7 @@ resource "docker_container" "worker" {
 
   env = concat(["Serilog__Properties__Application=${var.worker.serilog_application_name}"], local.gen_env, local.common_env)
 
+  user       = 3333
   log_driver = var.log_driver.name
   log_opts   = var.log_driver.log_opts
 

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -7,7 +7,7 @@ resource "docker_volume" "socket_vol" {
 resource "docker_volume" "comm_vol" {
   name = "comm_vol${var.replica_counter}"
   driver_opts = {
-    o : "uid=3333,gid=3333,mode=0777"
+    o : "mode=0777"
     device : "tmpfs"
     type : "tmpfs"
   }

--- a/terraform/modules/storage/database/mongo/inputs.tf
+++ b/terraform/modules/storage/database/mongo/inputs.tf
@@ -6,6 +6,10 @@ variable "network" {
   type = string
 }
 
+variable "windows" {
+  type = bool
+}
+
 variable "mongodb_params" {
   type = object({
     max_connection_pool_size = string
@@ -15,6 +19,5 @@ variable "mongodb_params" {
     use_direct_connection    = bool
     database_name            = string
     exposed_port             = number
-    windows                  = bool
   })
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -22,7 +22,6 @@ variable "mongodb_params" {
     use_direct_connection    = optional(bool, true)
     database_name            = optional(string, "database")
     exposed_port             = optional(number, 27017)
-    windows                  = optional(bool, false)
   })
   default = {}
 }
@@ -274,4 +273,9 @@ variable "tracing_ingestion_ports" {
 variable "container_init" {
   type    = bool
   default = true
+}
+
+variable "windows" {
+  type    = bool
+  default = false
 }


### PR DESCRIPTION
# Motivation

Reduce the size of the images and reduce surface of attack.

# Description

Use `mcr.microsoft.com/dotnet/aspnet:8.0-azurelinux3.0-distroless` as base image instead of `mcr.microsoft.com/dotnet/aspnet:8.0`. It mainly changes the way the images are constructed:
- Images are minimalist so it is not possible to create new users. We use `$APP_UID` user defined by the image with ID 1654 as of now instead of `armonikuser` with ID 5000.
- The `/cache` folder is not created anymore. Driver options are given to create the volume underneath and make it properly available for the agent and the worker.

The size of the images is reduced by around 100Mo.

# Testing

- Pipelines in this repo are passing.
- Tests in ArmoniK infrastructure on localhost and in AWS

# Impact

- Reduced surface of attack and less CVEs
- Smaller images
- For compatibility with other workers (extensions, samples), the infrastructure will have to set a common user between the agent and the worker to share the sockets used for communication between the two.

# Additional Information

- https://stackoverflow.com/questions/51456621/docker-volumes-specifying-permissions-using-mount-options
- https://www.howtogeek.com/812961/umask-linux/

