### PR TITLE
fix: acquire throttle

### DIFF
--- a/Common/src/Injection/Options/Pollster.cs
+++ b/Common/src/Injection/Options/Pollster.cs
@@ -52,6 +52,13 @@ public class Pollster
   public TimeSpan TimeoutBeforeNextAcquisition { get; set; } = TimeSpan.FromSeconds(10);
 
   /// <summary>
+  ///   Number of acquisitions to try during the processing of a previous task.
+  ///   If the processing task is still running after that many acquisitions,
+  ///   the Agent will stop acquiring tasks until the processing task has finished.
+  /// </summary>
+  public int NbAcquisitionRetry { get; set; } = 3;
+
+  /// <summary>
   ///   Shared folder between Agent and Worker
   /// </summary>
   public string SharedCacheFolder { get; set; } = "/cache/shared";


### PR DESCRIPTION
# Motivation

When a long task is running, the pollster will acquire tasks that will timeout again and again until the long running task finishes.
We could stop trying to acquire new tasks upon the first acquire timeout, until the end of the current running task.

# Description

When a task acquire time out, we just wait for the next pipeline stage to be ready to accept new tasks.

# Testing

New tests have been added to the RendezvousChannel for the WaitForReader and WaitForWriter methods.

# Impact

This will greatly reduce the number of acquire done when tasks are much longer than the acquire timeout, which should lead to lighter database usage and reduce the probability of pod stopping while acquiring a new task.

There should be no impact when task duration is shorter than the acquire timeout.

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
