### PR TITLE
fix: recreate rabbit connection when closed

### DIFF
--- a/Adaptors/RabbitMQ/src/ConnectionRabbit.cs
+++ b/Adaptors/RabbitMQ/src/ConnectionRabbit.cs
@@ -37,27 +37,21 @@ namespace ArmoniK.Core.Adapters.RabbitMQ;
 [UsedImplicitly]
 public class ConnectionRabbit : IConnectionRabbit
 {
-  private readonly AsyncLazy                 connectionTask_;
-  private readonly ILogger<ConnectionRabbit> logger_;
-
-  private readonly Amqp options_;
-
-  private bool isInitialized_;
+  private readonly ExecutionSingleizer<IModel> connectionSingleizer_ = new();
+  private readonly ILogger<ConnectionRabbit>   logger_;
+  private readonly Amqp                        options_;
+  private          bool                        isInitialized_;
+  private          IModel?                     model_;
 
   public ConnectionRabbit(Amqp                      options,
                           ILogger<ConnectionRabbit> logger)
   {
-    logger_         = logger;
-    options_        = options;
-    connectionTask_ = new AsyncLazy(() => InitTask(this));
+    logger_  = logger;
+    options_ = options;
   }
 
-  private IConnection? Connection { get; set; }
-
-  public IModel? Channel { get; private set; }
-
-  public async Task Init(CancellationToken cancellationToken = default)
-    => await connectionTask_;
+  public Task Init(CancellationToken cancellationToken = default)
+    => GetConnectionAsync(cancellationToken);
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
     => tag switch
@@ -65,7 +59,7 @@ public class ConnectionRabbit : IConnectionRabbit
          HealthCheckTag.Startup or HealthCheckTag.Readiness => Task.FromResult(isInitialized_
                                                                                  ? HealthCheckResult.Healthy()
                                                                                  : HealthCheckResult.Unhealthy($"{nameof(ConnectionRabbit)} is not yet initialized.")),
-         HealthCheckTag.Liveness => Task.FromResult(isInitialized_ && Connection is not null && Connection.IsOpen && Channel is not null && Channel.IsOpen
+         HealthCheckTag.Liveness => Task.FromResult(isInitialized_ && model_ is not null && model_.IsOpen
                                                       ? HealthCheckResult.Healthy()
                                                       : HealthCheckResult.Unhealthy($"{nameof(ConnectionRabbit)} not initialized or connection dropped.")),
          _ => throw new ArgumentOutOfRangeException(nameof(tag),
@@ -77,33 +71,60 @@ public class ConnectionRabbit : IConnectionRabbit
   {
     if (isInitialized_)
     {
-      Channel!.Close();
-      Connection!.Close();
-
-      Channel.Dispose();
-      Connection.Dispose();
+      model_!.Close();
+      model_!.Dispose();
     }
+
+    connectionSingleizer_.Dispose();
 
     GC.SuppressFinalize(this);
   }
 
-  private async Task InitTask(ConnectionRabbit  conn,
-                              CancellationToken cancellationToken = default)
+
+  public async Task<IModel> GetConnectionAsync(CancellationToken cancellationToken = default)
+  {
+    if (model_ is not null && !model_.IsClosed)
+    {
+      return model_;
+    }
+
+    return await connectionSingleizer_.Call(async token =>
+                                            {
+                                              // this is needed to resolve TOCTOU problem
+                                              if (model_ is not null && !model_.IsClosed)
+                                              {
+                                                return model_;
+                                              }
+
+                                              var conn = await CreateConnection(options_,
+                                                                                logger_,
+                                                                                token)
+                                                           .ConfigureAwait(false);
+                                              model_ = conn;
+                                              return conn;
+                                            },
+                                            cancellationToken)
+                                      .ConfigureAwait(false);
+  }
+
+  private static async Task<IModel> CreateConnection(Amqp              options,
+                                                     ILogger           logger,
+                                                     CancellationToken cancellationToken = default)
   {
     var factory = new ConnectionFactory
                   {
-                    UserName               = conn.options_.User,
-                    Password               = conn.options_.Password,
-                    HostName               = conn.options_.Host,
-                    Port                   = conn.options_.Port,
+                    UserName               = options.User,
+                    Password               = options.Password,
+                    HostName               = options.Host,
+                    Port                   = options.Port,
                     DispatchConsumersAsync = true,
                   };
 
 
-    if (options_.Scheme.Equals("AMQPS"))
+    if (options.Scheme.Equals("AMQPS"))
     {
       factory.Ssl.Enabled    = true;
-      factory.Ssl.ServerName = conn.options_.Host;
+      factory.Ssl.ServerName = options.Host;
       factory.Ssl.CertificateValidationCallback = delegate(object           _,
                                                            X509Certificate? _,
                                                            X509Chain?       _,
@@ -111,51 +132,46 @@ public class ConnectionRabbit : IConnectionRabbit
                                                   {
                                                     switch (errors)
                                                     {
-                                                      case SslPolicyErrors.RemoteCertificateNameMismatch when conn.options_.AllowHostMismatch:
+                                                      case SslPolicyErrors.RemoteCertificateNameMismatch when options.AllowHostMismatch:
                                                       case SslPolicyErrors.None:
                                                         return true;
                                                       default:
-                                                        logger_.LogError("SSL error : {error}",
-                                                                         errors);
+                                                        logger.LogError("SSL error : {error}",
+                                                                        errors);
                                                         return false;
                                                     }
                                                   };
     }
 
     var retry = 0;
-    for (; retry < conn.options_.MaxRetries; retry++)
+    for (; retry < options.MaxRetries; retry++)
     {
       try
       {
-        conn.Connection = factory.CreateConnection();
-        conn.Connection.ConnectionShutdown += (_,
-                                               ea) => OnShutDown(ea,
-                                                                 "Connection",
-                                                                 logger_);
+        var connection = factory.CreateConnection();
+        connection.ConnectionShutdown += (_,
+                                          ea) => OnShutDown(ea,
+                                                            "Connection",
+                                                            logger);
 
-        Channel = conn.Connection.CreateModel();
-        Channel.ModelShutdown += (_,
-                                  ea) => OnShutDown(ea,
-                                                    "Channel",
-                                                    logger_);
-        break;
+        var model = connection.CreateModel();
+        model.ModelShutdown += (_,
+                                ea) => OnShutDown(ea,
+                                                  "Channel",
+                                                  logger);
+        return model;
       }
       catch (Exception ex)
       {
-        logger_.LogInformation(ex,
-                               "Retrying to create connection");
+        logger.LogInformation(ex,
+                              "Retrying to create connection");
         await Task.Delay(1000 * retry,
                          cancellationToken)
                   .ConfigureAwait(false);
       }
     }
 
-    if (retry == conn.options_.MaxRetries)
-    {
-      throw new TimeoutException($"{nameof(conn.options_.MaxRetries)} reached");
-    }
-
-    conn.isInitialized_ = true;
+    throw new TimeoutException($"{nameof(options.MaxRetries)} reached");
   }
 
   private static void OnShutDown(ShutdownEventArgs ea,

--- a/Adaptors/RabbitMQ/src/ConnectionRabbit.cs
+++ b/Adaptors/RabbitMQ/src/ConnectionRabbit.cs
@@ -38,6 +38,7 @@ namespace ArmoniK.Core.Adapters.RabbitMQ;
 public class ConnectionRabbit : IConnectionRabbit
 {
   private readonly ExecutionSingleizer<IModel> connectionSingleizer_ = new();
+  private readonly ConnectionFactory           factory_;
   private readonly ILogger<ConnectionRabbit>   logger_;
   private readonly Amqp                        options_;
   private          bool                        isInitialized_;
@@ -48,6 +49,14 @@ public class ConnectionRabbit : IConnectionRabbit
   {
     logger_  = logger;
     options_ = options;
+    factory_ = new ConnectionFactory
+               {
+                 UserName               = options.User,
+                 Password               = options.Password,
+                 HostName               = options.Host,
+                 Port                   = options.Port,
+                 DispatchConsumersAsync = true,
+               };
   }
 
   public Task Init(CancellationToken cancellationToken = default)
@@ -97,6 +106,7 @@ public class ConnectionRabbit : IConnectionRabbit
                                               }
 
                                               var conn = await CreateConnection(options_,
+                                                                                factory_,
                                                                                 logger_,
                                                                                 token)
                                                            .ConfigureAwait(false);
@@ -108,19 +118,10 @@ public class ConnectionRabbit : IConnectionRabbit
   }
 
   private static async Task<IModel> CreateConnection(Amqp              options,
+                                                     ConnectionFactory factory,
                                                      ILogger           logger,
                                                      CancellationToken cancellationToken = default)
   {
-    var factory = new ConnectionFactory
-                  {
-                    UserName               = options.User,
-                    Password               = options.Password,
-                    HostName               = options.Host,
-                    Port                   = options.Port,
-                    DispatchConsumersAsync = true,
-                  };
-
-
     if (options.Scheme.Equals("AMQPS"))
     {
       factory.Ssl.Enabled    = true;

--- a/Adaptors/RabbitMQ/src/IConnectionRabbit.cs
+++ b/Adaptors/RabbitMQ/src/IConnectionRabbit.cs
@@ -16,6 +16,8 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 using ArmoniK.Core.Base;
 
@@ -25,5 +27,5 @@ namespace ArmoniK.Core.Adapters.RabbitMQ;
 
 public interface IConnectionRabbit : IInitializable, IDisposable
 {
-  public IModel? Channel { get; }
+  Task<IModel> GetConnectionAsync(CancellationToken cancellationToken = default);
 }

--- a/Adaptors/RabbitMQ/src/PullQueueStorage.cs
+++ b/Adaptors/RabbitMQ/src/PullQueueStorage.cs
@@ -69,12 +69,15 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
                       },
                     };
 
-    (await ConnectionRabbit.GetConnectionAsync(cancellationToken)
-                           .ConfigureAwait(false)).QueueDeclare(Options!.PartitionId,
-                                                                false, /* to survive broker restart */
-                                                                false, /* used by multiple connections */
-                                                                false, /* not deleted when last consumer unsubscribes (if it has had one) */
-                                                                queueArgs);
+    var connection = await ConnectionRabbit.GetConnectionAsync(cancellationToken)
+                                           .ConfigureAwait(false);
+
+    connection.QueueDeclare(Options!.PartitionId,
+                            false, /* to survive broker restart */
+                            false, /* used by multiple connections */
+                            false, /* not deleted when last consumer unsubscribes (if it has had one) */
+                            queueArgs);
+
     IsInitialized = true;
   }
 
@@ -92,9 +95,11 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
     {
       cancellationToken.ThrowIfCancellationRequested();
 
-      var message = (await ConnectionRabbit.GetConnectionAsync(cancellationToken)
-                                           .ConfigureAwait(false)).BasicGet(Options.PartitionId,
-                                                                            false);
+      var connection = await ConnectionRabbit.GetConnectionAsync(cancellationToken)
+                                             .ConfigureAwait(false);
+
+      var message = connection.BasicGet(Options.PartitionId,
+                                        false);
 
       if (message is null)
       {

--- a/Adaptors/RabbitMQ/src/PushQueueStorage.cs
+++ b/Adaptors/RabbitMQ/src/PushQueueStorage.cs
@@ -63,14 +63,17 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
   {
     var task = Task.Run(() => PushMessages(messages,
                                            partitionId,
-                                           priority),
+                                           priority,
+                                           cancellationToken),
                         cancellationToken);
     return task;
   }
 
-  private void PushMessages(IEnumerable<MessageData> messages,
-                            string                   partitionId,
-                            int                      priority)
+  private async Task PushMessages(IEnumerable<MessageData> messages,
+                                  string                   partitionId,
+                                  int                      priority,
+                                  CancellationToken        cancellationToken)
+
   {
     if (!IsInitialized)
     {
@@ -80,29 +83,32 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
     var queueArgs = new Dictionary<string, object>
                     {
                       {
-                        "x-max-priority", Options!.MaxPriority
+                        "x-max-priority", Options.MaxPriority
                       },
                       {
                         "x-queue-mode", "lazy" // queue will try to move messages to disk as early as practically possible
                       },
                     };
 
-    ConnectionRabbit.Channel!.QueueDeclare(partitionId,
-                                           false, /* to survive broker restart */
-                                           false, /* used by multiple connections */
-                                           false, /* not deleted when last consumer unsubscribes (if it has had one) */
-                                           queueArgs);
+    (await ConnectionRabbit.GetConnectionAsync(cancellationToken)
+                           .ConfigureAwait(false)).QueueDeclare(partitionId,
+                                                                false, /* to survive broker restart */
+                                                                false, /* used by multiple connections */
+                                                                false, /* not deleted when last consumer unsubscribes (if it has had one) */
+                                                                queueArgs);
 
     foreach (var msg in messages)
     {
-      var basicProperties = ConnectionRabbit.Channel!.CreateBasicProperties();
+      var basicProperties = (await ConnectionRabbit.GetConnectionAsync(cancellationToken)
+                                                   .ConfigureAwait(false)).CreateBasicProperties();
       basicProperties.Priority = Convert.ToByte(priority);
       basicProperties.MessageId = Guid.NewGuid()
                                       .ToString();
-      ConnectionRabbit.Channel.BasicPublish("",
-                                            partitionId,
-                                            basicProperties,
-                                            Encoding.UTF8.GetBytes(msg.TaskId));
+      (await ConnectionRabbit.GetConnectionAsync(cancellationToken)
+                             .ConfigureAwait(false)).BasicPublish("",
+                                                                  partitionId,
+                                                                  basicProperties,
+                                                                  Encoding.UTF8.GetBytes(msg.TaskId));
     }
   }
 }


### PR DESCRIPTION
# Motivation

When there is an issue with Rabbit connection and it closes, the agent cannot receive new messages because the connection is not recreated. Agent has to restart for Rabbit Adapter to work again.

# Description

As for Amqp, an ExecutionSingleizer was used to create a unique connection. It returns the existing connection when the connection is not closed. When the connection is closed, it creates a new one and returns it.


# Testing

Unit tests and integration tests were run and no issue appears.

# Impact

Improves ArmoniK resiliency when RabbitMQ encounters issues.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
