### PR TITLE
fix: properly implement IHealthCheckProvider.Check in MongoDB adapter

### DIFF
--- a/Adaptors/MongoDB/src/Common/MongoCollectionProvider.cs
+++ b/Adaptors/MongoDB/src/Common/MongoCollectionProvider.cs
@@ -68,10 +68,10 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
          HealthCheckTag.Startup or HealthCheckTag.Readiness => Task.FromResult(isInitialized_
                                                                                  ? HealthCheckResult.Healthy()
                                                                                  : HealthCheckResult
-                                                                                   .Unhealthy($"Mongo Collection<{nameof(TData)}> not initialized yet.")),
-         HealthCheckTag.Liveness => Task.FromResult(isInitialized_ && mongoCollection_ is null
+                                                                                   .Unhealthy($"Mongo Collection<{typeof(TData)}> not initialized yet.")),
+         HealthCheckTag.Liveness => Task.FromResult(isInitialized_ && mongoCollection_ is not null
                                                       ? HealthCheckResult.Healthy()
-                                                      : HealthCheckResult.Unhealthy($"Mongo Collection<{nameof(TData)}> not initialized yet.")),
+                                                      : HealthCheckResult.Unhealthy($"Mongo Collection<{typeof(TData)}> not initialized yet.")),
          _ => throw new ArgumentOutOfRangeException(nameof(tag),
                                                     tag,
                                                     null),

--- a/Adaptors/MongoDB/src/Common/MongoCollectionProvider.cs
+++ b/Adaptors/MongoDB/src/Common/MongoCollectionProvider.cs
@@ -67,10 +67,11 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
        {
          HealthCheckTag.Startup or HealthCheckTag.Readiness => Task.FromResult(isInitialized_
                                                                                  ? HealthCheckResult.Healthy()
-                                                                                 : HealthCheckResult.Unhealthy("MongoCollection not initialized yet.")),
+                                                                                 : HealthCheckResult
+                                                                                   .Unhealthy($"Mongo Collection<{nameof(TData)}> not initialized yet.")),
          HealthCheckTag.Liveness => Task.FromResult(isInitialized_ && mongoCollection_ is null
                                                       ? HealthCheckResult.Healthy()
-                                                      : HealthCheckResult.Unhealthy("MongoCollection not initialized yet.")),
+                                                      : HealthCheckResult.Unhealthy($"Mongo Collection<{nameof(TData)}> not initialized yet.")),
          _ => throw new ArgumentOutOfRangeException(nameof(tag),
                                                     tag,
                                                     null),

--- a/Adaptors/MongoDB/src/TaskWatcher.cs
+++ b/Adaptors/MongoDB/src/TaskWatcher.cs
@@ -27,6 +27,7 @@ using ArmoniK.Core.Adapters.MongoDB.Table.DataModel;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Storage.Events;
+using ArmoniK.Core.Utils;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
@@ -65,10 +66,18 @@ public class TaskWatcher : ITaskWatcher
   }
 
   /// <inheritdoc />
-  public Task<HealthCheckResult> Check(HealthCheckTag tag)
-    => Task.FromResult(isInitialized_
-                         ? HealthCheckResult.Healthy()
-                         : HealthCheckResult.Unhealthy());
+  public async Task<HealthCheckResult> Check(HealthCheckTag tag)
+  {
+    var result = await HealthCheckResultCombiner.Combine(tag,
+                                                         $"{nameof(TaskWatcher)} is not initialized",
+                                                         sessionProvider_,
+                                                         taskCollectionProvider_)
+                                                .ConfigureAwait(false);
+
+    return isInitialized_ && result.Status == HealthStatus.Healthy
+             ? HealthCheckResult.Healthy()
+             : HealthCheckResult.Unhealthy(result.Description);
+  }
 
   /// <inheritdoc />
   public async Task Init(CancellationToken cancellationToken)

--- a/Common/tests/Pollster/PollsterTest.cs
+++ b/Common/tests/Pollster/PollsterTest.cs
@@ -356,9 +356,8 @@ public class PollsterTest
 
     Console.WriteLine(res.Description);
 
