### PR TITLE
feat: add flag to toggle payload deletion after successful task

### DIFF
--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -37,4 +37,11 @@ public class Submitter
   ///   Negative values disable the check
   /// </summary>
   public int MaxErrorAllowed { get; set; } = 5;
+
+
+  /// <summary>
+  ///   Toggle payload suppression after the task is successful
+  ///   default: false
+  /// </summary>
+  public bool DeletePayload { get; set; } = false;
 }

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -521,17 +521,21 @@ public class Submitter : ISubmitter
                         .ConfigureAwait(false);
 
 
-        //Discard value is used to remove warnings CS4014 !!
-        _ = Task.Factory.StartNew(async () => await objectStorage_.TryDeleteAsync(new[]
-                                                                                  {
-                                                                                    taskData.TaskId,
-                                                                                  },
-                                                                                  CancellationToken.None)
-                                                                  .ConfigureAwait(false),
-                                  cancellationToken);
+        if (submitterOptions_.DeletePayload)
+        {
+          //Discard value is used to remove warnings CS4014 !!
+          _ = Task.Factory.StartNew(async () => await objectStorage_.TryDeleteAsync(new[]
+                                                                                    {
+                                                                                      taskData.TaskId,
+                                                                                    },
+                                                                                    CancellationToken.None)
+                                                                    .ConfigureAwait(false),
+                                    cancellationToken);
 
-        logger_.LogInformation("Remove input payload of {task}",
-                               taskData.TaskId);
+          logger_.LogInformation("Remove input payload of {task}",
+                                 taskData.TaskId);
+        }
+
         break;
       case OutputStatus.Error:
         // TODO FIXME: nothing will resubmit the task if there is a crash there


### PR DESCRIPTION
This flag defaults to false as the natural way to delete data in ArmoniK is to use the Results API that allows to delete data or the session API that allows to purge data for an entire session. These are the recommended and explicit ways to manage data now.
