### PR TITLE
refactor: add environment variable to select mongo binary and factorize some uses of Ephemeral Mongo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,10 +65,13 @@ jobs:
       run: |
           sudo snap install --edge --classic just
 
-    - name: Install libssl1.1 (EphemeralMongo6 v1.1.3 dependency)
+    - name: Install mongodb
       run: |
-          curl -fsSL https://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb -o /tmp/libssl.dev
-          sudo dpkg -i /tmp/libssl.dev
+          sudo apt-get install gnupg curl
+          curl -fsSL https://www.mongodb.org/static/pgp/server-8.0.asc | sudo gpg -o /usr/share/keyrings/mongodb-server-8.0.gpg --dearmor
+          echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb-server-8.0.gpg ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-8.0.list
+          sudo apt-get update
+          sudo apt-get install -y mongodb-org
 
     - name: Minio Server UP
       if: ${{ matrix.projects }} == "Adaptors/S3/tests"
@@ -88,7 +91,7 @@ jobs:
 
     - name: Run tests
       run: |
-          MONITOR_PREFIX="monitor/test/" MONITOR_CD=${{ matrix.projects }} tools/monitor.sh \
+          EphemeralMongo__BinaryDirectory=/usr/bin MONITOR_PREFIX="monitor/test/" MONITOR_CD=${{ matrix.projects }} tools/monitor.sh \
             dotnet test --logger "trx;LogFileName=test-results.trx" -p:RunAnalyzers=false -p:WarningLevel=0
 
     - name: Test Report
@@ -141,11 +144,6 @@ jobs:
     - name: Setup just
       run: |
           sudo snap install --edge --classic just
-
-    - name: Install libssl1.1 (EphemeralMongo6 v1.1.3 dependency)
-      run: |
-          curl -fsSL https://security.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.23_amd64.deb -o /tmp/libssl.dev
-          sudo dpkg -i /tmp/libssl.dev
 
     - name: Set up queue
       run: |

--- a/Adaptors/MongoDB/tests/IndexTest.cs
+++ b/Adaptors/MongoDB/tests/IndexTest.cs
@@ -16,19 +16,12 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 using ArmoniK.Core.Adapters.MongoDB.Table.DataModel;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Storage;
 
-using EphemeralMongo;
-
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
 
 using MongoDB.Driver;
 
@@ -42,61 +35,16 @@ internal class IndexTest
   [SetUp]
   public void StartUp()
   {
-    var logger = NullLogger.Instance;
-    var options = new MongoRunnerOptions
-                  {
-                    UseSingleNodeReplicaSet = false,
-#pragma warning disable CA2254 // log inputs should be constant
-                    StandardOuputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger = line => logger.LogError(line),
-#pragma warning restore CA2254
-                  };
-
-    runner_ = MongoRunner.Run(options);
-    client_ = new MongoClient(runner_.ConnectionString);
-
-    // Minimal set of configurations to operate on a toy DB
-    Dictionary<string, string?> minimalConfig = new()
-                                                {
-                                                  {
-                                                    "Components:TableStorage", "ArmoniK.Adapters.MongoDB.TableStorage"
-                                                  },
-                                                  {
-                                                    $"{Options.MongoDB.SettingSection}:{nameof(Options.MongoDB.DatabaseName)}", DatabaseName
-                                                  },
-                                                  {
-                                                    $"{Options.MongoDB.SettingSection}:{nameof(Options.MongoDB.TableStorage)}:PollingDelay", "00:00:10"
-                                                  },
-                                                };
-
-    var configuration = new ConfigurationManager();
-    configuration.AddInMemoryCollection(minimalConfig);
-
-    var services = new ServiceCollection();
-    services.AddMongoStorages(configuration,
-                              logger);
-    services.AddSingleton(ActivitySource);
-    services.AddTransient(_ => client_);
-    services.AddLogging();
-
-    provider_ = services.BuildServiceProvider(new ServiceProviderOptions
-                                              {
-                                                ValidateOnBuild = true,
-                                              });
+    dbProvider_ = new MongoDatabaseProvider();
+    provider_   = dbProvider_.GetServiceProvider();
   }
 
   [TearDown]
   public void TearDown()
