### PR TITLE
fix: agent is null when error occurs in PreProcessing

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -1022,10 +1022,6 @@ public sealed class TaskHandler : IAsyncDisposable
                                               CancellationToken cancellationToken)
   {
     using var measure = functionExecutionMetrics_.CountAndTime();
-    if (agent_ is null)
-    {
-      throw new NullReferenceException(nameof(agent_) + " is null.");
-    }
 
     if (sessionData_ is null)
     {
@@ -1094,8 +1090,11 @@ public sealed class TaskHandler : IAsyncDisposable
                                    : QueueMessageStatus.Processed;
       }
 
-      await agent_.CancelChildTasks(CancellationToken.None)
-                  .ConfigureAwait(false);
+      if (agent_ is not null)
+      {
+        await agent_.CancelChildTasks(CancellationToken.None)
+                    .ConfigureAwait(false);
+      }
     }
 
     // Rethrow enable the recording of the error by the Pollster Main loop

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -75,6 +75,7 @@ public class TestTaskHandlerProvider : IDisposable
                                  ITaskTable?             inputTaskTable        = null,
                                  ISessionTable?          inputSessionTable     = null,
                                  ITaskProcessingChecker? taskProcessingChecker = null,
+                                 IObjectStorage?         objectStorage         = null,
                                  TimeSpan?               graceDelay            = null)
   {
     var logger = NullLogger.Instance;
@@ -202,6 +203,11 @@ public class TestTaskHandlerProvider : IDisposable
     if (inputSessionTable is not null)
     {
       builder.Services.AddSingleton(inputSessionTable);
+    }
+
+    if (objectStorage is not null)
+    {
+      builder.Services.AddSingleton(objectStorage);
     }
 
     var computePlanOptions = builder.Configuration.GetRequiredValue<ComputePlane>(ComputePlane.SettingSection);


### PR DESCRIPTION
# Motivation

During TaskHandler Preprocessing, when an input data is not found, the following error is raised:

```
System.NullReferenceException: agent_ is null.
   at ArmoniK.Core.Common.Pollster.TaskHandler.HandleErrorInternalAsync(Exception e, TaskData taskData, Boolean resubmit, Boolean requeueIfUnavailable, CancellationToken cancellationToken) in /src/Common/src/Pollster/TaskHandler.cs:line 923
   at ArmoniK.Core.Common.Pollster.TaskHandler.HandleErrorRequeueAsync(Exception e, TaskData taskData, CancellationToken cancellationToken) in /src/Common/src/Pollster/TaskHandler.cs:line 887
   at ArmoniK.Core.Common.Pollster.TaskHandler.PreProcessing() in /src/Common/src/Pollster/TaskHandler.cs:line 702
   at ArmoniK.Core.Common.Pollster.Pollster.MainLoop(CancellationToken cancellationToken) in /src/Common/src/Pollster/Pollster.cs:line 408
```

Then task is requeud and creates an infinite loop.
This PR aims to fix this issue.

# Description

In TaskHandler HandleErrorAsync, a null check was done on the variable `agent_`. This variable is initialized in the function ExecuteTaskAsync which is called after PreProcessing. However, when an error occurs in PreProcessing, HandleErrorAsync is called. As `agent_` is not yet initialized; it produces the aforementioned error.

In HandleErrorAsync, `agent_` is needed to cancel potential child tasks. In Preprocessing, no child tasks can be created yet so if the agent is null (not yet initialized) no child tasks can be created so we do not need to perfom child tasks cancellation. 

# Testing

A unit test has been introduced that reproduces the issue.

# Impact

Avoid infinite loops when the input data is not found during task processing. Now, tasks are clearly put in Error.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.