### PR TITLE
fix: Reduce log verbosity in certificate validation

### DIFF
--- a/Utils/src/ServerCertificateValidator.cs
+++ b/Utils/src/ServerCertificateValidator.cs
@@ -34,6 +34,7 @@ public static class CertificateValidator
   /// </summary>
   /// <param name="logger">The logger to use for logging validation details.</param>
   /// <param name="authority">The root certificate authority to trust during validation.</param>
+  /// <param name="allowHostMismatch">Ignore HostMismatch error</param>
   /// <returns>
   ///   A <see cref="RemoteCertificateValidationCallback" /> delegate that performs SSL/TLS certificate validation.
   /// </returns>
@@ -64,13 +65,7 @@ public static class CertificateValidator
 
            // We allow host mismatch, so we remove the error
            sslPolicyErrors &= ~SslPolicyErrors.RemoteCertificateNameMismatch;
-           logger.LogInformation("Allowing RemoteCertificateNameMismatch since allowHostMismatch=true");
-         }
-
-         // If there is any error other than untrusted root or partial chain, fail the validation
-         if ((sslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0)
-         {
-           logger.LogWarning("Ignoring SSL validation error: RemoteCertificateChainErrors");
+           logger.LogDebug("Allowing RemoteCertificateNameMismatch since allowHostMismatch=true");
          }
 
          // If there is any errors other than the chain errors and the mismatch, fail the validation
@@ -103,7 +98,7 @@ public static class CertificateValidator
          var isTrusted = chain.ChainElements.Any(x => x.Certificate.Thumbprint == authority.Thumbprint);
          if (isTrusted)
          {
-           logger.LogInformation("SSL validation succeeded: certificate is trusted");
+           logger.LogDebug("SSL validation succeeded: certificate is trusted");
          }
          else
          {


### PR DESCRIPTION
# Motivation

SSL validation would generate info and warning logs on every validation even in case of success.

# Description

Remove useless log, and make success logs as Debug instead of Information

# Impact

No functional impact. Success validation are now visible only on Debug log level.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
