### PR TITLE
fix: add missing GH token in scout cron

### DIFF
--- a/.github/workflows/scout-cron.yml
+++ b/.github/workflows/scout-cron.yml
@@ -13,6 +13,8 @@ jobs:
     - name: List last releases
       id: releases
       run: echo "releases:$(gh release list -L 3 --json tagName -q '[ .[].tagName ]')"  >> "$GITHUB_OUTPUT"
+      env:
+        GH_TOKEN: ${{ github.token }}
 
   scout:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

Make sure the scout pipiline work properly.

# Description

Add the missing GitHub token a environment variable.

# Testing

Tests will be performed after because the pipeline need to be on main for testing.

# Impact

Notification of security issues.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
