### PR TITLE
fix: Retry upon RedisConnectionException

### DIFF
--- a/Adaptors/Redis/src/ObjectStorage.cs
+++ b/Adaptors/Redis/src/ObjectStorage.cs
@@ -230,7 +230,7 @@ public class ObjectStorage : IObjectStorage
         return await action()
                  .ConfigureAwait(false);
       }
-      catch (RedisTimeoutException ex)
+      catch (Exception ex) when (ex is RedisTimeoutException or RedisConnectionException)
       {
         if (retryCount + 1 >= redisOptions_.MaxRetry)
         {


### PR DESCRIPTION
# Motivation

If Redis client fails with a `RedisConnectionException`, the request is not retried by `PerformActionWithRetry`.

# Description

Add `RedisConnectionException` to the exceptions that are retried by `PerformActionWithRetry`.

# Impact

The Redis client would be more resilient to transient network issues.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
