### PR TITLE
fix: properly fill error in gRPC TaskSummary object

### DIFF
--- a/Common/src/gRPC/Convertors/TaskDataHolderExt.cs
+++ b/Common/src/gRPC/Convertors/TaskDataHolderExt.cs
@@ -136,9 +136,7 @@ public static class TaskDataHolderExt
          StartedAt = taskDataSummary.StartDate is not null
                        ? FromDateTime(taskDataSummary.StartDate.Value)
                        : null,
-         Error = taskDataSummary.Status == TaskStatus.Error
-                   ? taskDataSummary.Output?.Error
-                   : "",
+         Error         = taskDataSummary.Output?.Error ?? string.Empty,
          StatusMessage = taskDataSummary.StatusMessage,
          SubmittedAt = taskDataSummary.SubmittedDate is not null
                          ? FromDateTime(taskDataSummary.SubmittedDate.Value)


### PR DESCRIPTION
# Motivation

Error message was not available in TaskSummary object when task is in Retried Status  while it is available in TaskDetailed.

# Description

Change conversion from TaskDataHolder to gRPC TaskSummary object to fill in the error message when it is available instead of only during errors.

# Testing

GUI shows the error message when it shows TaskSummary objects

# Impact

Debugging informations are easier to access in the GUI.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
