### PR TITLE
refactor: add debug logs around message push into the queue storage

### DIFF
--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -223,6 +223,9 @@ public static class TaskLifeCycleHelper
       return;
     }
 
+    logger.LogDebug("Tasks to finalize : {@TaskRequests}",
+                    taskRequests);
+
     var prepareTaskDependencies = PrepareTaskDependencies(taskTable,
                                                           resultTable,
                                                           taskRequests,
@@ -260,6 +263,7 @@ public static class TaskLifeCycleHelper
                             pushQueueStorage,
                             sessionData,
                             readyTask,
+                            logger,
                             cancellationToken)
       .ConfigureAwait(false);
   }
@@ -447,6 +451,7 @@ public static class TaskLifeCycleHelper
                             pushQueueStorage,
                             sessionData,
                             readyTasks,
+                            logger,
                             cancellationToken)
       .ConfigureAwait(false);
   }
@@ -466,6 +471,7 @@ public static class TaskLifeCycleHelper
                                               IPushQueueStorage        pushQueueStorage,
                                               SessionData              sessionData,
                                               ICollection<MessageData> messages,
+                                              ILogger                  logger,
                                               CancellationToken        cancellationToken)
   {
     if (!messages.Any())
@@ -482,6 +488,9 @@ public static class TaskLifeCycleHelper
                                                  cancellationToken)
                               .ConfigureAwait(false);
       }
+
+      logger.LogDebug("Pushed messages : {@Messages}",
+                      messages);
     }
 
     await taskTable.FinalizeTaskCreation(messages.Select(task => task.TaskId)


### PR DESCRIPTION
# Motivation

Add debug logs to confirm messages inserted into the queue storage.

# Description

Add two logs in TaskLifeCycleHelper:
- messages that are created by a tasks
- messages pushed into the queue

They can be activated by the following env vars:
- `Serilog__MinimumLevel__Override__ArmoniK.Core.Common.Pollster.TaskHandler=Debug`
- `Serilog__MinimumLevel__Override__ArmoniK.Core.Common.gRPC.Services.Submitter=Debug`

# Testing

Logs appear in Seq while deploying locally.

# Impact

In Debug mode for the logger, the log volume will increase due to the addititon of new logs.

# Additional Information

Submitter will need to be removed in order to refactor logger contexts used in TaskLifeCycleHelper so that logs appear either in their context or within the caller context.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
