### PR TITLE
fix: resubmit task when agent tries to acquire a task in Retried

### DIFF
--- a/Adaptors/Memory/src/PushQueueStorage.cs
+++ b/Adaptors/Memory/src/PushQueueStorage.cs
@@ -78,7 +78,7 @@ public class PushQueueStorage : IPushQueueStorage
       if (!id2Handlers_.TryAdd(messageHandler.TaskId!,
                                messageHandler))
       {
-        throw new InvalidOperationException("Duplicate messageId found.");
+        throw new InvalidOperationException($"Duplicate messageId: {messageHandler.TaskId} found.");
       }
     }
 

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -64,7 +64,7 @@ public class TaskTable : ITaskTable
       if (!taskId2TaskData_.TryAdd(taskData.TaskId,
                                    taskData))
       {
-        throw new ArmoniKException($"Tasks '{taskData.TaskId}' already exists");
+        throw new TaskAlreadyExistsException($"Tasks '{taskData.TaskId}' already exists");
       }
 
       var session = session2TaskIds_.GetOrAdd(taskData.SessionId,

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -81,7 +81,7 @@ public class TaskTable : ITaskTable
                                            cancellationToken: cancellationToken)
                           .ConfigureAwait(false);
     }
-    catch (MongoBulkWriteException<TaskData> e)
+    catch (MongoBulkWriteException<TaskData> e) when (e.WriteErrors.All(error => error.Category == ServerErrorCategory.DuplicateKey))
     {
       throw new TaskAlreadyExistsException("Task already exists",
                                            e);

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -75,9 +75,17 @@ public class TaskTable : ITaskTable
 
     var taskCollection = taskCollectionProvider_.Get();
 
-    await taskCollection.InsertManyAsync(tasks.Select(taskData => taskData),
-                                         cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
+    try
+    {
+      await taskCollection.InsertManyAsync(tasks.Select(taskData => taskData),
+                                           cancellationToken: cancellationToken)
+                          .ConfigureAwait(false);
+    }
+    catch (MongoBulkWriteException<TaskData> e)
+    {
+      throw new TaskAlreadyExistsException("Task already exists",
+                                           e);
+    }
   }
 
   /// <inheritdoc />

--- a/Common/src/Exceptions/TaskAlreadyExistsException.cs
+++ b/Common/src/Exceptions/TaskAlreadyExistsException.cs
@@ -1,0 +1,40 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2024. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+namespace ArmoniK.Core.Common.Exceptions;
+
+[Serializable]
+public class TaskAlreadyExistsException : ArmoniKException
+{
+  public TaskAlreadyExistsException()
+  {
+  }
+
+  public TaskAlreadyExistsException(string message)
+    : base(message)
+  {
+  }
+
+  public TaskAlreadyExistsException(string    message,
+                                    Exception innerException)
+    : base(message,
+           innerException)
+  {
+  }
+}

--- a/Common/src/Pollster/AcquisitionStatus.cs
+++ b/Common/src/Pollster/AcquisitionStatus.cs
@@ -78,6 +78,27 @@ public enum AcquisitionStatus
   TaskIsRetried,
 
   /// <summary>
+  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task is
+  ///   <see cref="TaskStatus.Creating" />
+  ///   Retried task finalization is required.
+  /// </summary>
+  TaskIsRetriedAndRetryIsCreating,
+
+  /// <summary>
+  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task was not found
+  ///   in the database
+  ///   Retried task creation and submission is required.
+  /// </summary>
+  TaskIsRetriedAndRetryIsNotFound,
+
+  /// <summary>
+  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task is
+  ///   <see cref="TaskStatus.Submitted" />
+  ///   Reinsertion in the queue may be required.
+  /// </summary>
+  TaskIsRetriedAndRetryIsSubmitted,
+
+  /// <summary>
   ///   Task not acquired because its status is <see cref="TaskStatus.Processing" /> but the other pod does not seem to be
   ///   processing it
   /// </summary>

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -499,19 +499,13 @@ public sealed class TaskHandler : IAsyncDisposable
                             .ConfigureAwait(false);
           }
 
