### PR TITLE
docs: use inheritdoc to access API doc in gRPC services

### DIFF
--- a/Common/src/gRPC/Services/GrpcAgentService.cs
+++ b/Common/src/gRPC/Services/GrpcAgentService.cs
@@ -40,9 +40,7 @@ using Agent = ArmoniK.Api.gRPC.V1.Agent.Agent;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   Represents the gRPC service for interacting with the agent.
-/// </summary>
+/// <inheritdoc cref="Api.gRPC.V1.Agent.Agent" />
 [IgnoreAuthentication]
 public class GrpcAgentService : Agent.AgentBase
 {

--- a/Common/src/gRPC/Services/GrpcApplicationsService.cs
+++ b/Common/src/gRPC/Services/GrpcApplicationsService.cs
@@ -35,9 +35,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   Provides gRPC services for managing applications.
-/// </summary>
+/// <inheritdoc cref="Applications" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcApplicationsService : Applications.ApplicationsBase
 {

--- a/Common/src/gRPC/Services/GrpcAuthService.cs
+++ b/Common/src/gRPC/Services/GrpcAuthService.cs
@@ -33,9 +33,7 @@ using Microsoft.Extensions.Options;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   The gRPC service that provides methods for user authentication and authorization.
-/// </summary>
+/// <inheritdoc cref="Authentication" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcAuthService : Authentication.AuthenticationBase
 {

--- a/Common/src/gRPC/Services/GrpcEventsService.cs
+++ b/Common/src/gRPC/Services/GrpcEventsService.cs
@@ -32,9 +32,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   The gRPC service implementation for subscribing to events in the ArmoniK system.
-/// </summary>
+/// <inheritdoc cref="Events" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcEventsService : Events.EventsBase
 {

--- a/Common/src/gRPC/Services/GrpcHealthChecksService.cs
+++ b/Common/src/gRPC/Services/GrpcHealthChecksService.cs
@@ -34,9 +34,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   gRPC service for performing health checks.
-/// </summary>
+/// <inheritdoc cref="HealthChecksService" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcHealthChecksService : HealthChecksService.HealthChecksServiceBase
 {

--- a/Common/src/gRPC/Services/GrpcPartitionsService.cs
+++ b/Common/src/gRPC/Services/GrpcPartitionsService.cs
@@ -33,9 +33,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   The gRPC service implementation for managing partitions in the ArmoniK system.
-/// </summary>
+/// <inheritdoc cref="Partitions" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcPartitionsService : Partitions.PartitionsBase
 {

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -48,9 +48,7 @@ using ResultStatus = ArmoniK.Core.Common.Storage.ResultStatus;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   The gRPC service implementation for managing results in the ArmoniK system.
-/// </summary>
+/// <inheritdoc cref="Results" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcResultsService : Results.ResultsBase
 {

--- a/Common/src/gRPC/Services/GrpcSessionsService.cs
+++ b/Common/src/gRPC/Services/GrpcSessionsService.cs
@@ -38,9 +38,7 @@ using Microsoft.Extensions.Logging;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   Provides gRPC services for managing sessions in the ArmoniK system.
-/// </summary>
+/// <inheritdoc cref="Sessions" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcSessionsService : Sessions.SessionsBase
 {

--- a/Common/src/gRPC/Services/GrpcSubmitterService.cs
+++ b/Common/src/gRPC/Services/GrpcSubmitterService.cs
@@ -38,9 +38,7 @@ using Output = ArmoniK.Api.gRPC.V1.Output;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   Represents the old and deprecated gRPC service for handling task submission-related operations in the ArmoniK system.
-/// </summary>
+/// <inheritdoc cref="Api.gRPC.V1.Submitter.Submitter" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBase
 {

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -45,9 +45,7 @@ using TaskOptions = ArmoniK.Core.Base.DataStructures.TaskOptions;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   Provides gRPC services for managing tasks in the ArmoniK system.
-/// </summary>
+/// <inheritdoc cref="Task" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcTasksService : Task.TasksBase
 {

--- a/Common/src/gRPC/Services/GrpcVersionsService.cs
+++ b/Common/src/gRPC/Services/GrpcVersionsService.cs
@@ -28,9 +28,7 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace ArmoniK.Core.Common.gRPC.Services;
 
-/// <summary>
-///   Service to provide version information for the API and Core components.
-/// </summary>
+/// <inheritdoc cref="Versions" />
 [Authorize(AuthenticationSchemes = Authenticator.SchemeName)]
 public class GrpcVersionsService : Versions.VersionsBase
 {


### PR DESCRIPTION
# Motivation

Link to API documentation for gRPC services class using `inheritdoc` xml tag.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
