### PR TITLE
feat: Options to disable exactlyOnceDelivery

### DIFF
--- a/Adaptors/PubSub/src/PubSub.cs
+++ b/Adaptors/PubSub/src/PubSub.cs
@@ -59,4 +59,14 @@ internal class PubSub
   ///   Name of the KMS key used to protect messages
   /// </summary>
   public string KmsKeyName { get; set; } = string.Empty;
+
+  /// <summary>
+  ///   Option to force the ordering of messages (queue property)
+  /// </summary>
+  public bool MessageOrdering { get; set; } = false;
+
+  /// <summary>
+  ///   Guarantee that messages are not duplicated at Pub/Sub level
+  /// </summary>
+  public bool ExactlyOnceDelivery { get; set; } = false;
 }

--- a/Adaptors/PubSub/src/PullQueueStorage.cs
+++ b/Adaptors/PubSub/src/PullQueueStorage.cs
@@ -37,7 +37,9 @@ internal class PullQueueStorage : IPullQueueStorage
 {
   private readonly int    ackDeadlinePeriod_;
   private readonly int    ackExtendDeadlineStep_;
+  private readonly bool   exactlyOnceDelivery_;
   private readonly string kmsKeyName_;
+  private readonly bool   messageOrdering_;
 
   private readonly TimeSpan                   messageRetention_;
   private readonly PublisherServiceApiClient  publisher_;
@@ -56,7 +58,9 @@ internal class PullQueueStorage : IPullQueueStorage
     messageRetention_      = options.MessageRetention;
     ackDeadlinePeriod_     = options.AckDeadlinePeriod;
     ackExtendDeadlineStep_ = options.AckExtendDeadlineStep;
+    exactlyOnceDelivery_   = options.ExactlyOnceDelivery;
     kmsKeyName_            = options.KmsKeyName;
+    messageOrdering_       = options.MessageOrdering;
     subscriber_            = subscriber;
     publisher_             = publisher;
     topicName_ = TopicName.FromProjectTopic(options.ProjectId,
@@ -116,7 +120,8 @@ internal class PullQueueStorage : IPullQueueStorage
                                 {
                                   SubscriptionName          = subscriptionName_,
                                   TopicAsTopicName          = topicName_,
-                                  EnableExactlyOnceDelivery = true,
+                                  EnableExactlyOnceDelivery = exactlyOnceDelivery_,
+                                  EnableMessageOrdering     = messageOrdering_,
                                   AckDeadlineSeconds        = ackDeadlinePeriod_,
                                 };
       try


### PR DESCRIPTION
# Motivation

Pub/Sub has a feature to guarantee that messages are delivered exactly once (no duplication). This feature was enabled by the ArmoniK plugin, but it appears the impact is very high on the throughput of the queue, and is not necessary for the scheduling correctness because ArmoniK is already able to deduplicate messages while acquiring tasks from the queue.

# Description

This PR exposes 2 options ExactlyOnceDelivery and MessageOrdering when the plugin creates the subscriptions. Those options are disabled by default.

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
