### PR TITLE
refactor: streamline SSL certificate validation callback assignment

### DIFF
--- a/Adaptors/Amqp/src/ConnectionAmqp.cs
+++ b/Adaptors/Amqp/src/ConnectionAmqp.cs
@@ -16,7 +16,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Net.Security;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -105,12 +104,11 @@ public class ConnectionAmqp : IConnectionAmqp
     var connectionFactory = new ConnectionFactory();
     if (options.Scheme.Equals("AMQPS"))
     {
-      RemoteCertificateValidationCallback? validationCallback = null;
       if (options.Ssl && !string.IsNullOrEmpty(options.CaPath))
       {
-        validationCallback = CertificateValidator.CreateCallback(options.CaPath,
-                                                                 options.AllowInsecureTls,
-                                                                 logger);
+        connectionFactory.SSL.RemoteCertificateValidationCallback = CertificateValidator.CreateCallback(options.CaPath,
+                                                                                                        options.AllowInsecureTls,
+                                                                                                        logger);
       }
       else if (!options.Ssl)
       {
@@ -121,8 +119,6 @@ public class ConnectionAmqp : IConnectionAmqp
       {
         logger.LogError("No CA path provided for ActiveMQ");
       }
-
-      connectionFactory.SSL.RemoteCertificateValidationCallback = validationCallback;
     }
     else
     {


### PR DESCRIPTION
# Motivation

Reassign the certificate validation callback, in order to not assign a default remoteCertificateValidationCallback to our validation callback.

# Description

If only ssl options are true and there is a certificate, then we can assign a new value to our remoteCertificateValidationCallback. Otherwise, its default value isn't changed.

# Testing

Tested locally

# Impact

None

# Additional Information

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
