### PR TITLE
build: toggle off SBOM during image build because windows build fails

### DIFF
--- a/justfile
+++ b/justfile
@@ -277,7 +277,7 @@ build imageTag dockerFile target="":
   fi
   push_parameter=""
   if [ "{{push}}" == "true" ]; then
-    push_parameter="--push --provenance true --sbom true"
+    push_parameter="--push --provenance true"
   fi
   load_parameter=""
   if [ "{{load}}" == "true" ]; then


### PR DESCRIPTION
# Motivation

Image build does not work anymore due to missing informations to create SBOM for windows images.

# Description

Deactivate SBOM during docker image building.

# Testing

Images are built successfully now.

# Impact

Removing SBOM will make docker scout detect it is missing and will be less acurate.

# Additional Information

This PR should be reverted as we use SBOM for vulnerabilities detection.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
