### PR TITLE
fix: ensure task in error or retry children are properly cancelled

### DIFF
--- a/Common/src/Pollster/Agent.cs
+++ b/Common/src/Pollster/Agent.cs
@@ -210,21 +210,6 @@ public sealed class Agent : IAgent
   }
 
   /// <inheritdoc />
-  public async Task CancelChildTasks(CancellationToken cancellationToken)
-  {
-    if (createdTasks_.Any())
-    {
-      await taskTable_.CancelTaskAsync(createdTasks_.Select(request => request.TaskId)
-                                                    .AsICollection(),
-                                       cancellationToken)
-                      .ConfigureAwait(false);
-    }
-
-    logger_.LogDebug("Cancel {n} child tasks created by this task",
-                     createdTasks_.Count);
-  }
-
-  /// <inheritdoc />
   public async Task<ICollection<TaskCreationRequest>> SubmitTasks(ICollection<TaskSubmissionRequest> requests,
                                                                   TaskOptions?                       taskOptions,
                                                                   string                             sessionId,

--- a/Common/src/Pollster/IAgent.cs
+++ b/Common/src/Pollster/IAgent.cs
@@ -145,13 +145,4 @@ public interface IAgent : IDisposable
   Task<ICollection<string>> NotifyResultData(string              token,
                                              ICollection<string> resultIds,
                                              CancellationToken   cancellationToken);
-
-  /// <summary>
-  ///   Cancel child tasks created by the current task in processing
-  /// </summary>
-  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
-  /// <returns>
-  ///   Task representing the asynchronous execution of the method
-  /// </returns>
-  Task CancelChildTasks(CancellationToken cancellationToken);
 }

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -960,11 +960,6 @@ public sealed class TaskHandler : IAsyncDisposable
         await agent_.FinalizeTaskCreation(CancellationToken.None)
                     .ConfigureAwait(false);
       }
-      else
-      {
-        await agent_.CancelChildTasks(CancellationToken.None)
-                    .ConfigureAwait(false);
-      }
 
       await submitter_.CompleteTaskAsync(taskData_,
                                          sessionData_,
@@ -1088,12 +1083,6 @@ public sealed class TaskHandler : IAsyncDisposable
         messageHandler_.Status = resubmit
                                    ? QueueMessageStatus.Cancelled
                                    : QueueMessageStatus.Processed;
-      }
-
-      if (agent_ is not null)
-      {
-        await agent_.CancelChildTasks(CancellationToken.None)
-                    .ConfigureAwait(false);
       }
     }
 

--- a/Common/src/gRPC/Services/Submitter.cs
+++ b/Common/src/gRPC/Services/Submitter.cs
@@ -531,6 +531,20 @@ public class Submitter : ISubmitter
 
         break;
       case OutputStatus.Error:
+
+        await taskTable_.UpdateManyTasks(data => data.CreatedBy == taskData.TaskId,
+                                         new UpdateDefinition<TaskData>().Set(data => data.Status,
+                                                                              TaskStatus.Cancelled),
+                                         CancellationToken.None)
+                        .ConfigureAwait(false);
+
+        await resultTable_.UpdateManyResults(data => data.CreatedBy == taskData.TaskId,
+                                             new UpdateDefinition<Result>().Set(data => data.Status,
+                                                                                ResultStatus.Aborted),
+                                             CancellationToken.None)
+                          .ConfigureAwait(false);
+
+
         // TODO FIXME: nothing will resubmit the task if there is a crash there
         if (resubmit && taskData.RetryOfIds.Count < taskData.Options.MaxRetries)
         {

--- a/Common/tests/Helpers/SimpleAgent.cs
+++ b/Common/tests/Helpers/SimpleAgent.cs
@@ -82,9 +82,6 @@ public class SimpleAgent : IAgent
     => Task.FromResult(Array.Empty<string>()
                             .AsICollection());
 
-  public Task CancelChildTasks(CancellationToken cancellationToken)
-    => Task.CompletedTask;
-
   public void Dispose()
     => GC.SuppressFinalize(this);
 }

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -247,4 +247,8 @@ public class TestTaskHandlerProvider : IDisposable
                .Wait();
     GC.SuppressFinalize(this);
   }
+
+  public T GetRequiredService<T>()
+    where T : notnull
+    => app_.Services.GetRequiredService<T>();
 }

--- a/Common/tests/Helpers/WrapperAgentHandler.cs
+++ b/Common/tests/Helpers/WrapperAgentHandler.cs
@@ -15,35 +15,31 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 
-using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Common.Pollster;
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Common.Stream.Worker;
 