-  {
-    client_ = null;
-    runner_?.Dispose();
-  }
+    => dbProvider_?.Dispose();
 
-  private                 IMongoRunner?    runner_;
-  private                 IMongoClient?    client_;
-  private const           string           DatabaseName   = "ArmoniK_TestDB";
-  private static readonly ActivitySource   ActivitySource = new("ArmoniK.Core.Adapters.MongoDB.Tests");
-  private                 ServiceProvider? provider_;
+  private IServiceProvider?      provider_;
+  private MongoDatabaseProvider? dbProvider_;
 
   [Test]
   public void IndexCreationShouldSucceed()

--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -67,6 +67,12 @@ internal class MongoDatabaseProvider : IDisposable
                     ReplicaSetSetupTimeout = TimeSpan.FromSeconds(30),
                   };
 
+    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
+    if (!string.IsNullOrEmpty(binDir))
+    {
+      options.BinaryDirectory = binDir;
+    }
+
     runner_ = MongoRunner.Run(options);
     var settings = MongoClientSettings.FromUrl(new MongoUrl(runner_.ConnectionString));
 

--- a/Common/tests/Helpers/TestDatabaseProvider.cs
+++ b/Common/tests/Helpers/TestDatabaseProvider.cs
@@ -28,6 +28,7 @@ using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Injection;
 using ArmoniK.Core.Common.Storage;
+using ArmoniK.Core.Utils;
 
 using EphemeralMongo;
 
@@ -70,6 +71,12 @@ public class TestDatabaseProvider : IDisposable
                     StandardErrorLogger = line => logger.LogError(line),
 #pragma warning restore CA2254
                   };
+
+    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
+    if (!string.IsNullOrEmpty(binDir))
+    {
+      options.BinaryDirectory = binDir;
+    }
 
     var loggerProvider = new ConsoleForwardingLoggerProvider();
     var loggerDb       = loggerProvider.CreateLogger("db commands");
@@ -139,6 +146,8 @@ public class TestDatabaseProvider : IDisposable
            .Configure<AuthenticatorOptions>(o => o.CopyFrom(AuthenticatorOptions.DefaultNoAuth))
            .AddLogging()
            .AddSingleton<IObjectStorage, ObjectStorage>()
+           .AddOption<Injection.Options.Submitter>(builder.Configuration,
+                                                   Injection.Options.Submitter.SettingSection)
            .AddSingleton(loggerProvider.CreateLogger("root"))
            .AddSingleton(ActivitySource)
            .AddSingleton(_ => client_);

--- a/Common/tests/Helpers/TestPollingAgentProvider.cs
+++ b/Common/tests/Helpers/TestPollingAgentProvider.cs
@@ -69,6 +69,12 @@ public class TestPollingAgentProvider : IDisposable
 #pragma warning restore CA2254
                   };
 
+    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
+    if (!string.IsNullOrEmpty(binDir))
+    {
+      options.BinaryDirectory = binDir;
+    }
+
     runner_ = MongoRunner.Run(options);
     IMongoClient client = new MongoClient(runner_.ConnectionString);
 

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -93,6 +93,12 @@ public class TestPollsterProvider : IDisposable
 #pragma warning restore CA2254
                   };
 
+    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
+    if (!string.IsNullOrEmpty(binDir))
+    {
+      options.BinaryDirectory = binDir;
+    }
+
     runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -90,6 +90,12 @@ public class TestTaskHandlerProvider : IDisposable
 #pragma warning restore CA2254
                   };
 
+    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
+    if (!string.IsNullOrEmpty(binDir))
+    {
+      options.BinaryDirectory = binDir;
+    }
+
     runner_ = MongoRunner.Run(options);
     client_ = new MongoClient(runner_.ConnectionString);
 


### PR DESCRIPTION
# Motivation

Remove the dependency to libssl1.1 and factorize some duplicated code.

# Description

- Install mongoDB locally and add an environment variable to configure EphemeralMongo to use the locally installed binaries. As those binaries are more recent, they do not need libssl1.1.
- Factorize code by using existing helpers to setup Ephemeral mongo instances

# Testing

Unit tests pass locally.

# Impact

- Simplify code
- No more dependency to libssl1.1

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