-    Assert.AreEqual(new StringBuilder().AppendLine(desc)
-                                       .ToString(),
-                    healthResult.Description);
+    Assert.AreEqual(desc,
+                    healthResult.Description?.Trim());
     Assert.AreEqual(new AggregateException(ex).Message,
                     healthResult.Exception?.Message);
     Assert.AreEqual(HealthStatus.Unhealthy,

--- a/Utils/src/HealthCheckResultCombiner.cs
+++ b/Utils/src/HealthCheckResultCombiner.cs
@@ -1,0 +1,89 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Utils;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ArmoniK.Core.Utils;
+
+/// <summary>
+///   Helper class to combine the results of multiple <inheritdoc cref="IHealthCheckProvider.Check" />
+/// </summary>
+public static class HealthCheckResultCombiner
+{
+  /// <summary>
+  ///   Combine the results of multiple <inheritdoc cref="IHealthCheckProvider.Check" /> for a given tag and description
+  /// </summary>
+  /// <param name="tag">The tag on which to combine the results</param>
+  /// <param name="desc">The description to add to the results</param>
+  /// <param name="providers">The sources from which to get the results</param>
+  /// <returns>
+  ///   The combined result
+  /// </returns>
+  public static async Task<HealthCheckResult> Combine(HealthCheckTag                tag,
+                                                      string                        desc,
+                                                      params IHealthCheckProvider[] providers)
+  {
+    var exceptions  = new List<Exception>();
+    var data        = new Dictionary<string, object>();
+    var description = new StringBuilder(desc);
+    var worstStatus = HealthStatus.Healthy;
+
+    foreach (var healthCheckResult in await providers.Select(p => p.Check(tag))
+                                                     .WhenAll()
+                                                     .ConfigureAwait(false))
+    {
+      if (healthCheckResult.Status == HealthStatus.Healthy)
+      {
+        continue;
+      }
+
+      if (healthCheckResult.Exception is not null)
+      {
+        exceptions.Add(healthCheckResult.Exception);
+      }
+
+      foreach (var (key, value) in healthCheckResult.Data)
+      {
+        data[key] = value;
+      }
+
+      if (healthCheckResult.Description is not null)
+      {
+        description.AppendLine(healthCheckResult.Description);
+      }
+
+      worstStatus = worstStatus < healthCheckResult.Status
+                      ? worstStatus
+                      : healthCheckResult.Status;
+    }
+
+    return new HealthCheckResult(worstStatus,
+                                 description.ToString(),
+                                 new AggregateException(exceptions),
+                                 data);
+  }
+}

--- a/Utils/src/HealthCheckResultCombiner.cs
+++ b/Utils/src/HealthCheckResultCombiner.cs
@@ -49,8 +49,9 @@ public static class HealthCheckResultCombiner
   {
     var exceptions  = new List<Exception>();
     var data        = new Dictionary<string, object>();
-    var description = new StringBuilder(desc);
+    var description = new StringBuilder();
     var worstStatus = HealthStatus.Healthy;
+    description.AppendLine(desc);
 
     foreach (var healthCheckResult in await providers.Select(p => p.Check(tag))
                                                      .WhenAll()


### PR DESCRIPTION
# Motivation

Give more meaningful information when healthcheck fails due to issues with checks on the mongodb tables.

# Description

- Put a meaningful description in HealthCheckResult.Unhealthy() from the Mongo Adapter
- Reimplement Mongo Adapter Checks to call for the check from their dependencies, thus knowing what went wrong.

# Testing

- Unit tests and CI tests perform with sucess (locally too).
- Calling HeathChecksService should succeed. The following command can be used.

```bash
docker run --net armonik_network fullstorydev/grpcurl -plaintext armonik.control.submitter:1080 armonik.api.grpc.v1.health_checks.HealthChecksService.
CheckHealth
``` 

Output should look like:

```json
{
  "services": [
    {
      "name": "database",
      "healthy": "HEALTH_STATUS_ENUM_HEALTHY"
    },
    {
      "name": "object",
      "healthy": "HEALTH_STATUS_ENUM_HEALTHY"
    },
    {
      "name": "queue",
      "healthy": "HEALTH_STATUS_ENUM_HEALTHY"
    }
  ]
}
```

# Impact

- Easier to debug when there is an issue.


# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