-          switch ((taskNotFound, taskExists, retryData.Status))
-          {
-            case (false, false, TaskStatus.Submitted):
-              return AcquisitionStatus.TaskIsRetriedAndRetryIsSubmitted;
-            case (false, false, TaskStatus.Creating):
-              return AcquisitionStatus.TaskIsRetriedAndRetryIsCreating;
-            case (true, false, TaskStatus.Submitted):
-              return AcquisitionStatus.TaskIsRetriedAndRetryIsNotFound;
-            case (true, false, TaskStatus.Creating):
-              return AcquisitionStatus.TaskIsRetriedAndRetryIsNotFound;
-            default:
-              return AcquisitionStatus.TaskIsRetried;
-          }
+          return (taskNotFound, taskExists, retryData.Status) switch
+                 {
+                   (false, false, TaskStatus.Submitted)                       => AcquisitionStatus.TaskIsRetriedAndRetryIsSubmitted,
+                   (false, false, TaskStatus.Creating)                        => AcquisitionStatus.TaskIsRetriedAndRetryIsCreating,
+                   (true, false, TaskStatus.Submitted or TaskStatus.Creating) => AcquisitionStatus.TaskIsRetriedAndRetryIsNotFound,
+                   _                                                          => AcquisitionStatus.TaskIsRetried,
+                 };
 
         case TaskStatus.Unspecified:
         default:

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -204,4 +204,14 @@ public record TaskData(string        SessionId,
            taskData.Options.ApplicationNamespace,
            taskData.Options.ApplicationVersion,
            taskData.Options.ApplicationService);
+
+  /// <summary>
+  ///   Compute the Id of the new task if this task should be retried
+  ///   Should be deterministic as it can be called several time
+  /// </summary>
+  /// <returns>
+  ///   Id of the retried task
+  /// </returns>
+  public string RetryId()
+    => InitialTaskId + $"###{RetryOfIds.Count + 1}";
 }

--- a/Common/src/Storage/TaskTableExtensions.cs
+++ b/Common/src/Storage/TaskTableExtensions.cs
@@ -484,7 +484,7 @@ public static class TaskTableExtensions
                                              TaskData          taskData,
                                              CancellationToken cancellationToken = default)
   {
-    var newTaskId = taskData.InitialTaskId + $"###{taskData.RetryOfIds.Count + 1}";
+    var newTaskId = taskData.RetryId();
 
     var newTaskRetryOfIds = new List<string>(taskData.RetryOfIds)
                             {

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -483,4 +483,208 @@ public class TaskLifeCycleHelperTest
                                  .ConfigureAwait(false)).Select(handler => handler.TaskId)
                                                         .Count(s => s == taskId));
   }
