### PR TITLE
feat: add waitTimeSeconds as attribute in SQS adapter

### DIFF
--- a/Adaptors/SQS/src/PullQueueStorage.cs
+++ b/Adaptors/SQS/src/PullQueueStorage.cs
@@ -43,6 +43,7 @@ internal class PullQueueStorage : IPullQueueStorage
 
   private readonly string                     queueName_;
   private readonly Dictionary<string, string> tags_;
+  private readonly int                        waitTimeSeconds_;
   private          bool                       isInitialized_;
   private          string?                    queueUrl_;
 
@@ -57,6 +58,7 @@ internal class PullQueueStorage : IPullQueueStorage
 
     ackDeadlinePeriod_     = options.AckDeadlinePeriod;
     ackExtendDeadlineStep_ = options.AckExtendDeadlineStep;
+    waitTimeSeconds_       = options.WaitTimeSeconds;
   }
 
   public async IAsyncEnumerable<IQueueMessageHandler> PullMessagesAsync(int                                        nbMessages,
@@ -72,6 +74,7 @@ internal class PullQueueStorage : IPullQueueStorage
                                                        QueueUrl            = queueUrl_!,
                                                        MaxNumberOfMessages = nbMessages,
                                                        VisibilityTimeout   = ackDeadlinePeriod_,
+                                                       WaitTimeSeconds     = waitTimeSeconds_,
                                                      },
                                                      cancellationToken)
                                 .ConfigureAwait(false);

--- a/Adaptors/SQS/src/SQS.cs
+++ b/Adaptors/SQS/src/SQS.cs
@@ -54,4 +54,10 @@ internal class SQS
   ///   Time  in seconds between two modifications of acknowledgment deadline
   /// </summary>
   public int AckExtendDeadlineStep { get; set; } = 60;
+
+  /// <summary>
+  ///   SQS long polling wait time in seconds (1-20).
+  ///   Set to 0 in order to disable long polling.
+  /// </summary>
+  public int WaitTimeSeconds { get; set; } = 20;
 }


### PR DESCRIPTION
# Motivation

Add the attribute waitTimeSeconds to activate the long polling mode instead of short polling one.

# Description

Declare waitTimeSeconds as an attribute in the Amazon SQS configuration and add it in the constructor of ReceiveMessage request in order to use long polling mode.

# Testing

The SQS polling method should be long in the configuration.

# Impact

SQS polling mode will be long instead of short. 
https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html#sqs-long-polling 

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
