### PR TITLE
ci: use readthedocs apt_packages to install dotnet instead of downloading installer manually

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,14 +9,12 @@ build:
   os: ubuntu-24.04
   tools:
     python: "3.13"
+  apt_packages:
+    - dotnet-sdk-8.0
+    - dotnet8
   jobs:
-    post_install:
-      - curl -OfsSL https://dot.net/v1/dotnet-install.sh
-      - chmod +x dotnet-install.sh
-      - ./dotnet-install.sh
     pre_build:
-      - DOTNET_ROOT="$HOME/.dotnet" PATH="$PATH":"$DOTNET_ROOT":"$DOTNET_ROOT/tools" env
-      - DOTNET_ROOT="$HOME/.dotnet" PATH="$PATH":"$DOTNET_ROOT":"$DOTNET_ROOT/tools" tools/generate-csharp-doc.sh
+      - PATH="$PATH":"$HOME/.dotnet/tools" tools/generate-csharp-doc.sh
 
 # Move anchors out of the titles
 # Build documentation in the ".docs/" directory with Sphinx

--- a/tools/generate-csharp-doc.sh
+++ b/tools/generate-csharp-doc.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-dotnet tool update -g docfx
+set -e
+
+dotnet tool install -g docfx
 dotnet build
 docfx docfx.json
 sed -E -i 's/([#]+) <a id="([^"]+)"><\/a> (.+)/<a id="\2"><\/a>\n\1 \3/g' .docs/content/csharp/*.md


### PR DESCRIPTION
# Motivation

Reduce the failure rate of documentation builds.

# Description

Install dotnet with apt-get through readthedocs `apt_packages`  instead of using curl to download dotnet installer and execute it to install dotnet.  Curl step was failing a lot.

# Testing

Documentation is building properly.

# Impact

Decrease the burden of having a "green" pipeline.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
