### PR TITLE
test: install libssl1.1 because MongoDB installed by EphemeralMongoDB depends on it

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,11 @@ jobs:
       run: |
           sudo snap install --edge --classic just
 
+    - name: Install libssl1.1 (EphemeralMongo6 v1.1.3 dependency)
+      run: |
+          curl -fsSL https://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb -o /tmp/libssl.dev
+          sudo dpkg -i /tmp/libssl.dev
+
     - name: Minio Server UP
       if: ${{ matrix.projects }} == "Adaptors/S3/tests"
       run: |
@@ -136,6 +141,11 @@ jobs:
     - name: Setup just
       run: |
           sudo snap install --edge --classic just
+
+    - name: Install libssl1.1 (EphemeralMongo6 v1.1.3 dependency)
+      run: |
+          curl -fsSL https://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb -o /tmp/libssl.dev
+          sudo dpkg -i /tmp/libssl.dev
 
     - name: Set up queue
       run: |


### PR DESCRIPTION
# Motivation

Fix unit tests based on EphemeralMongo6.

# Description

EphemeralMongo installs a MongoDB version compiled for unbuntu 18 which depends on libssl1.1 that is not installed anymore on ubuntu-latest (24) GitHub runners. This PR installs libssl1.1 for the tests on these runners.

# Testing

Pipeline now works properly.

# Impact

We will have to remove this dependency when EphemeralMongo updates.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
