### PR TITLE
fix: unprocessed tasks when pod crashs

### DIFF
--- a/Common/src/Pollster/AcquisitionStatus.cs
+++ b/Common/src/Pollster/AcquisitionStatus.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -177,4 +177,9 @@ public enum AcquisitionStatus
   ///   Task is missing dependencies but happens to be in the queue
   /// </summary>
   TaskIsPending,
+
+  /// <summary>
+  ///   Task is submitted but execution is no possible
+  /// </summary>
+  TaskSubmittedWithNoPossibleExecution,
 }

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -678,6 +678,12 @@ public sealed class TaskHandler : IAsyncDisposable
                                        .ConfigureAwait(false);
             return AcquisitionStatus.AcquisitionFailedTaskCancelling;
           }
+        }
+
+        if (taskData_.Status is TaskStatus.Submitted)
+        {
+          messageHandler_.Status = QueueMessageStatus.Processed;
+          return AcquisitionStatus.TaskSubmittedWithNoPossibleExecution;
         }
 
         // if the task is running elsewhere, then the message is duplicated so we remove it from the queue

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2025. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -542,7 +542,15 @@ public static class TaskLifeCycleHelper
                            .AsICollection();
 
         await taskTable.UpdateManyTasks(data => data.SessionId == sessionId && data.Status == TaskStatus.Paused && taskIds.Contains(data.TaskId),
-                                        new UpdateDefinition<TaskData>().Set(data => data.Status,
+                                        new UpdateDefinition<TaskData>().Set(data => data.OwnerPodId,
+                                                                             "")
+                                                                        .Set(data => data.OwnerPodName,
+                                                                             "")
+                                                                        .Set(data => data.ReceptionDate,
+                                                                             null)
+                                                                        .Set(data => data.AcquisitionDate,
+                                                                             null)
+                                                                        .Set(data => data.Status,
                                                                              TaskStatus.Submitted),
                                         CancellationToken.None)
                        .ConfigureAwait(false);


### PR DESCRIPTION
# Motivation

Process tasks correctly even though a pod crash while processing them.

# Description

There is a case where tasks whose pod owner crashs are not re-processed. It happens whenever the releaseTask method called by the shutdown pod takes effect on the database while the tasks was gotten by another pod.

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
