### PR TITLE
fix: add validation for certificate name mismatch in TLS validation

### DIFF
--- a/Adaptors/MongoDB/src/ServiceCollectionExt.cs
+++ b/Adaptors/MongoDB/src/ServiceCollectionExt.cs
@@ -172,6 +172,7 @@ public static class ServiceCollectionExt
     if (!string.IsNullOrEmpty(mongoOptions.CAFile))
     {
       var validationCallback = CreateCallback(mongoOptions.CAFile,
+                                              mongoOptions.AllowInsecureTls,
                                               logger);
 
       settings.SslSettings = new SslSettings

--- a/Adaptors/Redis/src/ObjectBuilder.cs
+++ b/Adaptors/Redis/src/ObjectBuilder.cs
@@ -78,6 +78,7 @@ public class ObjectBuilder : IDependencyInjectionBuildable
     if (redisOptions.Ssl && !string.IsNullOrEmpty(redisOptions.CaPath))
     {
       validationCallback = CertificateValidator.CreateCallback(redisOptions.CaPath,
+                                                               redisOptions.AllowHostMismatch,
                                                                logger);
     }
 

--- a/Adaptors/Redis/src/Options/Redis.cs
+++ b/Adaptors/Redis/src/Options/Redis.cs
@@ -22,17 +22,18 @@ namespace ArmoniK.Core.Adapters.Redis.Options;
 public class Redis
 {
   public const string   SettingSection = nameof(Redis);
-  public       string   InstanceName    { get; set; } = "";
-  public       string   EndpointUrl     { get; set; } = "";
-  public       string   ClientName      { get; set; } = "";
-  public       string   SslHost         { get; set; } = "";
-  public       int      Timeout         { get; set; }
-  public       string   Password        { get; set; } = "";
-  public       string   User            { get; set; } = "";
-  public       bool     Ssl             { get; set; }
-  public       string   CredentialsPath { get; set; } = "";
-  public       string   CaPath          { get; set; } = "";
-  public       int      MaxRetry        { get; set; } = 5;
-  public       int      MsAfterRetry    { get; set; } = 500;
-  public       TimeSpan TtlTimeSpan     { set; get; } = TimeSpan.MaxValue;
+  public       string   InstanceName      { get; set; } = "";
+  public       string   EndpointUrl       { get; set; } = "";
+  public       string   ClientName        { get; set; } = "";
+  public       string   SslHost           { get; set; } = "";
+  public       int      Timeout           { get; set; }
+  public       string   Password          { get; set; } = "";
+  public       string   User              { get; set; } = "";
+  public       bool     Ssl               { get; set; }
+  public       string   CredentialsPath   { get; set; } = "";
+  public       string   CaPath            { get; set; } = "";
+  public       int      MaxRetry          { get; set; } = 5;
+  public       int      MsAfterRetry      { get; set; } = 500;
+  public       TimeSpan TtlTimeSpan       { set; get; } = TimeSpan.MaxValue;
+  public       bool     AllowHostMismatch { get; set; }
 }


### PR DESCRIPTION
# Motivation

We added a check for **RemoteCertificateNameMismatch** to further secure our TLS validation and avoid potential mismatches between the certificate name and the domain in use. We also introduced a boolean **allowHostMismatch** that lets users choose between strict domain name matching or allowing a mismatch between the certificate and the domain.

# Description

We updated the SSL validation logic to handle RemoteCertificateNameMismatch conditionally.

   - When allowHostMismatch is false, we reject certificates that present a mismatched domain name.
   - When allowHostMismatch is true, we tolerate this error and remove it from the list of SSL policy errors.

# Testing

- Verified that certificates with mismatched names are rejected if allowHostMismatch = false.
- Ensured mismatched certificates are allowed if allowHostMismatch = true.

# Impact

- Allows flexible TLS configuration based on different environment needs.

# Additional Information

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
