### PR TITLE
fix: Remove OpaqueID upon Result deletion

### DIFF
--- a/Common/src/Storage/ResultTableExtensions.cs
+++ b/Common/src/Storage/ResultTableExtensions.cs
@@ -261,7 +261,9 @@ public static class ResultTableExtensions
                                          CancellationToken cancellationToken = default)
     => await resultTable.UpdateOneResult(resultId,
                                          new UpdateDefinition<Result>().Set(result => result.Status,
-                                                                            ResultStatus.DeletedData),
+                                                                            ResultStatus.DeletedData)
+                                                                       .Set(result => result.OpaqueId,
+                                                                            Array.Empty<byte>()),
                                          cancellationToken)
                         .ConfigureAwait(false);
 }

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 
 using ArmoniK.Api.Common.Utils;
@@ -228,15 +229,26 @@ public class GrpcResultsService : Results.ResultsBase
     using var measure = meter_.CountAndTime();
     try
     {
-      var opaqueIds = await resultTable_.GetResults(result => request.ResultId.Contains(result.ResultId),
-                                                    result => result.OpaqueId,
-                                                    context.CancellationToken)
-                                        .ToListAsync(context.CancellationToken)
-                                        .ConfigureAwait(false);
+      await foreach (var ids in resultTable_.GetResults(result => request.ResultId.Contains(result.ResultId),
+                                                        result => result.OpaqueId,
+                                                        context.CancellationToken)
+                                            .ToChunksAsync(500,
+                                                           Timeout.InfiniteTimeSpan,
+                                                           context.CancellationToken)
+                                            .ConfigureAwait(false))
+      {
+        await objectStorage_.TryDeleteAsync(ids,
+                                            context.CancellationToken)
+                            .ConfigureAwait(false);
+      }
 
-      await objectStorage_.TryDeleteAsync(opaqueIds,
-                                          context.CancellationToken)
-                          .ConfigureAwait(false);
+      await resultTable_.UpdateManyResults(result => request.ResultId.Contains(result.ResultId),
+                                           new UpdateDefinition<Result>().Set(result => result.Status,
+                                                                              ResultStatus.DeletedData)
+                                                                         .Set(result => result.OpaqueId,
+                                                                              Array.Empty<byte>()),
+                                           context.CancellationToken)
+                        .ConfigureAwait(false);
 
       return new DeleteResultsDataResponse
              {


### PR DESCRIPTION
# Motivation

When a result is deleted from object storage, its OpaqueID should also be deleted from the database. This is especially useful for plugins that stores the result content inside the OpaqueID, like the embedded plugin.

It has already been done in some places, but there are a few missing places.

# Description

Remove the OpaqueID in the MarkAsDeleted method.

# Testing

No regression

# Impact

When using the Embedded object storage plugin with large payload, this enable the memory freeing within the database that we expect when we delete a result.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
