### PR TITLE
fix: catch TaskCanceledException when cancellation token is triggered while writing taskhandler in pollster

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -383,10 +383,15 @@ public class Pollster : IInitializable
                 // So remove the automatic dispose of the TaskHandler
                 taskHandlerDispose.Reset();
               }
-              catch (TimeoutException)
+              catch (Exception e)
               {
                 await taskHandler.ReleaseAndPostponeTask()
                                  .ConfigureAwait(false);
+
+                if (e is not (TimeoutException or OperationCanceledException))
+                {
+                  throw;
+                }
               }
             }
             catch (Exception e)


### PR DESCRIPTION
# Motivation

When agent stops due to exception manager cancellation being triggered, a TaskCanceledException is not catched, produces an error and does not release properly the current dispatched task. When the Dispatched task is reacquired by another agent, it send them into our retry process even tough it should not.

# Description

Catches all exception when writing the TaskHandler into the RunningTaskQueue, release the task and throw if the error is not a TaskCanceledException or TimeoutException.

# Testing

We observe that tasks are properly released after shutdown and that the error does not appear in the logs anymore.

# Impact

Reduce the unneeded retries.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
