### PR TITLE
ci: fail build if xml-doc is not present on public methods

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -227,7 +227,7 @@ jobs:
         submodules: true
 
     - name: Build the solution
-      run: dotnet build ArmoniK.Core.sln -c Release
+      run: dotnet build ArmoniK.Core.sln -c Release -warnAsError:"CS1570;CS1571;CS1572;CS1573;CS1587;CS1591"
 
   publish-nuget:
     runs-on: ubuntu-latest
@@ -258,7 +258,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - versionning
-      - buildProjects
     env:
       VERSION: ${{ needs.versionning.outputs.version }}
     strategy:

--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -8,6 +8,7 @@
     <Copyright>Copyright (C) ANEO, 2021-2021</Copyright>
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
# Motivation

Force documentation writing by failing project build when documentation is missing.

# Description

- Enable documentation build in ArmoniK.Core.Common project to check documentation availability
- Add `-warnAsError` flag to convert missing documentation warnings into errors.

# Testing

Build did not work when documentation was missing. A lot of PRs were added to add missing doc in the meantime.

# Impact

- Improve projet quality and facilitate proof reading.

