### PR TITLE
chore(config): Support for MongoDB connectionString

### DIFF
--- a/Adaptors/MongoDB/src/Options/MongoDB.cs
+++ b/Adaptors/MongoDB/src/Options/MongoDB.cs
@@ -46,6 +46,8 @@ public class MongoDB
 
   public string User { get; set; } = "";
 
+  public string ConnectionString { get; set; } = "";
+
   public string Password { get; set; } = "";
 
   public int MaxRetries { get; set; } = 5;

--- a/terraform/modules/storage/database/mongo/outputs.tf
+++ b/terraform/modules/storage/database/mongo/outputs.tf
@@ -1,15 +1,22 @@
+locals {
+  query_parameters = compact([
+    var.mongodb_params.use_direct_connection ? "directConnection=true" : null,
+    can(coalesce(var.mongodb_params.replica_set_name)) ? "replicaSet=${var.mongodb_params.replica_set_name}" : null,
+    "tls=true",
+    "tlsInsecure=true",
+  ])
+
+  query_suffix = length(local.query_parameters) > 0 ? "?${join("&", local.query_parameters)}" : ""
+
+  connection_string = "mongodb://${docker_container.database.name}:${var.mongodb_params.exposed_port}/${docker_container.database.name}${local.query_suffix}"
+}
+
 output "generated_env_vars" {
   value = {
     "Components__TableStorage"               = "ArmoniK.Adapters.MongoDB.TableStorage"
-    "MongoDB__Host"                          = docker_container.database.name
-    "MongoDB__Port"                          = "${var.mongodb_params.exposed_port}"
-    "MongoDB__DatabaseName"                  = docker_container.database.name
-    "MongoDB__MaxConnectionPoolSize"         = "${var.mongodb_params.max_connection_pool_size}"
+    "MongoDB__ConnectionString"              = local.connection_string
     "MongoDB__TableStorage__PollingDelayMin" = "${var.mongodb_params.min_polling_delay}"
     "MongoDB__TableStorage__PollingDelayMax" = "${var.mongodb_params.max_polling_delay}"
-    "MongoDB__DirectConnection"              = "${var.mongodb_params.use_direct_connection}"
-    "MongoDB__ReplicaSet"                    = "${var.mongodb_params.replica_set_name}"
-    "MongoDB__Tls"                           = "true"
     "MongoDB__AllowInsecureTls"              = "true"
     "MongoDB__CAFile"                        = "/mongo-certificate/ca.pem"
     "MongoDB__ServerSelectionTimeout"        = "00:00:20"


### PR DESCRIPTION
# Motivation

MongoDB connection string can be very complex with many options. Currently, not all features are supported, and it seems unreasonable to add ad-hoc options to Core to implement them.

# Description

Add a MongoDB__ConnectionString option that is parsed directly by MongoDB library.
If the connection string is used, previous options used for URL building are ignored.

# Test

The new MongoDB configuration has been tested in pipeline with both the old options and the new option, and works as expected.

# Impact

It is entirely retro-compatible as the previous method a connection is used when the connection is empty.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
