### PR TITLE
fix: if late cts cancellation is requested, do not respond that we are processing the task, so that the task is retried

### DIFF
--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -201,12 +201,13 @@ public static class Program
       app.MapGet("/taskprocessing",
                  async () =>
                  {
-                   var pollster = app.Services.GetRequiredService<Common.Pollster.Pollster>();
+                   var pollster  = app.Services.GetRequiredService<Common.Pollster.Pollster>();
+                   var exManager = app.Services.GetRequiredService<ExceptionManager>();
 
                    var check = await pollster.Check(HealthCheckTag.Liveness)
                                              .ConfigureAwait(false);
 
-                   if (check.Status == HealthStatus.Unhealthy)
+                   if (check.Status == HealthStatus.Unhealthy || exManager.LateCancellationToken.IsCancellationRequested)
                    {
                      return "";
                    }


### PR DESCRIPTION
# Motivation

The system previously responded with a list of task ids even when a cancellation of the instance was requested after the task had started (i.e., a late CTS cancellation). If the agent is stopping or crashing, the task may be requeued anytime and another agent can take the task. The other agent will see the task being processed in the previous implementation, potentially leading to a task removed from the queue by the second agent while the first agent crashes before properly finalizing the task. This fix reduces the probability of being in such a case.

# Description

In `/taskprocessing`, we get the `ExceptionManager` and check whether the late CTS is cancelled. If it is cancelled, we return an empty list.

# Testing

- Tests are passing locally and in the CI.

# Impact

We may insert tasks twice in the queue at the same time: during postprocessing from the first agent and during acquisition of the message in the second agent. Our deduplication mecanism should manage this case. We still have to monitor related bugs.

# Additional Information

This change ensures better fault tolerance in distributed task execution environments, especially when dealing with timing-sensitive cancellation scenarios. It aligns with expected behavior in systems requiring guaranteed task processing or retry mechanisms.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
