### PR TITLE
fix: allow to resume a running session

### DIFF
--- a/Common/src/Storage/SessionTableExtensions.cs
+++ b/Common/src/Storage/SessionTableExtensions.cs
@@ -233,7 +233,7 @@ public static class SessionTableExtensions
                                                            CancellationToken  cancellationToken = default)
   {
     var session = await sessionTable.UpdateOneSessionAsync(sessionId,
-                                                           data => data.Status == SessionStatus.Paused,
+                                                           data => data.Status == SessionStatus.Paused || data.Status == SessionStatus.Running,
                                                            new UpdateDefinition<SessionData>().Set(model => model.Status,
                                                                                                    SessionStatus.Running),
                                                            false,
@@ -251,8 +251,8 @@ public static class SessionTableExtensions
     switch (session.Status)
     {
       case SessionStatus.Paused:
-        throw new UnreachableException($"Session status should be {SessionStatus.Running} but is {session.Status}");
       case SessionStatus.Running:
+        throw new UnreachableException($"Session status should be {SessionStatus.Running} but is {session.Status}");
       case SessionStatus.Purged:
       case SessionStatus.Cancelled:
         throw new InvalidSessionTransitionException($"Cannot resume a session with status {session.Status}");

--- a/Common/src/gRPC/Services/GrpcSessionsService.cs
+++ b/Common/src/gRPC/Services/GrpcSessionsService.cs
@@ -35,8 +35,6 @@ using Grpc.Core;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Logging;
 
-using TaskStatus = ArmoniK.Core.Common.Storage.TaskStatus;
-
 namespace ArmoniK.Core.Common.gRPC.Services;
 
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
@@ -516,36 +514,28 @@ public class GrpcSessionsService : Sessions.SessionsBase
     catch (SessionNotFoundException e)
     {
       logger_.LogWarning(e,
-                         "Error while getting session");
+                         "Error while resuming session");
       throw new RpcException(new Status(StatusCode.NotFound,
                                         "Session not found"));
     }
     catch (InvalidSessionTransitionException e)
     {
       logger_.LogWarning(e,
-                         "Error while cancelling session");
+                         "Error while resuming session");
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
                                         "Session is in a state that cannot be cancelled"));
     }
     catch (ArmoniKException e)
     {
       logger_.LogWarning(e,
-                         "Error while getting session");
-      await taskTable_.UpdateManyTasks(data => data.SessionId == request.SessionId && data.Status == TaskStatus.Submitted,
-                                       new UpdateDefinition<TaskData>().Set(data => data.Status,
-                                                                            TaskStatus.Paused))
-                      .ConfigureAwait(false);
+                         "Error while resuming session");
       throw new RpcException(new Status(StatusCode.Internal,
                                         "Internal Armonik Exception, see application logs"));
     }
     catch (Exception e)
     {
       logger_.LogWarning(e,
-                         "Error while getting session");
-      await taskTable_.UpdateManyTasks(data => data.SessionId == request.SessionId && data.Status == TaskStatus.Submitted,
-                                       new UpdateDefinition<TaskData>().Set(data => data.Status,
-                                                                            TaskStatus.Paused))
-                      .ConfigureAwait(false);
+                         "Error while resuming session");
       throw new RpcException(new Status(StatusCode.Unknown,
                                         "Unknown Exception, see application logs"));
     }


### PR DESCRIPTION
# Motivation

Allow a running session to be resumed. It also allows to retry Resume RPC when errors occur. Does not put tasks back in Paused status when an error occur.

# Description

- Remove the call to change the task status back to paused when there is an exception.
- Allow session status change to Running when the session is already Running

# Testing

- Tests were performed with the GUI on the ArmoniK infrastructure. It fixes the issue when the Resume RPC times out. The tasks are not put back in Paused.

# Impact

- Resume is working more reliably.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
