### PR TITLE
ci: add missing checkout in scout cron job and enable workflow_dispatch

### DIFF
--- a/.github/workflows/scout-cron.yml
+++ b/.github/workflows/scout-cron.yml
@@ -3,6 +3,7 @@ name: Scout Images
 on:
     schedule:
       - cron: '10 9 * * 1'   # 9:10 on Monday
+    workflow_dispatch:
 
 jobs:
   releases:
@@ -35,6 +36,7 @@ jobs:
           - dockerhubaneo/armonik_core_bench_test_client
         version: ${{ fromJSON(needs.releases.outputs.releases) }}
     steps:
+    - uses: actions/checkout@eef61447b9ff4aafe5dcd4e0bbf5d482be7e7871 # v4
     - name: Login to Docker Hub
       uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3
       with:


### PR DESCRIPTION
# Motivation

Make sure the scout pipeline work properly.

# Description

- Add the missing checkout of the repo to access releases
- Enable manual trigger of the pipeline

# Testing

Tests will be performed after because the pipeline need to be on main for testing. Manual trigger will help to test faster.

# Impact

Notification of security issues.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
