### PR TITLE
fix: show exact core version in logs

### DIFF
--- a/Common/src/Utils/LoggerInit.cs
+++ b/Common/src/Utils/LoggerInit.cs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Diagnostics;
 
 using Destructurama;
 
@@ -43,8 +44,8 @@ public class LoggerInit
                                                     .WriteTo.Console(new CompactJsonFormatter())
                                                     .Enrich.FromLogContext()
                                                     .Enrich.WithProperty("CoreVersion",
-                                                                         typeof(LoggerInit).Assembly.GetName()
-                                                                                           .Version?.ToString() ?? "Unknown")
+                                                                         FileVersionInfo.GetVersionInfo(typeof(LoggerInit).Assembly.Location)
+                                                                                        .ProductVersion ?? "Unknown")
                                                     .Enrich.WithProperty("InstanceId",
                                                                          instanceId)
                                                     .Destructure.UsingAttributes()

--- a/Common/src/gRPC/Services/GrpcVersionsService.cs
+++ b/Common/src/gRPC/Services/GrpcVersionsService.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Diagnostics;
 using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1.Versions;
@@ -30,11 +31,11 @@ namespace ArmoniK.Core.Common.gRPC.Services;
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcVersionsService : Versions.VersionsBase
 {
-  public static readonly string CoreVersion = typeof(GrpcVersionsService).Assembly.GetName()
-                                                                         .Version!.ToString();
+  public static readonly string CoreVersion = FileVersionInfo.GetVersionInfo(typeof(GrpcVersionsService).Assembly.Location)
+                                                             .ProductVersion ?? "Unknown";
 
-  public static readonly string ApiVersion = typeof(Versions.VersionsBase).Assembly.GetName()
-                                                                          .Version!.ToString();
+  public static readonly string ApiVersion = FileVersionInfo.GetVersionInfo(typeof(Versions.VersionsBase).Assembly.Location)
+                                                            .ProductVersion ?? "Unknown";
 
   [RequiresPermission(typeof(GrpcVersionsService),
                       nameof(ListVersions))]


### PR DESCRIPTION
# Motivation

Improve identification of ArmoniK.Core version from logs.

# Description

Version was determined through package version which gives the Major.Minor.Patch version while ignoring prerelease suffixes (-SNAPSHOT*). This PR changes uses Product version instead which contains the full version.

# Testing

The proper version appears in the logs.

# Impact

Logs and version API now return the full versions.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
