### PR TITLE
refactor: remove TaskData.EscapeKey

### DIFF
--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -271,7 +271,7 @@ public class TaskTable : ITaskTable
                                    {
                                      var remainingDep = data.RemainingDataDependencies;
 
-                                     foreach (var dep in dependenciesToRemove.Select(TaskData.EscapeKey))
+                                     foreach (var dep in dependenciesToRemove)
                                      {
                                        remainingDep.Remove(dep);
                                      }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -370,11 +370,11 @@ public class TaskTable : ITaskTable
     }
 
 
-    var key0   = TaskData.EscapeKey(deps.Current);
+    var key0   = deps.Current;
     var update = new UpdateDefinitionBuilder<TaskData>().Unset(data => data.RemainingDataDependencies[key0]);
     while (deps.MoveNext())
     {
-      var key = TaskData.EscapeKey(deps.Current);
+      var key = deps.Current;
       update = update.Unset(data => data.RemainingDataDependencies[key]);
     }
 

--- a/Common/src/Storage/TaskData.cs
+++ b/Common/src/Storage/TaskData.cs
@@ -18,7 +18,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
 using ArmoniK.Core.Base.DataStructures;
 
@@ -140,7 +139,7 @@ public record TaskData(string        SessionId,
                                    {
                                      payloadId,
                                    })
-                           .ToDictionary(EscapeKey,
+                           .ToDictionary(s => s,
                                          _ => true),
            expectedOutputIds,
            taskId,
@@ -174,23 +173,6 @@ public record TaskData(string        SessionId,
                   UpdateDefinition<TaskData> updates)
     : this(original)
     => updates.ApplyTo(this);
-
-  /// <summary>
-  ///   ResultIds could contain dots (eg: it is the case in htcmock),
-  ///   but MongoDB does not support well dots in keys.
-  ///   This escapes the key to replace dots with something else.
-  ///   Escaped keys are guaranteed to have neither dots nor dollars
-  /// </summary>
-  /// <param name="key">Key string</param>
-  /// <returns>Escaped key</returns>
-  public static string EscapeKey(string key)
-    => new StringBuilder(key).Replace("@",
-                                      "@at@")
-                             .Replace(".",
-                                      "@dot@")
-                             .Replace("$",
-                                      "@dollar@")
-                             .ToString();
 
   /// <summary>
   ///   Conversion operator from <see cref="TaskData" /> to <see cref="Application" />

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -2151,8 +2151,8 @@ public class TaskTableTestBase
     {
       var taskId = Guid.NewGuid()
                        .ToString();
-      var dd1 = "dependency.1";
-      var dd2 = "dependency.2";
+      var dd1 = "dependency1";
+      var dd2 = "dependency2";
 
       await TaskTable!.CreateTasks(new[]
                                    {


### PR DESCRIPTION
# Motivation

Remove code that is not necessary anymore to improve maintainability.

# Description

TaskData.EscapeKey was needed to ensure keys provided by users were valid. This is not needed anymore beacause IDs are GUID generated by core. This PR removes this unnecessary step.

# Testing

Unit tests were used.

# Impact

Reduced code to maintain.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
