### PR TITLE
test: close session at the end of bench test

### DIFF
--- a/Tests/Bench/Client/src/Program.cs
+++ b/Tests/Bench/Client/src/Program.cs
@@ -611,6 +611,13 @@ internal static class Program
 
     var countFinished = Stopwatch.GetTimestamp();
 
+    await channelPool.WithInstanceAsync(channel => new Sessions.SessionsClient(channel).CloseSessionAsync(new CloseSessionRequest
+                                                                                                          {
+                                                                                                            SessionId = createSessionReply.SessionId,
+                                                                                                          }),
+                                        CancellationToken.None)
+                     .ConfigureAwait(false);
+
     var stats = new ExecutionStats
                 {
                   ElapsedTime          = TimeSpan.FromTicks((resultsReceived  - start)            / 100),


### PR DESCRIPTION
# Motivation

Sessions should be closed. Add session closure to Bench integration test.

# Description

Call session close API at the end of the processing in Bench integration tests.

# Testing

Check on the GUI that the session is properly closed.

# Impact

This should provide a clearer monitoring to sessions. A session closed will not process anymore tasks.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
