### PR TITLE
fix: limit parallelism in ResultsService.CreateResults

### DIFF
--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -44,4 +44,9 @@ public class Submitter
   ///   default: false
   /// </summary>
   public bool DeletePayload { get; set; } = false;
+
+  /// <summary>
+  ///   Parallelism used in the control plane when possible. Defaults to the number of threads.
+  /// </summary>
+  public int DegreeOfParallelism { get; set; } = 0;
 }

--- a/Common/tests/GrpcTasksServiceTests.cs
+++ b/Common/tests/GrpcTasksServiceTests.cs
@@ -50,6 +50,7 @@ public class GrpcTasksServiceTests
     => helper_ = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
                                                                   .AddSingleton<IPushQueueStorage, SimplePushQueueStorage>()
                                                                   .AddSingleton<MeterHolder>()
+                                                                  .AddSingleton<Injection.Options.Submitter>()
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()


### PR DESCRIPTION
# Motivation

We encounter a lot of MongoWaitQueueFullException when we call this method with many clients and a high degree of parallelism with our Bench integration test.

# Description

- Use parallel select to insert data into the object storage instead of doing all the insertions at the same time.
- Batch result completion query in databse instead of executing a query for each result at the same time. It was a call to the result completion here that was raising the MongoWaitQueueFullException.

# Testing

- Unit tests are passing.
- This implementation was tested with the workload that was producing the issue. The issue did not appear.

# Impact

- Allow larger scale tests where a large amount of tasks and data are submitted in parallel.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
