### PR TITLE
fix: add missing extension to re-integrate pipeline logs in seq

### DIFF
--- a/tools/logs2seq.py
+++ b/tools/logs2seq.py
@@ -141,7 +141,7 @@ def main():
     s3 = boto3.client('s3')
     s3.download_file(args.bucket_name, obj_name, file_name)
 
-    if file_name.endswith(".json.tar.gz"):
+    if file_name.endswith(".json.tar.gz") or file_name.endswith(".json.gz"):
         process_jsongz_log(args.url, file_name)
     elif file_name.endswith(".json"):
         process_json_log(args.url, file_name)


### PR DESCRIPTION
# Motivation

Script re-inserting logs from the pipeline into seq broke when pipeline was rewritten to support windows. The file extension changed.

# Description

Add `.json.gz` extension for input files in `log2seq` script.

# Testing

```
python tools/logs2seq.py $BUCKET core-pipeline 5008 1 htcmock-sqs-redis-Information-tcp.json.gz
```

now works properly.

# Impact

- Facilitate investigation when there are issues in the pipeline.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
