### PR TITLE
fix: Retry task upon pre-processing errors

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -811,11 +811,18 @@ public sealed class TaskHandler : IAsyncDisposable
                            .ConfigureAwait(false);
       fetchedDate_ = DateTime.UtcNow;
     }
-    catch (Exception e)
+    catch (ObjectDataNotFoundException e)
     {
       await HandleErrorRequeueAsync(e,
                                     taskData_,
                                     earlyCts_.Token)
+        .ConfigureAwait(false);
+    }
+    catch (Exception e)
+    {
+      await HandleErrorResubmitAsync(e,
+                                     taskData_,
+                                     earlyCts_.Token)
         .ConfigureAwait(false);
     }
   }


### PR DESCRIPTION
# Motivation

When the object storage is not accessible during the pre-processing, the task fails without any retry.

# Description

Check the type of exception thrown by the object storage. If it is `ObjectDataNotFoundException`, the task fails without any retry like before, but if the exception is anything other than that, the task is retried.

# Testing

Unit tests have been adapted to reflect the new semantics.

# Impact

In case of permanent errors (like object storage misconfiguration), the user will see the error after all the retries have been performed instead of directly at the first execution.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
