### PR TITLE
fix: Support empty list of completed result within a task

### DIFF
--- a/Common/src/Pollster/Agent.cs
+++ b/Common/src/Pollster/Agent.cs
@@ -143,7 +143,7 @@ public sealed class Agent : IAgent
     var resultsToComplete = await StoreDataAsync(cancellationToken)
                               .ConfigureAwait(false);
 
-    await resultTable_.CompleteManyResults(resultsToComplete.Select(pair => (pair.Key, pair.Value.size, pair.Value.id)),
+    await resultTable_.CompleteManyResults(resultsToComplete.ViewSelect(pair => (pair.Key, pair.Value.size, pair.Value.id)),
                                            cancellationToken)
                       .ConfigureAwait(false);
 

--- a/Common/src/Storage/ResultTableExtensions.cs
+++ b/Common/src/Storage/ResultTableExtensions.cs
@@ -154,9 +154,14 @@ public static class ResultTableExtensions
   /// </returns>
   /// <exception cref="ResultNotFoundException">when result to update is not found</exception>
   public static async Task CompleteManyResults(this IResultTable                                          resultTable,
-                                               IEnumerable<(string resultId, long size, byte[] opaqueId)> results,
+                                               ICollection<(string resultId, long size, byte[] opaqueId)> results,
                                                CancellationToken                                          cancellationToken = default)
   {
+    if (results.Count == 0)
+    {
+      return;
+    }
+
     var now = DateTime.UtcNow;
     await resultTable.BulkUpdateResults(results.Select(r => (r.resultId, new UpdateDefinition<Result>().Set(result => result.Status,
                                                                                                             ResultStatus.Completed)

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -231,7 +231,7 @@ public class GrpcResultsService : Results.ResultsBase
                               context.CancellationToken)
                       .ConfigureAwait(false);
 
-    await resultTable_.CompleteManyResults(results.Select(tuple => (tuple.Item1.ResultId, tuple.Item1.Size, tuple.id)),
+    await resultTable_.CompleteManyResults(results.ViewSelect(tuple => (tuple.Item1.ResultId, tuple.Item1.Size, tuple.id)),
                                            context.CancellationToken)
                       .ConfigureAwait(false);
 
@@ -539,7 +539,7 @@ public class GrpcResultsService : Results.ResultsBase
                                         $"Imported results should be in {ResultStatus.Created} status, invalid results {invalidResults}"));
     }
 
-    await resultTable_.CompleteManyResults(requests.Select(tuple => (tuple.Key, dict[tuple.Value]!.Value, tuple.Value)),
+    await resultTable_.CompleteManyResults(requests.ViewSelect(tuple => (tuple.Key, dict[tuple.Value]!.Value, tuple.Value)),
                                            context.CancellationToken)
                       .ConfigureAwait(false);
 


### PR DESCRIPTION
# Motivation

If a task ends without completing any result, the task fails within the MongoDB driver.

# Description

Add a check to avoid calling MongoDB in case the list is empty.

# Impact

This enables to have tasks without results, and tasks creating sub-tasks where sub-task inputs are already created outside the current task.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
