### PR TITLE
fix: error recovery after retry fail

### DIFF
--- a/Common/src/Pollster/AcquisitionStatus.cs
+++ b/Common/src/Pollster/AcquisitionStatus.cs
@@ -98,6 +98,15 @@ public enum AcquisitionStatus
   /// </summary>
   TaskIsRetriedAndRetryIsSubmitted,
 
+
+  /// <summary>
+  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task is
+  ///   <see cref="TaskStatus.Pending" />
+  ///   Reinsertion in the queue may be required.
+  /// </summary>
+  TaskIsRetriedAndRetryIsPending,
+
+
   /// <summary>
   ///   Task not acquired because its status is <see cref="TaskStatus.Processing" /> but the other pod does not seem to be
   ///   processing it


### PR DESCRIPTION
# Motivation

Follow up of #762. Pending tasks should also be finalized (and inserted into the queue).


# Description

During retry process when a task produces an exception, the retry may fail during insertion into the queue system or setting the task to Submitted. When this happen, the task in retried may stay into the queue and re-acquired. We check if the retried task (the new instance) exists and if it exists whith status Creating or Submitted, we finalize its creation. This PR adds also finalize creation of tasks with status Pending.

# Testing

Unit tests were added to validate were resubmit properly when the new instance of the task in error is Pending.

# Impact

Should fix part of the issue where tasks stay in Pending or Submitted whitout being processed.

# Additional Information

We need to try other queue systems to see if the same issue occur with them.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
