### PR TITLE
refactor: remove redondant test and rework timers for ExecuteTaskWithExceptionDuringCancellationShouldSucceed

### DIFF
--- a/Common/tests/Helpers/ExceptionWorkerStreamHandler.cs
+++ b/Common/tests/Helpers/ExceptionWorkerStreamHandler.cs
@@ -30,10 +30,15 @@ namespace ArmoniK.Core.Common.Tests.Helpers;
 public sealed class ExceptionWorkerStreamHandler<T> : IWorkerStreamHandler
   where T : Exception, new()
 {
-  private readonly int delay_;
+  private readonly bool acceptCancellation_;
+  private readonly int  delay_;
 
-  public ExceptionWorkerStreamHandler(int delay)
-    => delay_ = delay;
+  public ExceptionWorkerStreamHandler(int  delay,
+                                      bool acceptCancellation = true)
+  {
+    delay_              = delay;
+    acceptCancellation_ = acceptCancellation;
+  }
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
     => Task.FromResult(HealthCheckResult.Healthy());
@@ -51,9 +56,10 @@ public sealed class ExceptionWorkerStreamHandler<T> : IWorkerStreamHandler
                                                 CancellationToken cancellationToken)
   {
     await Task.Delay(TimeSpan.FromMilliseconds(delay_),
-                     cancellationToken)
+                     acceptCancellation_
+                       ? cancellationToken
+                       : CancellationToken.None)
               .ConfigureAwait(false);
-    cancellationToken.ThrowIfCancellationRequested();
     throw new T();
   }
 }

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -68,7 +68,8 @@ public class TestTaskHandlerProvider : IDisposable
                                  CancellationTokenSource cancellationTokenSource,
                                  ITaskTable?             inputTaskTable        = null,
                                  ISessionTable?          inputSessionTable     = null,
-                                 ITaskProcessingChecker? taskProcessingChecker = null)
+                                 ITaskProcessingChecker? taskProcessingChecker = null,
+                                 TimeSpan?               graceDelay            = null)
   {
     var logger = NullLogger.Instance;
 
@@ -113,7 +114,10 @@ public class TestTaskHandlerProvider : IDisposable
                                                     "DefaultPartition"
                                                   },
                                                   {
-                                                    $"{Injection.Options.Pollster.SettingSection}:{nameof(Injection.Options.Pollster.GraceDelay)}", "00:00:02"
+                                                    $"{Injection.Options.Pollster.SettingSection}:{nameof(Injection.Options.Pollster.GraceDelay)}", graceDelay is null
+                                                                                                                                                      ? "00:00:02"
+                                                                                                                                                      : graceDelay
+                                                                                                                                                        .ToString()
                                                   },
                                                   {
                                                     $"{Injection.Options.Pollster.SettingSection}:{nameof(Injection.Options.Pollster.SharedCacheFolder)}",


### PR DESCRIPTION
- refactor: remove redondant test
- refactor: rework timers for ExecuteTaskWithExceptionDuringCancellationShouldSucceed
