### PR TITLE
refactor: Upload results before submitting sub-tasks

### DIFF
--- a/Common/src/Pollster/Agent.cs
+++ b/Common/src/Pollster/Agent.cs
@@ -126,6 +126,13 @@ public sealed class Agent : IAgent
                               cancellationToken)
                       .ConfigureAwait(false);
 
+    var resultsToComplete = await StoreDataAsync(cancellationToken)
+                              .ConfigureAwait(false);
+
+    await resultTable_.CompleteManyResults(resultsToComplete.ViewSelect(pair => (pair.Key, pair.Value.size, pair.Value.id)),
+                                           cancellationToken)
+                      .ConfigureAwait(false);
+
     await TaskLifeCycleHelper.CreateTasks(taskTable_,
                                           resultTable_,
                                           sessionData_.SessionId,
@@ -140,13 +147,6 @@ public sealed class Agent : IAgent
                                           taskData_.TaskId,
                                           cancellationToken)
                     .ConfigureAwait(false);
-
-    var resultsToComplete = await StoreDataAsync(cancellationToken)
-                              .ConfigureAwait(false);
-
-    await resultTable_.CompleteManyResults(resultsToComplete.ViewSelect(pair => (pair.Key, pair.Value.size, pair.Value.id)),
-                                           cancellationToken)
-                      .ConfigureAwait(false);
 
     await TaskLifeCycleHelper.ResolveDependencies(taskTable_,
                                                   resultTable_,


### PR DESCRIPTION
# Motivation

If the result upload fails (eg: Object Storage is temporarily unavailable), sub-tasks are already submitted and remains in pending state. While it is benign as those tasks are never executed, it adds noise when debugging a faulty session.

# Description

Upload the results before creating the tasks in the database. As such, if an exception occurs during result upload, the task submission will be skipped.

# Testing

Add a unit test to ensure no task is created in case of result upload failure.

# Impact

This order might be a bit faster as all the payloads will be already completed when tasks are actually created, skipping a good portion of the dependency resolution.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
