### PR TITLE
fix: Resume session should complete task insertion into the queue

### DIFF
--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -535,18 +535,20 @@ public static class TaskLifeCycleHelper
                                                          cancellationToken)
                                           .ConfigureAwait(false))
       {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var taskIds = tasks.Select(task => task.TaskId)
                            .AsICollection();
 
         await taskTable.UpdateManyTasks(data => data.SessionId == sessionId && data.Status == TaskStatus.Paused && taskIds.Contains(data.TaskId),
                                         new UpdateDefinition<TaskData>().Set(data => data.Status,
                                                                              TaskStatus.Submitted),
-                                        cancellationToken)
+                                        CancellationToken.None)
                        .ConfigureAwait(false);
 
         await pushQueueStorage.PushMessagesAsync(tasks,
                                                  grouping.Key.PartitionId,
-                                                 cancellationToken)
+                                                 CancellationToken.None)
                               .ConfigureAwait(false);
       }
     }


### PR DESCRIPTION
# Motivation

Improve the coherence of Running tasks and tasks submitted in the queue after resuming the session.

# Description

When resuming session through our dedicated RPC and the interruption of this RPC, we were cancelling the insertion into the queue. Since, we set the status of the tasks to Running then insert the tasks into the queue, we were getting tasks in the status Running but not in the queue due to cancelling. This PR ensures that when we change the status of a chunk of tasks during resume, we try our best to insert them into the queue.

# Testing

Tests were performed during our benchmark campaign with several millions of tasks. All the tasks that were missing in the queue seems to have been properly inserted.

# Impact

Improve the quality and reliability of the resume session RPC.

# Additional Information

If the control plane is stopped during the submission of the tasks, there are no guarantees that the tasks will be properly inserted into the queue.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
