### PR TITLE
chore(deps): RabbitMQ 4

### DIFF
--- a/justfile
+++ b/justfile
@@ -38,13 +38,13 @@ export TF_VAR_queue_storage := if queue == "rabbitmq" {
   if os_family() == "windows" {
     '{ name = "rabbitmq", image = "micdenny/rabbitmq-windows:3.6.12" }'
   } else {
-    '{ name = "rabbitmq", image = "rabbitmq:3-management" }'
+    '{ name = "rabbitmq", image = "rabbitmq:4-management" }'
   }
 } else if queue == "rabbitmq091" {
   if os_family() == "windows" {
     '{ name = "rabbitmq", image = "micdenny/rabbitmq-windows:3.6.12", protocol = "amqp0_9_1" }'
   } else {
-    '{ name = "rabbitmq", image = "rabbitmq:3-management", protocol = "amqp0_9_1" }'
+    '{ name = "rabbitmq", image = "rabbitmq:4-management", protocol = "amqp0_9_1" }'
   }
 } else if queue == "artemis" {
   '{ name = "artemis", image = "quay.io/artemiscloud/activemq-artemis-broker:artemis.2.28.0" }'

--- a/terraform/modules/storage/queue/rabbitmq/inputs.tf
+++ b/terraform/modules/storage/queue/rabbitmq/inputs.tf
@@ -1,6 +1,6 @@
 variable "image" {
   type    = string
-  default = "rabbitmq:3-management"
+  default = "rabbitmq:4-management"
 }
 
 variable "network" {


### PR DESCRIPTION
# Motivation

RabbitMQ tests are unstable using RabbitMQ 3, and RabbitMQ now officially supports AMQP 1.

# Description

Use RabbitMQ 4 to limit CI failures due to unstable implementation.

# Testing

No failure after 20 runs on CI.

# Impact

RabbitMQ 4 should be more stable because of the official support for AMQP 1.0 (https://www.rabbitmq.com/blog/2024/08/05/native-amqp), and it is reportedly much faster than RabbitMQ 3 (https://www.rabbitmq.com/blog/2024/08/21/amqp-benchmarks).

# Additional Information

If the AMQP implementation of RabbitMQ works well, we might deprecate the RabbitMQ Adapter to only have the AMQP adapter.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
