### PR TITLE
fix: Relaxed constraint on list page size

### DIFF
--- a/Common/src/gRPC/Validators/ListApplicationsRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListApplicationsRequestValidator.cs
@@ -37,7 +37,7 @@ public class ListApplicationsRequestValidator : AbstractValidator<ListApplicatio
       .WithName($"{nameof(ListApplicationsRequest)}.{nameof(ListApplicationsRequest.Page)}");
     RuleFor(request => request.PageSize)
       .NotNull()
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(0)
       .WithName($"{nameof(ListApplicationsRequest)}.{nameof(ListApplicationsRequest.PageSize)}");
     RuleFor(request => request.Filters)
       .NotNull()

--- a/Common/src/gRPC/Validators/ListPartitionsRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListPartitionsRequestValidator.cs
@@ -37,7 +37,7 @@ public class ListPartitionsRequestValidator : AbstractValidator<ListPartitionsRe
       .WithName($"{nameof(ListPartitionsRequest)}.{nameof(ListPartitionsRequest.Page)}");
     RuleFor(request => request.PageSize)
       .NotNull()
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(0)
       .WithName($"{nameof(ListPartitionsRequest)}.{nameof(ListPartitionsRequest.PageSize)}");
     RuleFor(request => request.Filters)
       .NotNull()

--- a/Common/src/gRPC/Validators/ListResultsRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListResultsRequestValidator.cs
@@ -37,7 +37,7 @@ public class ListResultsRequestValidator : AbstractValidator<ListResultsRequest>
       .WithName($"{nameof(ListResultsRequest)}.{nameof(ListResultsRequest.Page)}");
     RuleFor(request => request.PageSize)
       .NotNull()
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(0)
       .WithName($"{nameof(ListResultsRequest)}.{nameof(ListResultsRequest.PageSize)}");
     RuleFor(request => request.Filters)
       .NotNull()

--- a/Common/src/gRPC/Validators/ListSessionsRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListSessionsRequestValidator.cs
@@ -37,7 +37,7 @@ public class ListSessionsRequestValidator : AbstractValidator<ListSessionsReques
       .WithName($"{nameof(ListSessionsRequest)}.{nameof(ListSessionsRequest.Page)}");
     RuleFor(request => request.PageSize)
       .NotNull()
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(0)
       .WithName($"{nameof(ListSessionsRequest)}.{nameof(ListSessionsRequest.PageSize)}");
     RuleFor(request => request.Filters)
       .NotNull()

--- a/Common/src/gRPC/Validators/ListTasksRequestValidator.cs
+++ b/Common/src/gRPC/Validators/ListTasksRequestValidator.cs
@@ -37,7 +37,7 @@ public class ListTasksRequestValidator : AbstractValidator<ListTasksRequest>
       .WithName($"{nameof(ListTasksRequest)}.{nameof(ListTasksRequest.Page)}");
     RuleFor(request => request.PageSize)
       .NotNull()
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(0)
       .WithName($"{nameof(ListTasksRequest)}.{nameof(ListTasksRequest.PageSize)}");
     RuleFor(request => request.Filters)
       .NotNull()

--- a/Common/tests/Validators/ListApplicationsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListApplicationsRequestValidatorTest.cs
@@ -148,10 +148,10 @@ public class ListApplicationsRequestValidatorTest
   }
 
   [Test]
-  public void ListApplicationsRequestZeroPageSizeShouldFail()
+  public void ListApplicationsRequestZeroPageSizeShouldBeValid()
   {
     validListApplicationsRequest_!.PageSize = 0;
-    Assert.IsFalse(validator_.Validate(validListApplicationsRequest_)
-                             .IsValid);
+    Assert.IsTrue(validator_.Validate(validListApplicationsRequest_)
+                            .IsValid);
   }
 }

--- a/Common/tests/Validators/ListPartitionsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListPartitionsRequestValidatorTest.cs
@@ -142,10 +142,10 @@ public class ListPartitionsRequestValidatorTest
   }
 
   [Test]
-  public void ListPartitionsRequestZeroPageSizeShouldFail()
+  public void ListPartitionsRequestZeroPageSizeShouldBeValid()
   {
     validListPartitionsRequest_!.PageSize = 0;
-    Assert.IsFalse(validator_.Validate(validListPartitionsRequest_)
-                             .IsValid);
+    Assert.IsTrue(validator_.Validate(validListPartitionsRequest_)
+                            .IsValid);
   }
 }

--- a/Common/tests/Validators/ListResultsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListResultsRequestValidatorTest.cs
@@ -142,10 +142,10 @@ public class ListResultsRequestValidatorTest
   }
 
   [Test]
-  public void ListResultsRequestZeroPageSizeShouldFail()
+  public void ListResultsRequestZeroPageSizeShouldBeValid()
   {
     validListResultsRequest_!.PageSize = 0;
-    Assert.IsFalse(validator_.Validate(validListResultsRequest_)
-                             .IsValid);
+    Assert.IsTrue(validator_.Validate(validListResultsRequest_)
+                            .IsValid);
   }
 }

--- a/Common/tests/Validators/ListSessionsRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListSessionsRequestValidatorTest.cs
@@ -142,10 +142,10 @@ public class ListSessionsRequestValidatorTest
   }
 
   [Test]
-  public void ListSessionsRequestZeroPageSizeShouldFail()
+  public void ListSessionsRequestZeroPageSizeShouldBeValid()
   {
     validListSessionsRequest_!.PageSize = 0;
-    Assert.IsFalse(validator_.Validate(validListSessionsRequest_)
-                             .IsValid);
+    Assert.IsTrue(validator_.Validate(validListSessionsRequest_)
+                            .IsValid);
   }
 }

--- a/Common/tests/Validators/ListTasksRequestValidatorTest.cs
+++ b/Common/tests/Validators/ListTasksRequestValidatorTest.cs
@@ -142,10 +142,10 @@ public class ListTasksRequestValidatorTest
   }
 
   [Test]
-  public void ListTasksRequestZeroPageSizeShouldFail()
+  public void ListTasksRequestZeroPageSizeShouldBeValid()
   {
     validListTasksRequest_!.PageSize = 0;
-    Assert.IsFalse(validator_.Validate(validListTasksRequest_)
-                             .IsValid);
+    Assert.IsTrue(validator_.Validate(validListTasksRequest_)
+                            .IsValid);
   }
 }


### PR DESCRIPTION
# Motivation

It can be useful to have the count of tasks or results matching a given filter without getting those tasks or results.
Interface-wise, it make sense to ask a page-size of 0 to get only the the count.
Fix for https://github.com/aneoconsulting/ArmoniK.Api/issues/585

# Description

Lift the constraint on page size in the message validation.

# Impact

There is no impact as the change is entirely retro-compatible. All requests that were valid before are still valid, and requests with a pagesize of zero are now valid.

# Additional Information

The actual database implementation already supports a pagesize of 0 internally (ex: https://github.com/aneoconsulting/ArmoniK.Core/blob/main/Adaptors/MongoDB/src/TaskTable.cs#L209).

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
