### PR TITLE
fix: stoppedHeartCts_ from SQS should not be set to null here

### DIFF
--- a/Adaptors/SQS/src/Heart.cs
+++ b/Adaptors/SQS/src/Heart.cs
@@ -57,7 +57,6 @@ public class Heart
   public async Task Stop()
   {
     stoppedHeartCts_?.Cancel();
-    stoppedHeartCts_ = null;
     try
     {
       if (runningTask_ != null)


### PR DESCRIPTION
# Motivation

Resolve issues where we encounter NullReferenceException when CancellationTokenSource is null during Message Dispose in SQS.

# Description

- `stoppedHeartCts_` was set too early to null and was done at the right place later on. We remove the bugged set.

# Testing

- Pipeline and local tests are working properly.

# Impact

- Less errors
- May improve SQS performances because some messages were not properly acknowledged

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
