### PR TITLE
refactor: simplify and clarify logic for retrying tasks during Agent cancellation

### DIFF
--- a/Common/src/Exceptions/WorkerDownException.cs
+++ b/Common/src/Exceptions/WorkerDownException.cs
@@ -17,37 +17,40 @@
 
 using System;
 
-namespace ArmoniK.Core.Base.Exceptions;
+using ArmoniK.Core.Base.Exceptions;
+
+namespace ArmoniK.Core.Common.Exceptions;
 
 /// <summary>
-///   Base exception for exceptions in ArmoniK core
+///   Exception that is thrown when the agent detects the worker is down.
 /// </summary>
 [Serializable]
-public class ArmoniKException : Exception
+public class WorkerDownException : ArmoniKException
 {
   /// <summary>
-  ///   Initializes a new instance of the <see cref="ArmoniKException" />
+  ///   Initializes a new instance of the <see cref="WorkerDownException" /> class.
   /// </summary>
-  public ArmoniKException()
+  public WorkerDownException()
   {
   }
 
   /// <summary>
-  ///   Initializes a new instance of the <see cref="ArmoniKException" /> with the specified error message
+  ///   Initializes a new instance of the <see cref="WorkerDownException" /> class with a specified error message.
   /// </summary>
-  /// <param name="message">The error message</param>
-  public ArmoniKException(string message)
+  /// <param name="message">The message that describes the error.</param>
+  public WorkerDownException(string message)
     : base(message)
   {
   }
 
   /// <summary>
-  ///   Initializes a new instance of the <see cref="ArmoniKException" /> with the specified error message and an exception
+  ///   Initializes a new instance of the <see cref="WorkerDownException" /> class with a specified error message and a
+  ///   reference to the inner exception that is the cause of this exception.
   /// </summary>
-  /// <param name="message">The error message</param>
-  /// <param name="innerException">The inner exception that triggered this exception</param>
-  public ArmoniKException(string     message,
-                          Exception? innerException)
+  /// <param name="message">The message that describes the error.</param>
+  /// <param name="innerException">The exception that is the cause of the current exception.</param>
+  public WorkerDownException(string     message,
+                             Exception? innerException)
     : base(message,
            innerException)
   {

--- a/Common/src/Pollster/RunningTaskProcessor.cs
+++ b/Common/src/Pollster/RunningTaskProcessor.cs
@@ -107,6 +107,12 @@ public class RunningTaskProcessor : BackgroundService
       {
         break;
       }
+      catch (WorkerDownException e)
+      {
+        exceptionManager_.FatalError(logger_,
+                                     e,
+                                     "Fatal error while executing task");
+      }
       catch (Exception e)
       {
         exceptionManager_.RecordError(logger_,

--- a/Common/tests/Helpers/ExceptionWorkerStreamHandler.cs
+++ b/Common/tests/Helpers/ExceptionWorkerStreamHandler.cs
@@ -32,16 +32,21 @@ public sealed class ExceptionWorkerStreamHandler<T> : IWorkerStreamHandler
 {
   private readonly bool acceptCancellation_;
   private readonly int  delay_;
+  private readonly bool healthy_;
 
   public ExceptionWorkerStreamHandler(int  delay,
-                                      bool acceptCancellation = true)
+                                      bool acceptCancellation = true,
+                                      bool healthy            = true)
   {
     delay_              = delay;
     acceptCancellation_ = acceptCancellation;
+    healthy_            = healthy;
   }
 
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
-    => Task.FromResult(HealthCheckResult.Healthy());
+    => Task.FromResult(healthy_
+                         ? HealthCheckResult.Healthy()
+                         : HealthCheckResult.Unhealthy());
 
   public Task Init(CancellationToken cancellationToken)
     => Task.CompletedTask;

--- a/Common/tests/Pollster/PollsterTest.cs
+++ b/Common/tests/Pollster/PollsterTest.cs
@@ -848,7 +848,8 @@ public class PollsterTest
     var stop = testServiceProvider.StopApplicationAfter(TimeSpan.FromMilliseconds(300));
 
     Assert.DoesNotThrowAsync(() => testServiceProvider.Pollster.MainLoop());
-    Assert.DoesNotThrowAsync(() => stop);
+    Assert.That(() => stop,
+                Throws.InstanceOf<OperationCanceledException>());
 
     Assert.AreEqual(TaskStatus.Submitted,
                     await testServiceProvider.TaskTable.GetTaskStatus(taskSubmitted,
@@ -857,6 +858,7 @@ public class PollsterTest
     Assert.AreEqual(Array.Empty<string>(),
                     testServiceProvider.Pollster.TaskProcessing);
 
-    testServiceProvider.AssertFailAfterError(5);
+    testServiceProvider.AssertFailAfterError(0);
+    Assert.True(testServiceProvider.ExceptionManager.Failed);
   }
 }


### PR DESCRIPTION
# Motivation

The existing logic for handling task retries was complex and potentially error-prone, making it difficult to maintain and understand. An error appeared with a new Exception that was not retried when it should be, producing infinite loops where the task was not executed. The task should have been retried and set to error when the retry limit was reached.

# Description

This PR refactors the task retry mechanism during Agent cancellation by:​

- Simplifying the control flow to make the logic more straightforward.​
- Clarifying conditions under which tasks should be retried, ensuring consistent behavior.​
- Reducing code complexity to improve maintainability and reduce the likelihood of bugs.​
- Checking the status of the worker during pre-processing to ensure it is available. It simplifies a lot of the logic since we can requeue tasks if worker is not available and retry tasks if there is an error during the execution of the task. During a cancellation from the `ExceptionManager`, the task is also requeued if it does not finish in its remaining time.

These changes aim to make the system's behavior more predictable and the codebase easier to work with.

# Testing

- Reviewed and updated existing unit tests to align with the refactored logic.​
- Conducted integration tests to verify that tasks are retried appropriately during Agent cancellations.​
- Ensured that no regressions were introduced by comparing behavior before and after the changes.​

# Impact

- Improved code clarity and maintainability in the task retry mechanism.​
- Enhanced reliability of task retries during Agent cancellations.​

# Additional Information

This refactoring is part of ongoing efforts to improve the robustness and maintainability of the ArmoniK.Core codebase. By addressing complex areas of the code, we aim to facilitate future enhancements and reduce the potential for bugs.​

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
