### PR TITLE
fix: task had status processing on another pod who crashed, but it was released during acquirement

### DIFF
--- a/Common/src/Pollster/AcquisitionStatus.cs
+++ b/Common/src/Pollster/AcquisitionStatus.cs
@@ -179,7 +179,12 @@ public enum AcquisitionStatus
   TaskIsPending,
 
   /// <summary>
-  ///   Task is submitted but execution is not possible
+  ///   Task has status 'submitted' but it had the status 'dispatched' during the start of acquirement
   /// </summary>
-  TaskSubmittedWithNoPossibleExecution,
+  TaskSubmittedButPreviouslyDispatched,
+
+  /// <summary>
+  ///   Task has status 'submitted' but it had the status 'processing' during the start of acquirement
+  /// </summary>
+  TaskSubmittedButPreviouslyProcessing,
 }

--- a/Common/src/Pollster/AcquisitionStatus.cs
+++ b/Common/src/Pollster/AcquisitionStatus.cs
@@ -179,12 +179,16 @@ public enum AcquisitionStatus
   TaskIsPending,
 
   /// <summary>
-  ///   Task has status 'submitted' but it had the status 'dispatched' during the start of acquirement
+  ///   Task is received with status  <see cref="TaskStatus.Dispatched" /> but its status is
+  ///   <see cref="TaskStatus.Submitted" />
+  ///   after failing to check the agent that should be running the task initially
   /// </summary>
   TaskSubmittedButPreviouslyDispatched,
 
   /// <summary>
-  ///   Task has status 'submitted' but it had the status 'processing' during the start of acquirement
+  ///   Task is received with status  <see cref="TaskStatus.Processing" /> but its status is
+  ///   <see cref="TaskStatus.Submitted" />
+  ///   after failing to check the agent that should be running the task initially
   /// </summary>
   TaskSubmittedButPreviouslyProcessing,
 }

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -416,8 +416,9 @@ public sealed class TaskHandler : IAsyncDisposable
 
               if (taskData_.Status is TaskStatus.Submitted)
               {
-                logger_.LogInformation("Task {task} was being processed on another pod, but has been released during acquirement",
-                                       taskData_.TaskId);
+                logger_.LogInformation("Task {task} with status: {status} was being processed on another pod, but has been released during acquirement",
+                                       taskData_.TaskId,
+                                       taskData_.Status);
                 messageHandler_.Status = QueueMessageStatus.Postponed;
                 // TODO: AcquistionStatus must be tested
                 return AcquisitionStatus.TaskSubmittedButPreviouslyProcessing;
@@ -637,6 +638,9 @@ public sealed class TaskHandler : IAsyncDisposable
 
           if (taskData_.Status is TaskStatus.Submitted)
           {
+            logger_.LogInformation("Task {task} with status {status} was dispatched on another pod who crashed, but has been released during acquirement",
+                                   taskData_.TaskId,
+                                   taskData_.Status);
             messageHandler_.Status = QueueMessageStatus.Postponed;
             // TODO: AcquistionStatus TaskSubmittedButPreviouslyDispatched must be tested
             return AcquisitionStatus.TaskSubmittedButPreviouslyDispatched;


### PR DESCRIPTION
# Motivation

Cover the case where the task had status processing on another pod who crashed, but it was released during acquirement

# Description

When a task is acquired it might be a task from a pod that crashed who was in the status processing. During this acquisition it is possible that the task status will change as the pod releases the task. This scenario is not being treated by the actual code.

# Testing

The test was made on test environment with stress tests (each test with 3 million tasks)

# Impact

No impact, it only fixes a bug.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
