### PR TITLE
ci: Install just from taiki-e action instead of snap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,8 +62,9 @@ jobs:
           terraform_version: latest
 
     - name: Setup just
-      run: |
-          sudo snap install --edge --classic just
+      uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+      with:
+        tool: just
 
     - name: Install mongodb
       run: |
@@ -135,8 +136,9 @@ jobs:
        terraform_version: latest
 
     - name: Setup just
-      run: |
-          sudo snap install --edge --classic just
+      uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+      with:
+        tool: just
 
     - name: Set up queue
       run: |
@@ -279,8 +281,9 @@ jobs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3  
 
     - name: Setup just
-      run: |
-          sudo snap install --edge --classic just
+      uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+      with:
+        tool: just
 
     - name: Login to Docker Hub
       uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
@@ -358,8 +361,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -481,8 +485,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
       
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -771,8 +776,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -857,8 +863,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -977,8 +984,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -1051,8 +1059,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
@@ -1123,8 +1132,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -90,7 +90,9 @@ jobs:
       uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
 
     - name: Setup just
-      run: sudo snap install --edge --classic just
+      uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+      with:
+        tool: just
 
     - name: login
       run: echo ${{ secrets.DOCKER_HUB_TOKEN }} | docker login -u ${{ secrets.DOCKER_HUB_LOGIN }} --password-stdin

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -33,8 +33,9 @@ jobs:
           pip install awscli
 
       - name: Setup just
-        run: |
-          sudo snap install --edge --classic just
+        uses: taiki-e/install-action@be7c31b6745feec79dec5eb79178466c0670bb2d # v2
+        with:
+          tool: just
 
       - name: Minio Server UP
         if: ${{ matrix.projects }} == "Adaptors/S3/tests"


### PR DESCRIPTION
# Motivation

Sometimes, snap takes a very long time to download and install packages, leading to pipeline failures.

Example:

```
Run sudo snap install --edge --classic just
error: cannot perform the following tasks:
- Download snap "snapd" (23771) from channel "stable" (download too slow: 3590.39 bytes/sec)
```

# Description

Install `just` from [taiki-e action](https://github.com/taiki-e/install-action) instead of snap. This action should not be sensible to any API rate-limiting of any kind.

# Impact

This should reduce the failure potential of installing just.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
