### PR TITLE
docs: typo migration to 0.30 not 0.29

### DIFF
--- a/.docs/content/0.installation/5.version-migration.md
+++ b/.docs/content/0.installation/5.version-migration.md
@@ -1,6 +1,6 @@
 # How to migrate ArmoniK.Core dependencies during upgrade ?
 
-## 0.28.x -> 0.29.x
+## 0.29.x -> 0.30.x
 
 ### Database
 


### PR DESCRIPTION
# Motivation

Fix a small typo in the documentation.

# Description

Doc was writen before the 0.29.0 release was done so it was not accurate. This PR makes the correction.

