### PR TITLE
fix: remove all completed dependencies from tasks remaining dependencies during submission

### DIFF
--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -133,7 +133,11 @@ public record TaskData(string        SessionId,
            payloadId,
            parentTaskIds,
            dataDependencies,
-           dataDependencies.ToDictionary(EscapeKey,
+           dataDependencies.Concat(new[]
+                                   {
+                                     payloadId,
+                                   })
+                           .ToDictionary(EscapeKey,
                                          _ => true),
            expectedOutputIds,
            taskId,

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -330,8 +330,8 @@ public static class TaskLifeCycleHelper
                                                                  cancellationToken)
                                                      .ConfigureAwait(false))
     {
-      completedDependencies.Add(completedResult);
       allDependencies.Remove(completedResult);
+      completedDependencies.Add(completedResult);
     }
 
     // Remove all the dependencies that are already completed from the task.

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -258,7 +258,8 @@ public static class TaskLifeCycleHelper
                                                                               ILogger                          logger,
                                                                               CancellationToken                cancellationToken)
   {
-    var allDependencies = new HashSet<string>();
+    var allDependencies       = new HashSet<string>();
+    var completedDependencies = new List<string>();
 
     // Get all the results that are a dependency of at least one task
     foreach (var request in taskRequests)
@@ -274,6 +275,7 @@ public static class TaskLifeCycleHelper
                                               .ConfigureAwait(false))
     {
       allDependencies.Remove(resultId);
+      completedDependencies.Add(resultId);
     }
 
     // Build the mapping between tasks and their dependencies
@@ -323,12 +325,14 @@ public static class TaskLifeCycleHelper
                      .ConfigureAwait(false);
 
     // Check all the remaining dependencies
-    var completedDependencies = await resultTable.GetResults(result => allDependencies.Contains(result.ResultId) && result.Status == ResultStatus.Completed,
-                                                             result => result.ResultId,
-                                                             cancellationToken)
-                                                 .ToListAsync(cancellationToken)
-                                                 .ConfigureAwait(false);
-    allDependencies.ExceptWith(completedDependencies);
+    await foreach (var completedResult in resultTable.GetResults(result => allDependencies.Contains(result.ResultId) && result.Status == ResultStatus.Completed,
+                                                                 result => result.ResultId,
+                                                                 cancellationToken)
+                                                     .ConfigureAwait(false))
+    {
+      completedDependencies.Add(completedResult);
+      allDependencies.Remove(completedResult);
+    }
 
     // Remove all the dependencies that are already completed from the task.
     // If an Agent has completed one of the dependencies between the GetResults and this remove,

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -2047,6 +2047,7 @@ public class TaskTableTestBase
                                                            {
                                                              dd1,
                                                              dd2,
+                                                             "PayloadId",
                                                            },
                                                            CancellationToken.None)
                      .ConfigureAwait(false);
@@ -2099,6 +2100,7 @@ public class TaskTableTestBase
                                                            },
                                                            new[]
                                                            {
+                                                             "PayloadId",
                                                              dd1,
                                                            },
                                                            CancellationToken.None)


### PR DESCRIPTION


on a un pb quand la tache est crée avec une dépendence qui a été complétée avant la soumission de la tache
cette dépendance n'est pas enlevée des remaining dependencies
du coup, la tache qui vient d'etre crée ne peut pas etre mise dans la queue et traitée par ce que la condition pour le faire, c'est que le champ remaning depedencies soit vide