### PR TITLE
build: add tls for mongo in deployment

### DIFF
--- a/Adaptors/MongoDB/src/ServiceCollectionExt.cs
+++ b/Adaptors/MongoDB/src/ServiceCollectionExt.cs
@@ -49,10 +49,33 @@ namespace ArmoniK.Core.Adapters.MongoDB;
 
 public static class ServiceCollectionExt
 {
+  public static void LogObjectProperties<T>(ILogger logger,
+                                            T obj,
+                                            string objectName)
+  {
+    if (obj == null)
+    {
+      logger.LogError("{ObjectName} is null",
+                      objectName);
+      return;
+    }
+
+    var properties = typeof(T).GetProperties();
+    foreach (var property in properties)
+    {
+      var value = property.GetValue(obj,
+                                    null);
+      logger.LogInformation("{ObjectName}.{Property} = {Value}",
+                            objectName,
+                            property.Name,
+                            value);
+    }
+  }
+
   [PublicAPI]
   public static IServiceCollection AddMongoComponents(this IServiceCollection services,
-                                                      ConfigurationManager    configuration,
-                                                      ILogger                 logger)
+                                                      ConfigurationManager configuration,
+                                                      ILogger logger)
   {
     services.AddMongoClient(configuration,
                             logger);
@@ -63,8 +86,8 @@ public static class ServiceCollectionExt
 
   [PublicAPI]
   public static IServiceCollection AddMongoStorages(this IServiceCollection services,
-                                                    ConfigurationManager    configuration,
-                                                    ILogger                 logger)
+                                                    ConfigurationManager configuration,
+                                                    ILogger logger)
   {
     logger.LogInformation("Configure MongoDB Components");
 
@@ -95,14 +118,13 @@ public static class ServiceCollectionExt
   }
 
   public static IServiceCollection AddMongoClient(this IServiceCollection services,
-                                                  ConfigurationManager    configuration,
-                                                  ILogger                 logger)
+                                                  ConfigurationManager configuration,
+                                                  ILogger logger)
   {
     Options.MongoDB mongoOptions;
     services.AddOption(configuration,
                        Options.MongoDB.SettingSection,
                        out mongoOptions);
-
     using var _ = logger.BeginNamedScope("MongoDB configuration",
                                          ("host", mongoOptions.Host),
                                          ("port", mongoOptions.Port));
@@ -165,13 +187,13 @@ public static class ServiceCollectionExt
     var settings = MongoClientSettings.FromUrl(new MongoUrl(connectionString));
 
     // Configure the connection settings
-    settings.AllowInsecureTls       = mongoOptions.AllowInsecureTls;
-    settings.UseTls                 = mongoOptions.Tls;
-    settings.DirectConnection       = mongoOptions.DirectConnection;
-    settings.Scheme                 = ConnectionStringScheme.MongoDB;
-    settings.MaxConnectionPoolSize  = mongoOptions.MaxConnectionPoolSize;
+    settings.AllowInsecureTls = mongoOptions.AllowInsecureTls;
+    settings.UseTls = mongoOptions.Tls;
+    settings.DirectConnection = mongoOptions.DirectConnection;
+    settings.Scheme = ConnectionStringScheme.MongoDB;
+    settings.MaxConnectionPoolSize = mongoOptions.MaxConnectionPoolSize;
     settings.ServerSelectionTimeout = mongoOptions.ServerSelectionTimeout;
-    settings.ReplicaSetName         = mongoOptions.ReplicaSet;
+    settings.ReplicaSetName = mongoOptions.ReplicaSet;
 
     if (!string.IsNullOrEmpty(mongoOptions.CAFile))
     {
@@ -191,95 +213,82 @@ public static class ServiceCollectionExt
       // Load the CA certificate
       try
       {
-        var authority = new X509Certificate2(mongoOptions.CAFile);
-        logger.LogInformation("CA certificate loaded: {authority.Subject}",
-                              authority.Subject);
-
+        var fileInfo = new FileInfo(mongoOptions.CAFile);
+        LogObjectProperties(logger,
+                            fileInfo,
+                            nameof(fileInfo));
+        var content = File.ReadAllLines(mongoOptions.CAFile);
+        LogObjectProperties(logger,
+                            content,
+                            nameof(content));
+        var authority = new X509Certificate2(mongoOptions.CAFile,
+                                             "",
+                                             X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet);
+        logger.LogInformation("CA certificate loaded: {authority}",
+                              authority);
         //  SSL Parameters configuration
         settings.SslSettings = new SslSettings
-                               {
-                                 ClientCertificates  = new X509Certificate2Collection(authority),
-                                 EnabledSslProtocols = SslProtocols.Tls12,
-                                 ServerCertificateValidationCallback = (sender,
-                                                                        certificate,
-                                                                        certChain,
-                                                                        sslPolicyErrors) =>
-                                                                       {
-                                                                         if (sslPolicyErrors == SslPolicyErrors.None)
-                                                                         {
-                                                                           logger.LogInformation("SSL validation successful: no errors.");
-                                                                           return true;
-                                                                         }
+        {
+          ClientCertificates = new X509Certificate2Collection(authority),
+          EnabledSslProtocols = SslProtocols.Tls12,
+          ServerCertificateValidationCallback = (sender,
+                                                 certificate,
+                                                 certChain,
+                                                 sslPolicyErrors) =>
 
-                                                                         logger.LogError("SSL validation failed with errors: {sslPolicyErrors}",
-                                                                                         sslPolicyErrors);
+                                                {
+                                                  logger.LogInformation("SSL validation callback called.");
+                                                  if (sslPolicyErrors == SslPolicyErrors.None)
+                                                  {
+                                                    logger.LogInformation("SSL validation successful: no errors.");
+                                                    return true;
+                                                  }
 
-                                                                         if (certificate == null)
-                                                                         {
-                                                                           logger.LogError("Certificate is null!");
-                                                                           return false;
-                                                                         }
+                                                  if (certificate == null)
+                                                  {
+                                                    logger.LogInformation("Certificate is null!");
+                                                    return false;
+                                                  }
 
-                                                                         var cert = new X509Certificate2(certificate);
-                                                                         if (certChain == null)
-                                                                         {
-                                                                           logger.LogError("Certificate chain is null!");
-                                                                           return false;
-                                                                         }
+                                                  if (certChain == null)
+                                                  {
+                                                    logger.LogInformation("Certificate chain is null!");
+                                                    return false;
+                                                  }
 
-                                                                         certChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                                                                         certChain.ChainPolicy.VerificationFlags =
-                                                                           X509VerificationFlags.AllowUnknownCertificateAuthority;
-                                                                         // Build the chain 
-                                                                         if (!certChain.Build(cert))
-                                                                         {
-                                                                           logger.LogError("SSL chain validation failed.");
-                                                                           foreach (var status in certChain.ChainStatus)
-                                                                           {
-                                                                             logger.LogError("ChainStatus: {status.StatusInformation} ({status.Status})",
-                                                                                             status.StatusInformation,
-                                                                                             status.Status);
-                                                                           }
-
-                                                                           return false;
-                                                                         }
-
-                                                                         // Verification of the chain root 
-                                                                         if (authority != null)
-                                                                         {
-                                                                           certChain.ChainPolicy.ExtraStore.Add(authority);
-                                                                           logger.LogInformation("Added CA certificate to chain policy.");
-                                                                           var isTrusted =
-                                                                             certChain.ChainElements.Any(x => x.Certificate.Thumbprint == authority.Thumbprint);
-
-                                                                           if (!isTrusted)
-                                                                           {
-                                                                             logger.LogError("Certificate chain root does not match the specified CA authority.");
-                                                                             return false;
-                                                                           }
-                                                                         }
+                                                  logger.LogError("SSL validation failed with errors: {sslPolicyErrors}",
+                                                                  sslPolicyErrors.ToString());
 
 
-                                                                         var validHosts = new[]
-                                                                                          {
-                                                                                            mongoOptions.Host,
-                                                                                            "127.0.0.1",
-                                                                                            "localhost"
-                                                                                          };
-                                                                         if (!validHosts.Any(host => cert.Subject.Contains($"CN={host}",
-                                                                                                                           StringComparison.OrdinalIgnoreCase)))
-                                                                         {
-                                                                           logger
-                                                                             .LogError("Certificate host mismatch. Expected one of: {ValidHosts}, but found: {CertSubject}",
-                                                                                       validHosts,
-                                                                                       cert.Subject);
-                                                                           return false;
-                                                                         }
+                                                  var cert = new X509Certificate2(certificate);
 
-                                                                         logger.LogInformation("SSL validation successful.");
-                                                                         return true;
-                                                                       }
-                               };
+
+                                                  if (mongoOptions.AllowInsecureTls)
+                                                  {
+                                                    certChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                                                    certChain.ChainPolicy.VerificationFlags =
+                                                      X509VerificationFlags.AllowUnknownCertificateAuthority;
+                                                  }
+
+                                                  certChain.ChainPolicy.ExtraStore.Add(authority);
+                                                  if (!certChain.Build(cert))
+                                                  {
+                                                    logger.LogError("SSL chain validation failed.");
+                                                    foreach (var status in certChain.ChainStatus)
+                                                    {
+                                                      logger.LogError("ChainStatus: {status.StatusInformation} ({status.Status})",
+                                                                      status.StatusInformation,
+                                                                      status.Status);
+                                                    }
+
+                                                    return false;
+                                                  }
+
+                                                  logger.LogError("SSL validation failed with errors: {sslPolicyErrors}",
+                                                                  sslPolicyErrors.ToString());
+                                                  return false;
+                                                }
+        };
       }
       catch (CryptographicException e)
       {
@@ -338,7 +347,7 @@ public static class ServiceCollectionExt
   /// <returns>Services</returns>
   [PublicAPI]
   public static IServiceCollection AddClientSubmitterAuthenticationStorage(this IServiceCollection services,
-                                                                           ConfigurationManager    configuration)
+                                                                           ConfigurationManager configuration)
   {
     var components = configuration.GetSection(Components.SettingSection);
     if (components[nameof(Components.AuthenticationStorage)] == "ArmoniK.Adapters.MongoDB.AuthenticationTable")
@@ -359,7 +368,7 @@ public static class ServiceCollectionExt
   /// <returns>Services</returns>
   [PublicAPI]
   public static IServiceCollection AddClientSubmitterAuthServices(this IServiceCollection services,
-                                                                  ConfigurationManager    configuration,
+                                                                  ConfigurationManager configuration,
                                                                   out AuthenticationCache authCache)
   {
     authCache = new AuthenticationCache();

--- a/Adaptors/MongoDB/src/ServiceCollectionExt.cs
+++ b/Adaptors/MongoDB/src/ServiceCollectionExt.cs
@@ -221,9 +221,7 @@ public static class ServiceCollectionExt
         LogObjectProperties(logger,
                             content,
                             nameof(content));
-        var authority = new X509Certificate2(mongoOptions.CAFile,
-                                             "",
-                                             X509KeyStorageFlags.Exportable | X509KeyStorageFlags.MachineKeySet);
+        var authority = new X509Certificate2(mongoOptions.CAFile);
         logger.LogInformation("CA certificate loaded: {authority}",
                               authority);
         //  SSL Parameters configuration
@@ -244,6 +242,12 @@ public static class ServiceCollectionExt
                                                     return true;
                                                   }
 
+                                                  // If there is any error other than untrusted root or partial chain, fail the validation
+                                                  if ((sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+                                                  {
+                                                    return false;
+                                                  }
+
                                                   if (certificate == null)
                                                   {
                                                     logger.LogInformation("Certificate is null!");
@@ -255,20 +259,21 @@ public static class ServiceCollectionExt
                                                     logger.LogInformation("Certificate chain is null!");
                                                     return false;
                                                   }
+                                                  // If there is any error other than untrusted root or partial chain, fail the validation
+                                                  if (certChain.ChainStatus.Any(status => status.Status is not X509ChainStatusFlags.UntrustedRoot and not X509ChainStatusFlags.PartialChain))
+                                                  {
+                                                    return false;
+                                                  }
 
                                                   logger.LogError("SSL validation failed with errors: {sslPolicyErrors}",
-                                                                  sslPolicyErrors.ToString());
+                                                                  sslPolicyErrors);
 
 
                                                   var cert = new X509Certificate2(certificate);
+                                                  certChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
+                                                  certChain.ChainPolicy.VerificationFlags =
+                                                    X509VerificationFlags.AllowUnknownCertificateAuthority;
 
-
-                                                  if (mongoOptions.AllowInsecureTls)
-                                                  {
-                                                    certChain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;
-                                                    certChain.ChainPolicy.VerificationFlags =
-                                                      X509VerificationFlags.AllowUnknownCertificateAuthority;
-                                                  }
 
                                                   certChain.ChainPolicy.ExtraStore.Add(authority);
                                                   if (!certChain.Build(cert))
@@ -284,9 +289,8 @@ public static class ServiceCollectionExt
                                                     return false;
                                                   }
 
-                                                  logger.LogError("SSL validation failed with errors: {sslPolicyErrors}",
-                                                                  sslPolicyErrors.ToString());
-                                                  return false;
+                                                  return certChain.ChainElements.Cast<X509ChainElement>()
+                               .Any(x => x.Certificate.Thumbprint == authority.Thumbprint); ;
                                                 }
         };
       }

