### PR TITLE
ci: increase timeouts for mongo deployment on windows

### DIFF
--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -45,13 +45,13 @@ resource "docker_container" "database" {
   }
 }
 resource "time_sleep" "wait" {
-  create_duration = var.mongodb_params.windows ? "30s" : "0s"
+  create_duration = var.mongodb_params.windows ? "40s" : "0s"
   depends_on      = [docker_container.database]
 }
 locals {
   linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://127.0.0.1:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
   // mongosh is not installed in windows docker images so we need it to be installed locally
-  windows_run       = "mongosh.exe mongodb://127.0.0.1:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name} --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
+  windows_run       = "mongosh.exe mongodb://127.0.0.1:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name}?serverSelectionTimeoutMS=10000 --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
   prefix_run        = var.mongodb_params.windows ? local.windows_run : local.linux_run
   mongo_init_repset = <<EOT
 rs.initiate({


### PR DESCRIPTION
# Motivation

Improve pipeline reliability by tuning MongoDB deployment on Windows thus losing less time rerunning them.

# Description

- Increase wait time for MongoDB deployment because there is no health check (mongosh is not available in the Windows container) from 30s to 40s.
- Increase serverSelectionTimeoutMS from the 2s default to 10s. Server selection was not working likely because MongoDB was not deployed. This allows more time to deploy MongoDB on Windows in the pipeline.

# Testing

- Windows job in the pipeline was re-run around 20 times without issues.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
