### PR TITLE
ci: pull windows client image in a separate step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -614,6 +614,11 @@ jobs:
         run: just -v tag=$env:VERSION object=local worker=htcmock ingress=false prometheus=false grafana=false seq=false queue=rabbitmq091 deploy
         shell: powershell
 
+      - name: Pull image
+        run: docker pull dockerhubaneo/armonik_core_htcmock_test_client:$env:VERSION
+        timeout-minutes: 10
+        shell: powershell
+
       - name: Run HtcMock test 100 tasks 1 level
         timeout-minutes: 3
         shell: powershell


### PR DESCRIPTION
# Motivation

Separate pull and run of windows image to improve workflows success rate.

# Description

This PR modifies the CI to pull bench windows image before running them to let more time to download the image than the run of it.

# Testing

Windows workflow now succeed.

# Impact

Improve windows workflow success rate.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
