### PR TITLE
fix: reset taskData information when session is resumed and task in resubmitted

### DIFF
--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -542,7 +542,15 @@ public static class TaskLifeCycleHelper
                            .AsICollection();
 
         await taskTable.UpdateManyTasks(data => data.SessionId == sessionId && data.Status == TaskStatus.Paused && taskIds.Contains(data.TaskId),
-                                        new UpdateDefinition<TaskData>().Set(data => data.Status,
+                                        new UpdateDefinition<TaskData>().Set(data => data.OwnerPodId,
+                                                                             "")
+                                                                        .Set(data => data.OwnerPodName,
+                                                                             "")
+                                                                        .Set(data => data.ReceptionDate,
+                                                                             null)
+                                                                        .Set(data => data.AcquisitionDate,
+                                                                             null)
+                                                                        .Set(data => data.Status,
                                                                              TaskStatus.Submitted),
                                         CancellationToken.None)
                        .ConfigureAwait(false);


### PR DESCRIPTION
# Motivation

Reset task data information whenever a session is resumed and the task will be enqueued. 

# Description

This bugs happens whenever a task is not correctly released by a worker and the session is paused before the task is resubmitted. This makes the ownerPodId not to be reseted and the task will never be processed.

# Testing

An unit test was added.

# Impact

It solves a bug.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