-using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Common.Tests.Helpers;
 
-public class SimpleWorkerStreamHandler : IWorkerStreamHandler
+public class WrapperAgentHandler : IAgentHandler
 {
-  public Output Output = new(OutputStatus.Success,
-                             "");
+  private readonly IAgent agent_;
 
-  public Task<HealthCheckResult> Check(HealthCheckTag tag)
-    => Task.FromResult(HealthCheckResult.Healthy());
+  public WrapperAgentHandler(IAgent agent)
+    => agent_ = agent;
 
-  public Task Init(CancellationToken cancellationToken)
+  public Task Stop(CancellationToken cancellationToken)
     => Task.CompletedTask;
 
-  public void Dispose()
-    => GC.SuppressFinalize(this);
-
-  public Task<Output> StartTaskProcessing(TaskData          taskData,
-                                          string            token,
-                                          string            dataFolder,
-                                          CancellationToken cancellationToken)
-    => Task.FromResult(Output);
+  public Task<IAgent> Start(string            token,
+                            ILogger           logger,
+                            SessionData       sessionData,
+                            TaskData          taskData,
+                            string            folder,
+                            CancellationToken cancellationToken)
+    => Task.FromResult(agent_);
 }

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -18,9 +18,12 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.CompilerServices;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -28,11 +31,13 @@ using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Services;
+using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
 using ArmoniK.Core.Common.Pollster.TaskProcessingChecker;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Stream.Worker;
 using ArmoniK.Core.Common.Tests.Helpers;
+using ArmoniK.Core.Common.Utils;
 
 using Grpc.Core;
 
@@ -1581,6 +1586,165 @@ public class TaskHandlerTest
     Assert.AreEqual(QueueMessageStatus.Processed,
                     sqmh.Status);
   }
