### PR TITLE
fix: race condition between submit task and upload result

### DIFF
--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -103,6 +103,9 @@ public class ResultTable : IResultTable
       return;
     }
 
+    Logger.LogDebug("Add task dependencies: {@Dependencies}",
+                    dependencies);
+
     var dependencyRequests = dependencies.Select(dependency => new UpdateManyModel<Result>(Builders<Result>.Filter.Where(result => dependency.Key == result.ResultId),
                                                                                            Builders<Result>.Update.AddToSetEach(result => result.DependentTasks,
                                                                                                                                 dependency.Value)));

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -380,6 +380,10 @@ public class TaskTable : ITaskTable
       update = update.Unset(data => data.RemainingDataDependencies[key]);
     }
 
+    Logger.LogDebug("Remove data dependencies {@ResultIds} for tasks {@TaskIds}",
+                    dependenciesToRemove,
+                    taskIds);
+
     await taskCollection.UpdateManyAsync(data => taskIds.Contains(data.TaskId),
                                          update,
                                          cancellationToken: cancellationToken)

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -294,6 +294,9 @@ public static class TaskLifeCycleHelper
                                                                               ILogger                          logger,
                                                                               CancellationToken                cancellationToken)
   {
+    using var scope = logger.BeginScope("Prepare task dependencies for {@TaskIds}",
+                                        taskRequests.ViewSelect(req => req.TaskId));
+
     var allDependencies       = new HashSet<string>();
     var completedDependencies = new List<string>();
 
@@ -303,6 +306,9 @@ public static class TaskLifeCycleHelper
       allDependencies.UnionWith(request.DataDependencies);
       allDependencies.Add(request.PayloadId);
     }
+
+    logger.LogDebug("Check Result status for results {@ResultIds}",
+                    allDependencies);
 
     // Get the dependencies that are already completed to avoid tracking already completed results
     await foreach (var resultId in resultTable.GetResults(result => allDependencies.Contains(result.ResultId) && result.Status == ResultStatus.Completed,
@@ -412,6 +418,9 @@ public static class TaskLifeCycleHelper
                                                ILogger             logger,
                                                CancellationToken   cancellationToken = default)
   {
+    using var activity = logger.BeginScope("Resolving dependencies for {@ResultIds}",
+                                           results);
+
     logger.LogDebug("Submit tasks which new data are available");
 
     // Get all tasks that depend on the results that were completed by the given results (removing duplicates)
@@ -427,11 +436,8 @@ public static class TaskLifeCycleHelper
       return;
     }
 
-    if (logger.IsEnabled(LogLevel.Debug))
-    {
-      logger.LogDebug("Dependent Tasks Dictionary {@dependents}",
-                      dependentTasks);
-    }
+    logger.LogDebug("Dependent Tasks Dictionary {@dependents}",
+                    dependentTasks);
 
     // Remove all results that were completed by the current task from their dependents.
     // This will try to remove more results than strictly necessary.
@@ -452,6 +458,10 @@ public static class TaskLifeCycleHelper
                                                     cancellationToken)
                                     .ToListAsync(cancellationToken)
                                     .ConfigureAwait(false);
+
+    logger.LogDebug("Check tasks status for tasks {@TaskIds}, found {@ReadyTasks}",
+                    dependentTasks,
+                    readyTasks);
 
     await EnqueueReadyTasks(taskTable,
                             pushQueueStorage,

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -450,8 +450,9 @@ public static class TaskLifeCycleHelper
     // Find all tasks whose dependencies are now complete in order to start them.
     // Multiple agents can see the same task as ready and will try to start it multiple times.
     // This is benign as it will be handled during dequeue with message deduplication.
-    var readyTasks = await taskTable.FindTasksAsync(data => dependentTasks.Contains(data.TaskId) && data.Status == TaskStatus.Pending &&
-                                                            data.RemainingDataDependencies                      == new Dictionary<string, bool>(),
+    var readyTasks = await taskTable.FindTasksAsync(data => dependentTasks.Contains(data.TaskId)                                      &&
+                                                            (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
+                                                            data.RemainingDataDependencies == new Dictionary<string, bool>(),
                                                     data => new MessageData(data.TaskId,
                                                                             data.SessionId,
                                                                             data.Options),

--- a/Common/src/Storage/TaskTableExtensions.cs
+++ b/Common/src/Storage/TaskTableExtensions.cs
@@ -322,7 +322,7 @@ public static class TaskTableExtensions
                                 ? TaskStatus.Paused
                                 : TaskStatus.Submitted);
 
-    var res = await taskTable.UpdateManyTasks(tdm => taskIds.Contains(tdm.TaskId) && tdm.Status == TaskStatus.Pending,
+    var res = await taskTable.UpdateManyTasks(tdm => taskIds.Contains(tdm.TaskId) && (tdm.Status == TaskStatus.Creating || tdm.Status == TaskStatus.Pending),
                                               new UpdateDefinition<TaskData>().Set(tdm => tdm.Status,
                                                                                    paused
                                                                                      ? TaskStatus.Paused

--- a/Common/src/Storage/TaskTableExtensions.cs
+++ b/Common/src/Storage/TaskTableExtensions.cs
@@ -316,6 +316,12 @@ public static class TaskTableExtensions
                                                       bool                paused            = false,
                                                       CancellationToken   cancellationToken = default)
   {
+    taskTable.Logger.LogDebug("Mark tasks {@TaskIds} as {Status}",
+                              taskIds,
+                              paused
+                                ? TaskStatus.Paused
+                                : TaskStatus.Submitted);
+
     var res = await taskTable.UpdateManyTasks(tdm => taskIds.Contains(tdm.TaskId) && tdm.Status == TaskStatus.Pending,
                                               new UpdateDefinition<TaskData>().Set(tdm => tdm.Status,
                                                                                    paused


### PR DESCRIPTION
# Motivation

There is a race condition between the task submission and the result upload, where result completion would enqueue a task only if the task was already in pending state, but in some cases, task submission did not change the state to pending yet.

# Description

Adjust the check to include the creating state. Add logs during dependency resolution to help the debugging.

# Testing

The Extension C# stress test failed without this fix, but is now passing.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
