### PR TITLE
feat: support for client cert and multiple host connection string for mongo adapter

### DIFF
--- a/Adaptors/MongoDB/src/Options/MongoDB.cs
+++ b/Adaptors/MongoDB/src/Options/MongoDB.cs
@@ -16,8 +16,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 
 using JetBrains.Annotations;
+
+using MongoDB.Driver.Core.Configuration;
 
 // ReSharper disable InconsistentNaming
 
@@ -36,11 +39,11 @@ public class MongoDB
 
   public string ReplicaSet { get; set; } = "";
 
-  public string Host { get; set; } = "";
-
-  public int Port { get; set; }
+  public List<string> Hosts { get; set; } = new();
 
   public string CAFile { get; set; } = "";
+
+  public List<string> ClientCertificateFiles { get; set; } = new();
 
   public string CredentialsPath { get; set; } = "";
 
@@ -60,6 +63,7 @@ public class MongoDB
 
   public QueueStorage QueueStorage { get; set; } = new();
 
-  public int      MaxConnectionPoolSize  { get; set; } = 500;
-  public TimeSpan ServerSelectionTimeout { get; set; } = TimeSpan.FromMinutes(2);
+  public int                    MaxConnectionPoolSize  { get; set; } = 500;
+  public TimeSpan               ServerSelectionTimeout { get; set; } = TimeSpan.FromMinutes(2);
+  public ConnectionStringScheme Scheme                 { get; set; } = ConnectionStringScheme.MongoDB;
 }

--- a/terraform/modules/storage/database/mongo/outputs.tf
+++ b/terraform/modules/storage/database/mongo/outputs.tf
@@ -1,8 +1,7 @@
 output "generated_env_vars" {
   value = {
     "Components__TableStorage"               = "ArmoniK.Adapters.MongoDB.TableStorage"
-    "MongoDB__Host"                          = docker_container.database.name
-    "MongoDB__Port"                          = "${var.mongodb_params.exposed_port}"
+    "MongoDB__Hosts__0"                      = "${docker_container.database.name}:${var.mongodb_params.exposed_port}"
     "MongoDB__DatabaseName"                  = docker_container.database.name
     "MongoDB__MaxConnectionPoolSize"         = "${var.mongodb_params.max_connection_pool_size}"
     "MongoDB__TableStorage__PollingDelayMin" = "${var.mongodb_params.min_polling_delay}"


### PR DESCRIPTION
Support for multiple client certificates. Clients we use supports it. May be used for certificate rotation.

Environment variable to set up client certificates:
```
MongoDB__ClientCertificateFiles__0=/path/to/pem/file0
MongoDB__ClientCertificateFiles__1=/path/to/pem/file1
```
Beware that client certificate files should be mounted in the container at the location given by the environment variables.


Support for multiple hosts has been added. The follonwing code shows how to specify multiple hosts:
```
MongoDB__Hosts__0=mongo0:27017
MongoDB__Hosts__1=mongo1:27017
```

Beware that `MongoDB__Host` and `MongoDB__Port` were removed in this PR.
```
MongoDB__Host=mongo
MongoDB__Port=27017
```
is now equivalent to
```
MongoDB__Hosts__0=mongo:27017
```


Finally, a variable to change mongo connection scheme has been introduced. It takes two values:
```
MongoDB__Scheme=MongoDB
MongoDB__Scheme=MongoDBPlusSrv
```