### PR TITLE
test: Add Retry option for MultipleWatchShouldSucceed unit test that crashes on pipeline

### DIFF
--- a/Common/tests/WatchToGrpcTests.cs
+++ b/Common/tests/WatchToGrpcTests.cs
@@ -78,6 +78,7 @@ public class WatchToGrpcTests
   [Test]
   [TestCase(3)]
   [TestCase(6)]
+  [Retry(3)]
   public async Task MultipleWatchShouldSucceed(int nTries)
   {
     var cts      = new CancellationTokenSource(TimeSpan.FromSeconds(3));


### PR DESCRIPTION
# Motivation

Make unit tests more robust on the pipeline.

# Description

Use Nunit `Retry` feature on tests that are not stable enough and where several attempt should be made in the pipieline for them to succeed.

Should solve some of the issues from #544.

# Testing

- Tests seem more stable on the pipeline

# Impact

- Less need to retry our pipelines

# Additional Information

- We may need to increase the number of retries to be sure it works most of the time.
- https://docs.nunit.org/articles/nunit/writing-tests/attributes/retry.html

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