+
+  [Test]
+  public async Task FinalizeTwiceShouldSucceed()
+  {
+    using var holder = new Holder();
+
+    var sessionId = await SessionLifeCycleHelper.CreateSession(holder.SessionTable,
+                                                               holder.PartitionTable,
+                                                               new List<string>
+                                                               {
+                                                                 Holder.Partition,
+                                                               },
+                                                               holder.Options.ToTaskOptions(),
+                                                               Holder.Partition)
+                                                .ConfigureAwait(false);
+
+    var sessionData = await holder.SessionTable.GetSessionAsync(sessionId)
+                                  .ConfigureAwait(false);
+
+    var results = new List<Result>
+                  {
+                    new(sessionId,
+                        Guid.NewGuid()
+                            .ToString(),
+                        "Payload",
+                        "",
+                        "",
+                        ResultStatus.Completed,
+                        new List<string>(),
+                        DateTime.UtcNow,
+                        0,
+                        Array.Empty<byte>()),
+                    new(sessionId,
+                        Guid.NewGuid()
+                            .ToString(),
+                        "DataDependency1",
+                        "",
+                        "",
+                        ResultStatus.Created,
+                        new List<string>(),
+                        DateTime.UtcNow,
+                        0,
+                        Array.Empty<byte>()),
+                    new(sessionId,
+                        Guid.NewGuid()
+                            .ToString(),
+                        "DataDependency2",
+                        "",
+                        "",
+                        ResultStatus.Created,
+                        new List<string>(),
+                        DateTime.UtcNow,
+                        0,
+                        Array.Empty<byte>()),
+                    new(sessionId,
+                        Guid.NewGuid()
+                            .ToString(),
+                        "Output",
+                        "",
+                        "",
+                        ResultStatus.Created,
+                        new List<string>(),
+                        DateTime.UtcNow,
+                        0,
+                        Array.Empty<byte>()),
+                  };
+
+    await holder.ResultTable.Create(results)
+                .ConfigureAwait(false);
+
+    var tasks = new List<TaskCreationRequest>
+                {
+                  new(Guid.NewGuid()
+                          .ToString(),
+                      results[0]
+                        .ResultId,
+                      holder.Options.ToTaskOptions(),
+                      new List<string>
+                      {
+                        results[3]
+                          .ResultId,
+                      },
+                      new List<string>
+                      {
+                        results[1]
+                          .ResultId,
+                        results[2]
+                          .ResultId,
+                      }),
+                };
+
+    var taskId = tasks.Single()
+                      .TaskId;
+
+    await TaskLifeCycleHelper.CreateTasks(holder.TaskTable,
+                                          holder.ResultTable,
+                                          sessionId,
+                                          sessionId,
+                                          tasks,
+                                          NullLogger.Instance)
+                             .ConfigureAwait(false);
+
+    var taskData = await holder.TaskTable.ReadTaskAsync(taskId)
+                               .ConfigureAwait(false);
+
+    Assert.AreEqual(TaskStatus.Creating,
+                    taskData.Status);
+
+    await TaskLifeCycleHelper.FinalizeTaskCreation(holder.TaskTable,
+                                                   holder.ResultTable,
+                                                   holder.PushQueueStorage,
+                                                   tasks,
+                                                   sessionData,
+                                                   sessionId,
+                                                   NullLogger.Instance)
+                             .ConfigureAwait(false);
+
+    taskData = await holder.TaskTable.ReadTaskAsync(taskId)
+                           .ConfigureAwait(false);
+
+    Assert.AreEqual(TaskStatus.Pending,
+                    taskData.Status);
+    Assert.AreEqual(2,
+                    taskData.RemainingDataDependencies.Count);
+
+
+    // complete first data dependency
+    await holder.ResultTable.CompleteResult(sessionId,
+                                            results[1]
+                                              .ResultId,
+                                            10)
+                .ConfigureAwait(false);
+    await holder.ResultTable.CompleteResult(sessionId,
+                                            results[2]
+                                              .ResultId,
+                                            10)
+                .ConfigureAwait(false);
+    await TaskLifeCycleHelper.ResolveDependencies(holder.TaskTable,
+                                                  holder.ResultTable,
+                                                  holder.PushQueueStorage,
+                                                  sessionData,
+                                                  new List<string>
+                                                  {
+                                                    results[1]
+                                                      .ResultId,
+                                                    results[2]
+                                                      .ResultId,
+                                                  },
+                                                  NullLogger.Instance)
+                             .ConfigureAwait(false);
+
+    taskData = await holder.TaskTable.ReadTaskAsync(taskId)
+                           .ConfigureAwait(false);
+
+    Assert.AreEqual(TaskStatus.Submitted,
+                    taskData.Status);
+    Assert.IsEmpty(taskData.RemainingDataDependencies);
+    var count = 0;
+    while (holder.QueueStorage.Channel.Reader.TryRead(out var handler))
+    {
+      if (handler.TaskId == taskId)
+      {
+        count++;
+      }
+    }
+
+    Assert.AreEqual(1,
+                    count);
+
+    await TaskLifeCycleHelper.FinalizeTaskCreation(holder.TaskTable,
+                                                   holder.ResultTable,
+                                                   holder.PushQueueStorage,
+                                                   tasks,
+                                                   sessionData,
+                                                   sessionId,
+                                                   NullLogger.Instance)
+                             .ConfigureAwait(false);
+
+    await TaskLifeCycleHelper.FinalizeTaskCreation(holder.TaskTable,
+                                                   holder.ResultTable,
+                                                   holder.PushQueueStorage,
+                                                   tasks,
+                                                   sessionData,
+                                                   sessionId,
+                                                   NullLogger.Instance)
+                             .ConfigureAwait(false);
+
+    taskData = await holder.TaskTable.ReadTaskAsync(taskId)
+                           .ConfigureAwait(false);
+
+    Assert.AreEqual(TaskStatus.Submitted,
+                    taskData.Status);
+    count = 0;
+    while (holder.QueueStorage.Channel.Reader.TryRead(out var handler))
+    {
+      if (handler.TaskId == taskId)
+      {
+        count++;
+      }
+    }
+
+    Assert.AreEqual(2,
+                    count);
+  }
 }

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -1847,6 +1847,18 @@ public class TaskTableTestBase
   }
 
   [Test]