--- a/Utils/src/ServerCertificateValidator.cs
+++ b/Utils/src/ServerCertificateValidator.cs
@@ -1,0 +1,135 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.IO;
+using System.Linq;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+
+using Microsoft.Extensions.Logging;
+
+namespace ArmoniK.Core.Utils;
+
+/// <summary>
+///   Provides utilities for validating SSL/TLS certificates.
+/// </summary>
+public static class CertificateValidator
+{
+  /// <summary>
+  ///   Creates a callback function to validate SSL/TLS certificates during a secure connection.
+  /// </summary>
+  /// <param name="logger">The logger to use for logging validation details.</param>
+  /// <param name="authority">The root certificate authority to trust during validation.</param>
+  /// <returns>
+  ///   A <see cref="RemoteCertificateValidationCallback" /> delegate that performs SSL/TLS certificate validation.
+  /// </returns>
+  public static RemoteCertificateValidationCallback ValidationCallback(ILogger          logger,
+                                                                       X509Certificate2 authority)
+    => (sender,
+        certificate,
+        chain,
+        sslPolicyErrors) =>
+       {
+         if (certificate == null || chain == null)
+         {
+           logger.LogWarning("Certificate or certificate chain is null");
+           return false;
+         }
+
+         // If there is any error other than untrusted root or partial chain, fail the validation
+         if ((sslPolicyErrors & ~SslPolicyErrors.RemoteCertificateChainErrors) != 0)
+         {
+           logger.LogDebug("SSL validation failed with errors: {sslPolicyErrors}",
+                           sslPolicyErrors);
+           return false;
+         }
+
+         if (certificate == null)
+         {
+           logger.LogDebug("Certificate is null!");
+           return false;
+         }
+
+         if (chain == null)
+         {
+           logger.LogDebug("Certificate chain is null!");
+           return false;
+         }
+
+         // If there is any error other than untrusted root or partial chain, fail the validation
+         if (chain.ChainStatus.Any(status => status.Status is not X509ChainStatusFlags.UntrustedRoot and not X509ChainStatusFlags.PartialChain))
+         {
+           logger.LogDebug("SSL validation failed with chain status: {chainStatus}",
+                           chain.ChainStatus);
+           return false;
+         }
+
+         var cert = new X509Certificate2(certificate);
+         chain.ChainPolicy.RevocationMode    = X509RevocationMode.NoCheck;
+         chain.ChainPolicy.VerificationFlags = X509VerificationFlags.AllowUnknownCertificateAuthority;
+
+         chain.ChainPolicy.ExtraStore.Add(authority);
+         if (!chain.Build(cert))
+         {
+           return false;
+         }
+
+         var isTrusted = chain.ChainElements.Any(x => x.Certificate.Thumbprint == authority.Thumbprint);
+         if (isTrusted)
+         {
+           logger.LogInformation("SSL validation succeeded");
+         }
+         else
+         {
+           logger.LogInformation("SSL validation failed with errors: {sslPolicyErrors}",
+                                 sslPolicyErrors);
+         }
+
+         return isTrusted;
+       };
+
+  /// <summary>
+  ///   Creates a certificate validation callback from a Certificate Authority (CA) file.
+  /// </summary>
+  /// <param name="caFilePath">The file path to the CA certificate.</param>
+  /// <param name="logger">The logger to use for logging validation details.</param>
+  /// <returns>
+  ///   A <see cref="RemoteCertificateValidationCallback" /> delegate that performs SSL/TLS certificate validation.
+  /// </returns>
+  /// <exception cref="FileNotFoundException">
+  ///   Thrown if the specified CA certificate file is not found.
+  /// </exception>
+  public static RemoteCertificateValidationCallback CreateCallback(string  caFilePath,
+                                                                   ILogger logger)
+  {
+    if (!File.Exists(caFilePath))
+    {
+      logger.LogError("CA certificate Mongo file not found at {path}",
+                      caFilePath);
+      throw new FileNotFoundException("CA certificate Mongo file not found",
+                                      caFilePath);
+    }
+
+    var content   = File.ReadAllText(caFilePath);
+    var authority = X509Certificate2.CreateFromPem(content);
+    logger.LogInformation("Loaded CA certificate from file {path}",
+                          caFilePath);
+    var callback = ValidationCallback(logger,
+                                      authority);
+    return callback;
+  }
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -120,6 +120,7 @@ module "submitter" {
   generated_env_vars = local.environment
   log_driver         = module.fluenbit.log_driver
   volumes            = local.volumes
+  mounts             = module.database.core_mounts
 }
 
 module "compute_plane" {
@@ -134,6 +135,7 @@ module "compute_plane" {
   volumes            = local.volumes
   network            = docker_network.armonik.id
   log_driver         = module.fluenbit.log_driver
+  mounts             = module.database.core_mounts
 }
 
 module "metrics_exporter" {
@@ -143,6 +145,7 @@ module "metrics_exporter" {
   network            = docker_network.armonik.id
   generated_env_vars = local.environment
   log_driver         = module.fluenbit.log_driver
+  mounts             = module.database.core_mounts
 }
 
 module "partition_metrics_exporter" {
@@ -153,6 +156,7 @@ module "partition_metrics_exporter" {
   generated_env_vars = local.environment
   metrics_env_vars   = module.metrics_exporter.metrics_env_vars
   log_driver         = module.fluenbit.log_driver
+  mounts             = module.database.core_mounts
 }
 
 module "ingress" {

--- a/terraform/modules/compute_plane/inputs.tf
+++ b/terraform/modules/compute_plane/inputs.tf
@@ -32,6 +32,10 @@ variable "volumes" {
   type = map(string)
 }
 
+variable "mounts" {
+  type = map(string)
+}
+
 variable "replica_counter" {
   type = number
 }

--- a/terraform/modules/compute_plane/main.tf
+++ b/terraform/modules/compute_plane/main.tf
@@ -74,5 +74,13 @@ resource "docker_container" "polling_agent" {
     }
   }
 
+  dynamic "upload" {
+    for_each = var.mounts
+    content {
+      source = upload.value
+      file   = upload.key
+    }
+  }
+
   depends_on = [docker_container.worker]
 }

--- a/terraform/modules/monitoring/metrics/inputs.tf
+++ b/terraform/modules/monitoring/metrics/inputs.tf
@@ -14,6 +14,10 @@ variable "generated_env_vars" {
   type = map(string)
 }
 
+variable "mounts" {
+  type = map(string)
+}
+
 variable "exposed_port" {
   type    = number
   default = 5002

--- a/terraform/modules/monitoring/metrics/main.tf
+++ b/terraform/modules/monitoring/metrics/main.tf
@@ -20,4 +20,12 @@ resource "docker_container" "metrics" {
     internal = 1080
     external = var.exposed_port
   }
+
+  dynamic "upload" {
+    for_each = var.mounts
+    content {
+      source = upload.value
+      file   = upload.key
+    }
+  }
 }

--- a/terraform/modules/monitoring/partition_metrics/inputs.tf
+++ b/terraform/modules/monitoring/partition_metrics/inputs.tf
@@ -19,6 +19,10 @@ variable "generated_env_vars" {
   type = map(string)
 }
 
+variable "mounts" {
+  type = map(string)
+}
+
 variable "metrics_env_vars" {
   type = map(string)
 }

--- a/terraform/modules/monitoring/partition_metrics/main.tf
+++ b/terraform/modules/monitoring/partition_metrics/main.tf
@@ -21,7 +21,7 @@ resource "docker_container" "partition_metrics" {
     external = var.exposed_port
   }
 
-    dynamic "upload" {
+  dynamic "upload" {
     for_each = var.mounts
     content {
       source = upload.value

--- a/terraform/modules/monitoring/partition_metrics/main.tf
+++ b/terraform/modules/monitoring/partition_metrics/main.tf
@@ -20,4 +20,12 @@ resource "docker_container" "partition_metrics" {
     internal = 1080
     external = var.exposed_port
   }
+
+    dynamic "upload" {
+    for_each = var.mounts
+    content {
+      source = upload.value
+      file   = upload.key
+    }
+  }
 }

--- a/terraform/modules/storage/database/mongo/certificates.tf
+++ b/terraform/modules/storage/database/mongo/certificates.tf
@@ -1,0 +1,69 @@
+#------------------------------------------------------------------------------
+# Certificate Authority
+#------------------------------------------------------------------------------
+resource "tls_private_key" "root_mongodb" {
+  algorithm   = "RSA"
+  ecdsa_curve = "P384"
+  rsa_bits    = "4096"
+}
+
+resource "tls_self_signed_cert" "root_mongodb" {
+  private_key_pem       = tls_private_key.root_mongodb.private_key_pem
+  is_ca_certificate     = true
+  validity_period_hours = 100000
+  allowed_uses = [
+    "cert_signing",
+    "key_encipherment",
+    "digital_signature"
+  ]
+  subject {
+    organization = "ArmoniK mongodb Root (NonTrusted)"
+    common_name  = "ArmoniK mongodb Root (NonTrusted) Private Certificate Authority"
+    country      = "France"
+  }
+}
+
+#------------------------------------------------------------------------------
+# Certificate
+#------------------------------------------------------------------------------
+resource "tls_private_key" "mongodb_private_key" {
+  algorithm   = "RSA"
+  ecdsa_curve = "P384"
+  rsa_bits    = "4096"
+}
+
+resource "tls_cert_request" "mongodb_cert_request" {
+  private_key_pem = tls_private_key.mongodb_private_key.private_key_pem
+  subject {
+    country     = "France"
+    common_name = "127.0.0.1"
+    # organization = "127.0.0.1"
+  }
+  ip_addresses = ["127.0.0.1"]
+  dns_names    = [var.mongodb_params.database_name]
+}
+
+resource "tls_locally_signed_cert" "mongodb_certificate" {
+  cert_request_pem      = tls_cert_request.mongodb_cert_request.cert_request_pem
+  ca_private_key_pem    = tls_private_key.root_mongodb.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.root_mongodb.cert_pem
+  validity_period_hours = 100000
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+    "any_extended",
+  ]
+}
+
+locals {
+  server_key = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_private_key.mongodb_private_key.private_key_pem)
+}
+
+resource "local_sensitive_file" "ca" {
+  content         = tls_locally_signed_cert.mongodb_certificate.ca_cert_pem
+  filename        = "${path.root}/generated/mongo/ca.pem"
+  file_permission = "0644"
+}
+

--- a/terraform/modules/storage/database/mongo/certificates.tf
+++ b/terraform/modules/storage/database/mongo/certificates.tf
@@ -40,7 +40,7 @@ resource "tls_cert_request" "mongodb_cert_request" {
     # organization = "127.0.0.1"
   }
   ip_addresses = ["127.0.0.1"]
-  dns_names    = [var.mongodb_params.database_name]
+  dns_names    = [var.mongodb_params.database_name, "localhost"]
 }
 
 resource "tls_locally_signed_cert" "mongodb_certificate" {

--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -24,7 +24,7 @@ resource "docker_container" "database" {
     for_each = var.mongodb_params.windows ? [] : [1]
     content {
       test     = ["CMD", "mongosh", "--quiet", "--tls", "--tlsCAFile", "/mongo-certificate/ca.pem", "--eval", "db.runCommand('ping').ok"]
-     interval = "3s"
+      interval = "3s"
       retries  = "2"
       timeout  = "3s"
     }
@@ -34,6 +34,10 @@ resource "docker_container" "database" {
     file    = "/mongo-certificate/key.pem"
     content = local.server_key
   }
+  upload {
+    file    = "/mongo-init.js"
+    content = local.mongo_init_repset
+  }
 
   upload {
     file    = "/mongo-certificate/ca.pem"
@@ -41,23 +45,35 @@ resource "docker_container" "database" {
   }
 }
 resource "time_sleep" "wait" {
-  create_duration = var.mongodb_params.windows ? "15s" : "0s"
+  create_duration = var.mongodb_params.windows ? "30s" : "0s"
   depends_on      = [docker_container.database]
 }
-
 locals {
-  linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://localhost:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
+  linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://127.0.0.1:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
   // mongosh is not installed in windows docker images so we need it to be installed locally
-  windows_run = "mongosh.exe mongodb://localhost:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name} --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
-  prefix_run  = var.mongodb_params.windows ? local.windows_run : local.linux_run
+  windows_run       = "mongosh.exe mongodb://127.0.0.1:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name} --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
+  prefix_run        = var.mongodb_params.windows ? local.windows_run : local.linux_run
+  mongo_init_repset = <<EOT
+rs.initiate({
+  _id: "${var.mongodb_params.replica_set_name}",
+  members: [
+    {_id: 0, host: "127.0.0.1:27017"}
+  ]
+});
+EOT
 }
+resource "local_file" "mongo_init" {
+  content  = local.mongo_init_repset
+  filename = "${path.root}/generated/mongo/mongo_init.js"
 
+}
 resource "null_resource" "init_replica" {
   provisioner "local-exec" {
-    command = "${local.prefix_run} --eval \"rs.initiate({_id: '${var.mongodb_params.replica_set_name}', members: [{_id: 0, host: 'localhost:27017'}]})\""
+    command = var.mongodb_params.windows ? "${local.windows_run} --file ${local_file.mongo_init.filename}" : "${local.linux_run} --file /mongo-init.js"
   }
   depends_on = [time_sleep.wait]
 }
+
 
 resource "null_resource" "partitions_in_db" {
   for_each = var.partition_list

--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -46,7 +46,7 @@ resource "time_sleep" "wait" {
 }
 
 locals {
-  linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://127.0.0.1:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
+  linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://localhost:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
   // mongosh is not installed in windows docker images so we need it to be installed locally
   windows_run = "mongosh.exe mongodb://localhost:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name} --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
   prefix_run  = var.mongodb_params.windows ? local.windows_run : local.linux_run
@@ -54,16 +54,7 @@ locals {
 
 resource "null_resource" "init_replica" {
   provisioner "local-exec" {
-    command = <<EOT
-
-
-${local.prefix_run} --eval 'rs.initiate({
-    _id: "${var.mongodb_params.replica_set_name}",
-    members: [
-        { _id: 0, host: "127.0.0.1:27017" }
-    ]
-})'
-EOT
+    command = "${local.prefix_run} --eval \"rs.initiate({_id: '${var.mongodb_params.replica_set_name}', members: [{_id: 0, host: 'localhost:27017'}]})\""
   }
   depends_on = [time_sleep.wait]
 }

--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -24,11 +24,12 @@ resource "docker_container" "database" {
     for_each = var.mongodb_params.windows ? [] : [1]
     content {
       test     = ["CMD", "mongosh", "--quiet", "--tls", "--tlsCAFile", "/mongo-certificate/ca.pem", "--eval", "db.runCommand('ping').ok"]
-      interval = "3s"
+     interval = "3s"
       retries  = "2"
       timeout  = "3s"
     }
   }
+
   upload {
     file    = "/mongo-certificate/key.pem"
     content = local.server_key
@@ -39,7 +40,6 @@ resource "docker_container" "database" {
     content = tls_locally_signed_cert.mongodb_certificate.ca_cert_pem
   }
 }
-
 resource "time_sleep" "wait" {
   create_duration = var.mongodb_params.windows ? "15s" : "0s"
   depends_on      = [docker_container.database]
@@ -54,7 +54,16 @@ locals {
 
 resource "null_resource" "init_replica" {
   provisioner "local-exec" {
-    command = "${local.prefix_run} --eval 'rs.initiate({_id: \"${var.mongodb_params.replica_set_name}\"})'"
+    command = <<EOT
+
+
+${local.prefix_run} --eval 'rs.initiate({
+    _id: "${var.mongodb_params.replica_set_name}",
+    members: [
+        { _id: 0, host: "127.0.0.1:27017" }
+    ]
+})'
+EOT
   }
   depends_on = [time_sleep.wait]
 }

--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -7,7 +7,7 @@ resource "docker_container" "database" {
   name  = var.mongodb_params.database_name
   image = docker_image.database.image_id
 
-  command = ["mongod", "--bind_ip_all", "--replSet", var.mongodb_params.replica_set_name, "--tlsMode=requireTLS", "--tlsDisabledProtocols=TLS1_0", "--tlsCertificateKeyFile=/cert/key.pem", "--tlsCAFile=/cert/ca.pem", "--tlsAllowConnectionsWithoutCertificates"]
+  command = ["mongod", "--bind_ip_all", "--replSet", var.mongodb_params.replica_set_name, "--tlsMode=requireTLS", "--tlsDisabledProtocols=TLS1_0", "--tlsCertificateKeyFile=/mongo-certificate/key.pem", "--tlsCAFile=/mongo-certificate/ca.pem", "--tlsAllowConnectionsWithoutCertificates"]
 
   networks_advanced {
     name = var.network
@@ -23,19 +23,19 @@ resource "docker_container" "database" {
   dynamic "healthcheck" {
     for_each = var.mongodb_params.windows ? [] : [1]
     content {
-      test     = ["CMD", "mongosh", "--quiet", "--tls", "--tlsCAFile", "/cert/ca.pem", "--eval", "db.runCommand('ping').ok"]
+      test     = ["CMD", "mongosh", "--quiet", "--tls", "--tlsCAFile", "/mongo-certificate/ca.pem", "--eval", "db.runCommand('ping').ok"]
       interval = "3s"
       retries  = "2"
       timeout  = "3s"
     }
   }
   upload {
-    file    = "/cert/key.pem"
+    file    = "/mongo-certificate/key.pem"
     content = local.server_key
   }
 
   upload {
-    file    = "/cert/ca.pem"
+    file    = "/mongo-certificate/ca.pem"
     content = tls_locally_signed_cert.mongodb_certificate.ca_cert_pem
   }
 }
@@ -46,7 +46,7 @@ resource "time_sleep" "wait" {
 }
 
 locals {
-  linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://127.0.0.1:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /cert/ca.pem"
+  linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://127.0.0.1:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
   // mongosh is not installed in windows docker images so we need it to be installed locally
   windows_run = "mongosh.exe mongodb://localhost:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name} --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
   prefix_run  = var.mongodb_params.windows ? local.windows_run : local.linux_run

--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -54,7 +54,7 @@ locals {
 
 resource "null_resource" "init_replica" {
   provisioner "local-exec" {
-    command = "${local.prefix_run} --eval 'rs.initiate()'"
+    command = "${local.prefix_run} --eval 'rs.initiate({_id: \"${var.mongodb_params.replica_set_name}\"})'"
   }
   depends_on = [time_sleep.wait]
 }

--- a/terraform/modules/storage/database/mongo/outputs.tf
+++ b/terraform/modules/storage/database/mongo/outputs.tf
@@ -9,7 +9,17 @@ output "generated_env_vars" {
     "MongoDB__TableStorage__PollingDelayMax" = "${var.mongodb_params.max_polling_delay}"
     "MongoDB__DirectConnection"              = "${var.mongodb_params.use_direct_connection}"
     "MongoDB__ReplicaSet"                    = "${var.mongodb_params.replica_set_name}"
+    "MongoDB__Tls"                           = "true"
+    "MongoDB__AllowInsecureTls"              = "true"
+    "MongoDB__CAFile"                        = "/cert/ca.pem"
+    "MongoDB__ServerSelectionTimeout"        = "00:00:20"
   }
 
   depends_on = [null_resource.partitions_in_db]
+}
+
+output "core_mounts" {
+  value = {
+    "/cert/ca.pem" = local_sensitive_file.ca.filename
+  }
 }

--- a/terraform/modules/storage/database/mongo/outputs.tf
+++ b/terraform/modules/storage/database/mongo/outputs.tf
@@ -11,7 +11,7 @@ output "generated_env_vars" {
     "MongoDB__ReplicaSet"                    = "${var.mongodb_params.replica_set_name}"
     "MongoDB__Tls"                           = "true"
     "MongoDB__AllowInsecureTls"              = "true"
-    "MongoDB__CAFile"                        = "/cert/ca.pem"
+    "MongoDB__CAFile"                        = "/mongo-certificate/ca.pem"
     "MongoDB__ServerSelectionTimeout"        = "00:00:20"
   }
 
@@ -20,6 +20,6 @@ output "generated_env_vars" {
 
 output "core_mounts" {
   value = {
-    "/cert/ca.pem" = local_sensitive_file.ca.filename
+    "/mongo-certificate/ca.pem" = local_sensitive_file.ca.filename
   }
 }

--- a/terraform/modules/storage/database/mongo/versions.tf
+++ b/terraform/modules/storage/database/mongo/versions.tf
@@ -8,5 +8,9 @@ terraform {
       source  = "hashicorp/time"
       version = "0.12.1"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.4"
+    }
   }
 }

--- a/terraform/modules/submitter/inputs.tf
+++ b/terraform/modules/submitter/inputs.tf
@@ -18,6 +18,10 @@ variable "generated_env_vars" {
   type = map(string)
 }
 
+variable "mounts" {
+  type = map(string)
+}
+
 variable "volumes" {
   type = map(string)
 }

--- a/terraform/modules/submitter/main.tf
+++ b/terraform/modules/submitter/main.tf
@@ -34,4 +34,12 @@ resource "docker_container" "submitter" {
       source = mounts.key
     }
   }
+
+  dynamic "upload" {
+    for_each = var.mounts
+    content {
+      source = upload.value
+      file   = upload.key
+    }
+  }
 }


### PR DESCRIPTION
# Motivation

- Remove the use of the LocalTrustStore to manage CA certificates for TLS in connections to MongoDB.
- Test TLS connection to MongoDB directly from Core.
- Support TLS connection to MongoDB from Windows based compute plane.

# Description

- Generate custom certificates and use them to enable TLS for MongDB.
- Rewrite validation callback passed to MongoDB driver to support TLS without using the LocalTrustStore on Linux and Windows.

# Testing

- CI pipelines of this repository are working properly with the new certificates and validation callback.
- This branch was also tested within the infrastructure with Windows based compute plane instances.

# Impact

- Enable TLS for our current Windows deployment.

# Additional Information

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.