### PR TITLE
fix: set AWSSDK.Core in MongoDB plugin to fix issue when dynamically loading SQS

### DIFF
--- a/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
+++ b/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
@@ -32,6 +32,7 @@
     </PackageReference>
     <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.36" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj
+++ b/Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj
@@ -14,6 +14,7 @@
     <PackageReference Include="AWSSDK.S3" Version="3.7.405" />
     <!-- AWSSDK.SecurityToken is required to handle the default authentication -->
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.36" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.36" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Adaptors/SQS/src/ArmoniK.Core.Adapters.SQS.csproj
+++ b/Adaptors/SQS/src/ArmoniK.Core.Adapters.SQS.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="AWSSDK.SQS" Version="3.7.400.36" />
     <!-- AWSSDK.SecurityToken is required to handle the default authentication -->
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.36" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.400.36" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.0.1" />
   </ItemGroup>
 

--- a/Common/src/Injection/ServiceCollectionExt.cs
+++ b/Common/src/Injection/ServiceCollectionExt.cs
@@ -104,6 +104,7 @@ public static class ServiceCollectionExt
     }
 
     var assembly = Assembly.LoadFrom(queueSettings.AdapterAbsolutePath);
+
     logger.LogInformation("Loaded assembly {assemblyName}",
                           assembly.FullName);
 

--- a/Common/tests/AdapterLoading/AdapterLoadingTest.cs
+++ b/Common/tests/AdapterLoading/AdapterLoadingTest.cs
@@ -62,6 +62,8 @@ public class AdapterLoadingTest
                                     "ArmoniK.Core.Adapters.Amqp.QueueBuilder").SetArgDisplayNames("Amqp");
       yield return new TestCaseData($"{SolutionRoot}{RabbitPath}",
                                     "ArmoniK.Core.Adapters.RabbitMQ.QueueBuilder").SetArgDisplayNames("RabbitMQ");
+      yield return new TestCaseData($"{SolutionRoot}{SqsPath}",
+                                    "ArmoniK.Core.Adapters.SQS.QueueBuilder").SetArgDisplayNames("SQS");
     }
   }
 
@@ -99,6 +101,9 @@ public class AdapterLoadingTest
                                            },
                                            {
                                              "Amqp:User", "User"
+                                           },
+                                           {
+                                             "SQS:ServiceURL", "http://test:4566"
                                            },
                                          };
 
@@ -187,22 +192,6 @@ public class AdapterLoadingTest
                                         $"{SolutionRoot}{PubSubPath}"
                                       },
                                     }).SetArgDisplayNames("PubSub no credentials");
-
-      yield return new TestCaseData(new MissingMethodException(),
-                                    new Dictionary<string, string?>
-                                    {
-                                      {
-                                        "SQS:ServiceURL", "ServiceURL"
-                                      },
-                                      {
-                                        $"{Components.SettingSection}:{nameof(Components.QueueAdaptorSettings)}:{nameof(Components.QueueAdaptorSettings.ClassName)}",
-                                        "ArmoniK.Core.Adapters.SQS.QueueBuilder"
-                                      },
-                                      {
-                                        $"{Components.SettingSection}:{nameof(Components.QueueAdaptorSettings)}:{nameof(Components.QueueAdaptorSettings.AdapterAbsolutePath)}",
-                                        $"{SolutionRoot}{SqsPath}"
-                                      },
-                                    }).SetArgDisplayNames("SQS misses a method when loading");
     }
   }
 


### PR DESCRIPTION
# Motivation

Fix AWS nugets package dynamic loading. 

# Description

AWSSDK.Core version in S3 and SQS nugets was conflicting with the one in MongoDB nuget dependencies. This PR uses the same version everywhere, fix the issue.

# Testing

Unit tests were added to validate the proper dynamic loading of SQS.

# Impact

It should allow the #782 to work properly.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
