### PR TITLE
fix: Ignore failure to connect to the agent when cancelling tasks

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -198,6 +198,11 @@ public sealed class TaskHandler : IAsyncDisposable
     using var activity = activitySource_.StartActivityFromParent(activityContext_,
                                                                  activity_);
 
+    using var _ = logger_.BeginNamedScope("StopCancelledTask",
+                                          ("taskId", messageHandler_.TaskId),
+                                          ("messageHandler", messageHandler_.MessageId),
+                                          ("sessionId", taskData_?.SessionId ?? ""));
+
     if (taskData_?.Status is not null or TaskStatus.Cancelled or TaskStatus.Cancelling)
     {
       taskData_ = await taskTable_.ReadTaskAsync(messageHandler_.TaskId,


### PR DESCRIPTION
# Motivation

Make task cancellation more robust.

# Description

When a task is canceled, the control plane sets the task to cancelling, contacts the agent executing the task to cancel its execution, and then marks the task's results as Aborted. The task will not be retried. Task cancellation is final. The client is then notified that it is no longer necessary to wait for the result in question. The SDK takes over and handles the fact that the result will never be obtained.

During task cancellation, if the control plane is unable to establish a network communication with the agent executing the task, the control plane cannot communicate with the agent and produces an error. Then, the entire second part of the invalid result notification process is not executed.

This PR adds  try catch that ignores errors during communication to the agent. It ensures the resultats are properly aborted and the client is notified.

# Testing

We modified the `OwnerPodId` in the database to an IP that is not available and we observe the client being properly notified of the aborted results.

# Impact

It can hide a misconfigured infrastrure where the control planes cannot communicate to the agents. In this case, running tasks on the agents will not be cancelled and produce undesirable side effects.


# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