+  public void CreateSameTaskShouldThrow()
+  {
+    if (RunTests)
+    {
+      Assert.ThrowsAsync<TaskAlreadyExistsException>(() => TaskTable!.CreateTasks(new[]
+                                                                                  {
+                                                                                    taskCompletedData_,
+                                                                                  }));
+    }
+  }
+
+  [Test]
   public async Task ListTaskEmptyResultShouldSucceed()
   {
     if (RunTests)


### PR DESCRIPTION
# Motivation

Fix the issue in which retried task appear in Creating and are not processed further, preventing application from running to completion.

To my understanding, during downscaling, preemption or crash and when the worker crashes too, the agent can be abruptly stopped during the submission of the retried task (task creation, task finalization or insertion into the queue). We also observe that the agent tries to acquire the initial task with status Retried instead of the new copy of the task (the new attempt). The retried task is only in the Creating status, showing that the task finalization was not properly done. This means that the initial task' finalization has not completed properly.

# Description

To mitigate this issue, we implement a recovery mechanism that, when an agent tries to acquire the initial task, the agent will properly finalize the retried task before removing the initial task from the queue instead of only removing the initial task from the queue.

When the initial task with status Retried is acquired by the agent, we check whether the retry task has been properly finalized. To do so, we get the metadata of the retried task. If we can retrieve them and the retried task is in Creating or Submitted we perform task finalization and insertion in the queue again. If the task was already inserted in the queue, task deduplication should do its job and ignore the duplicate. If the retried task is in another status, we remove the message from the queue. If the retried task is not found, we submit the retried task completely (creation, finalization, queueing). If the retried task has already been created between our read and our creation in the database, we check the status of the retried tasks and perform finalization if task is Creating or Submitted.

# Testing

I was not able to fully reproduce this issue in Core docker deployment even while trying to stop agents abruptly with the following script. I used a modified bench worker that was only producing errors.

```bash
#!/bin/sh

for i in $(seq 1 40); do
    for a in $(docker ps -q --filter name=armonik.compute.pollingagent); do
        docker restart -s sigterm -t 0 $a
        # sleep 1
    done
done
```

I also tried to vary the delay and still was not able to reproduce.

I added unit tests that can put tasks in the same state that we observed. They also validate that we are able to recover from the invalid state and resubmit the task in retry.

# Impact

- Acquisition of task in Retried status is more complex now and make more calls to the database, reducing performances while improving recovery on failure.
- Sometimes, in the case explicited here, the retry task may be inserted twice into the queue, making use of the deduplication mechanism to remove the duplicata from the queue.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.