+
+  [Test]
+  public async Task ExecuteErrorTaskAndAbortChildrenShouldSucceed()
+  {
+    var sqmh = new SimpleQueueMessageHandler
+               {
+                 CancellationToken = CancellationToken.None,
+                 Status            = QueueMessageStatus.Waiting,
+                 MessageId = Guid.NewGuid()
+                                 .ToString(),
+               };
+
+    var sh = new SimpleWorkerStreamHandler
+             {
+               Output = new Output(OutputStatus.Error,
+                                   "Error task to validate child tasks are cancelled properly"),
+             };
+    using var testServiceProvider = new TestTaskHandlerProvider(sh,
+                                                                new SimpleAgentHandler(),
+                                                                sqmh);
+
+    var (taskId, _, _, _, sessionId) = await InitProviderRunnableTask(testServiceProvider)
+                                         .ConfigureAwait(false);
+
+
+    var sessionData = await testServiceProvider.SessionTable.GetSessionAsync(sessionId)
+                                               .ConfigureAwait(false);
+    var taskData = await testServiceProvider.TaskTable.ReadTaskAsync(taskId,
+                                                                     CancellationToken.None)
+                                            .ConfigureAwait(false);
+
+    var token = Guid.NewGuid()
+                    .ToString();
+
+    var agent = new Agent(testServiceProvider.GetRequiredService<ISubmitter>(),
+                          testServiceProvider.GetRequiredService<IObjectStorage>(),
+                          testServiceProvider.GetRequiredService<IPushQueueStorage>(),
+                          testServiceProvider.GetRequiredService<IResultTable>(),
+                          testServiceProvider.GetRequiredService<ITaskTable>(),
+                          sessionData,
+                          taskData,
+                          Path.GetTempFileName(),
+                          token,
+                          testServiceProvider.Logger);
+
+    var payloadId = (await agent.CreateResults(token,
+                                               new[]
+                                               {
+                                                 (new ResultCreationRequest(sessionId,
+                                                                            "payload"), new ReadOnlyMemory<byte>(Encoding.UTF8.GetBytes("payload"))),
+                                               },
+                                               CancellationToken.None)
+                                .ConfigureAwait(false)).Single()
+                                                       .ResultId;
+
+    var output = (await agent.CreateResultsMetaData(token,
+                                                    new[]
+                                                    {
+                                                      new ResultCreationRequest(sessionId,
+                                                                                "output"),
+                                                    },
+                                                    CancellationToken.None)
+                             .ConfigureAwait(false)).Single()
+                                                    .ResultId;
+
+    var task = (await agent.SubmitTasks(new List<TaskSubmissionRequest>
+                                        {
+                                          new(payloadId,
+                                              null,
+                                              new List<string>
+                                              {
+                                                output,
+                                              },
+                                              new List<string>()),
+                                        },
+                                        null,
+                                        sessionId,
+                                        token,
+                                        CancellationToken.None)
+                           .ConfigureAwait(false)).Single()
+                                                  .TaskId;
+
+    var agentHandler = new WrapperAgentHandler(agent);
+
+    var taskHandler = new TaskHandler(testServiceProvider.GetRequiredService<ISessionTable>(),
+                                      testServiceProvider.GetRequiredService<ITaskTable>(),
+                                      testServiceProvider.GetRequiredService<IResultTable>(),
+                                      testServiceProvider.GetRequiredService<ISubmitter>(),
+                                      testServiceProvider.GetRequiredService<DataPrefetcher>(),
+                                      sh,
+                                      sqmh,
+                                      testServiceProvider.GetRequiredService<ITaskProcessingChecker>(),
+                                      "ownerpodid",
+                                      "ownerpodname",
+                                      testServiceProvider.GetRequiredService<ActivitySource>(),
+                                      agentHandler,
+                                      testServiceProvider.GetRequiredService<ILogger>(),
+                                      testServiceProvider.GetRequiredService<Injection.Options.Pollster>(),
+                                      () =>
+                                      {
+                                      },
+                                      testServiceProvider.GetRequiredService<ExceptionManager>(),
+                                      testServiceProvider.GetRequiredService<FunctionExecutionMetrics<TaskHandler>>());
+
+    sqmh.TaskId = taskId;
+
+    var acquired = await taskHandler.AcquireTask()
+                                    .ConfigureAwait(false);
+
+    Assert.AreEqual(AcquisitionStatus.Acquired,
+                    acquired);
+
+    await taskHandler.PreProcessing()
+                     .ConfigureAwait(false);
+
+    await taskHandler.ExecuteTask()
+                     .ConfigureAwait(false);
+
+    await taskHandler.PostProcessing()
+                     .ConfigureAwait(false);
+
+    taskData = await testServiceProvider.TaskTable.ReadTaskAsync(taskId,
+                                                                 CancellationToken.None)
+                                        .ConfigureAwait(false);
+
+    Console.WriteLine(taskData);
+
+    Assert.AreEqual(TaskStatus.Error,
+                    taskData.Status);
+    Assert.IsNotNull(taskData.StartDate);
+    Assert.IsNotNull(taskData.EndDate);
+    Assert.IsNotNull(taskData.ProcessingToEndDuration);
+    Assert.IsNotNull(taskData.CreationToEndDuration);
+    Assert.Greater(taskData.CreationToEndDuration,
+                   taskData.ProcessingToEndDuration);
+
+    Assert.AreEqual(QueueMessageStatus.Processed,
+                    sqmh.Status);
+
+    taskData = await testServiceProvider.TaskTable.ReadTaskAsync(task,
+                                                                 CancellationToken.None)
+                                        .ConfigureAwait(false);
+    Console.WriteLine(taskData);
+    Assert.AreEqual(TaskStatus.Cancelled,
+                    taskData.Status);
+
+    var result = await testServiceProvider.ResultTable.GetResult(payloadId)
+                                          .ConfigureAwait(false);
+
+    Assert.AreEqual(ResultStatus.Aborted,
+                    result.Status);
+
+    result = await testServiceProvider.ResultTable.GetResult(output)
+                                      .ConfigureAwait(false);
+
+    Assert.AreEqual(ResultStatus.Aborted,
+                    result.Status);
+  }
+
 
   private class ObjectStorageThrowNotFound : IObjectStorage
   {


### PR DESCRIPTION
# Motivation

When tasks postprocessing is not executed, children tasks and results are not aborted. It lets a lot of tasks and results in Creating, adding lot of noise when debugging and misleading remnants of failed tasks as tasks that could potentially complete.

# Description

Move children (tasks and results) cancellation from Agent.CancelChild to Submitter.CompleteAsync ensuring that children cancellation is called everytime a task is set to Error or Retry. It uses the new CreatedBy field to find all related tasks and results.

# Testing

- Unit test were added to make sure children were properly cancelled when tasks return an Error.
- Validated using integration tests: HtcMock is able to produce exception during task execution, generating retries. All children tasks were cancelled.

# Impact

- Improved debugging
- Clearer end of session

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
