### PR TITLE
fix: Idem-potent retry

### DIFF
--- a/Common/src/Pollster/AcquisitionStatus.cs
+++ b/Common/src/Pollster/AcquisitionStatus.cs
@@ -78,36 +78,6 @@ public enum AcquisitionStatus
   TaskIsRetried,
 
   /// <summary>
-  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task is
-  ///   <see cref="TaskStatus.Creating" />
-  ///   Retried task finalization is required.
-  /// </summary>
-  TaskIsRetriedAndRetryIsCreating,
-
-  /// <summary>
-  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task was not found
-  ///   in the database
-  ///   Retried task creation and submission is required.
-  /// </summary>
-  TaskIsRetriedAndRetryIsNotFound,
-
-  /// <summary>
-  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task is
-  ///   <see cref="TaskStatus.Submitted" />
-  ///   Reinsertion in the queue may be required.
-  /// </summary>
-  TaskIsRetriedAndRetryIsSubmitted,
-
-
-  /// <summary>
-  ///   Task not acquired because its status is <see cref="TaskStatus.Retried" />. Moreover, the retried task is
-  ///   <see cref="TaskStatus.Pending" />
-  ///   Reinsertion in the queue may be required.
-  /// </summary>
-  TaskIsRetriedAndRetryIsPending,
-
-
-  /// <summary>
   ///   Task not acquired because its status is <see cref="TaskStatus.Processing" /> but the other pod does not seem to be
   ///   processing it
   /// </summary>

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -381,15 +381,14 @@ public static class TaskLifeCycleHelper
     // If the agent completes the dependencies _before_ the GetResults, both will try to remove it,
     // and both will queue the task.
     // This is benign as it will be handled during dequeue with message deduplication.
-    var x = await taskTable.RemoveRemainingDataDependenciesAsync(taskDependencies.Keys,
-                                                                 completedDependencies,
-                                                                 data => new MessageData(data.TaskId,
-                                                                                         data.SessionId,
-                                                                                         data.Options),
-                                                                 cancellationToken)
-                           .ToListAsync(cancellationToken)
-                           .ConfigureAwait(false);
-    return x;
+    return await taskTable.RemoveRemainingDataDependenciesAsync(taskDependencies.Keys,
+                                                                completedDependencies,
+                                                                data => new MessageData(data.TaskId,
+                                                                                        data.SessionId,
+                                                                                        data.Options),
+                                                                cancellationToken)
+                          .ToListAsync(cancellationToken)
+                          .ConfigureAwait(false);
   }
 
   /// <summary>
@@ -614,172 +613,347 @@ public static class TaskLifeCycleHelper
   /// <param name="logger">Logger</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>The status of the processed task</returns>
-  public static async Task CompleteTaskAsync(ITaskTable        taskTable,
-                                             IResultTable      resultTable,
-                                             IObjectStorage    objectStorage,
-                                             IPushQueueStorage pushQueueStorage,
-                                             Submitter         options,
-                                             TaskData          taskData,
-                                             SessionData       sessionData,
-                                             bool              resubmit,
-                                             Output            output,
-                                             ILogger           logger,
-                                             CancellationToken cancellationToken = default)
+  public static Task<TaskData> CompleteTaskAsync(ITaskTable        taskTable,
+                                                 IResultTable      resultTable,
+                                                 IObjectStorage    objectStorage,
+                                                 IPushQueueStorage pushQueueStorage,
+                                                 Submitter         options,
+                                                 TaskData          taskData,
+                                                 SessionData       sessionData,
+                                                 bool              resubmit,
+                                                 Output            output,
+                                                 ILogger           logger,
+                                                 CancellationToken cancellationToken = default)
+    => (output.Status, resubmit) switch
+       {
+         (OutputStatus.Success, _) => CompleteTaskAsync(taskTable,
+                                                        resultTable,
+                                                        objectStorage,
+                                                        options,
+                                                        taskData,
+                                                        logger,
+                                                        cancellationToken),
+         (OutputStatus.Error, true) => AbortOrRetryTaskAsync(taskTable,
+                                                             resultTable,
+                                                             objectStorage,
+                                                             pushQueueStorage,
+                                                             options,
+                                                             taskData,
+                                                             sessionData,
+                                                             null,
+                                                             output.Error,
+                                                             logger,
+                                                             cancellationToken),
+         (OutputStatus.Timeout or OutputStatus.Error, _) => AbortTaskAsync(taskTable,
+                                                                           resultTable,
+                                                                           objectStorage,
+                                                                           options,
+                                                                           taskData,
+                                                                           output.Status,
+                                                                           output.Error,
+                                                                           logger,
+                                                                           cancellationToken),
+         _ => throw new ArgumentOutOfRangeException(),
+       };
+
+
+  /// <summary>
+  ///   Complete the task depending on the given output
+  /// </summary>
+  /// <param name="taskTable">Interface to manage task states</param>
+  /// <param name="resultTable">Interface to manage result states</param>
+  /// <param name="objectStorage">Interface to manage object data</param>
+  /// <param name="options">Submitter options</param>
+  /// <param name="taskData">Data of the task</param>
+  /// <param name="logger">Logger</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>The status of the processed task</returns>
+  public static async Task<TaskData> CompleteTaskAsync(ITaskTable        taskTable,
+                                                       IResultTable      resultTable,
+                                                       IObjectStorage    objectStorage,
+                                                       Submitter         options,
+                                                       TaskData          taskData,
+                                                       ILogger           logger,
+                                                       CancellationToken cancellationToken = default)
   {
-    var taskDataEnd = taskData with
-                      {
-                        EndDate = DateTime.UtcNow,
-                        CreationToEndDuration = DateTime.UtcNow   - taskData.CreationDate,
-                        ProcessingToEndDuration = DateTime.UtcNow - taskData.StartDate,
-                        ReceivedToEndDuration = DateTime.UtcNow   - taskData.ReceptionDate,
-                      };
+    taskData = taskData.WithEndDate();
 
-    switch (output.Status)
+    await taskTable.SetTaskSuccessAsync(taskData,
+                                        cancellationToken)
+                   .ConfigureAwait(false);
+
+
+    if (options.DeletePayload)
     {
-      case OutputStatus.Success:
-        await taskTable.SetTaskSuccessAsync(taskDataEnd,
-                                            cancellationToken)
-                       .ConfigureAwait(false);
-
-
-        if (options.DeletePayload)
-        {
-          var payloadData = await resultTable.GetResult(taskData.PayloadId,
-                                                        CancellationToken.None)
-                                             .ConfigureAwait(false);
-
-          if (!payloadData.ManualDeletion)
-          {
-            //Discard value is used to remove warnings CS4014 !!
-            _ = Task.Factory.StartNew(async () =>
-                                      {
-                                        await objectStorage.TryDeleteAsync(new[]
-                                                                           {
-                                                                             payloadData.OpaqueId,
-                                                                           },
-                                                                           CancellationToken.None)
-                                                           .ConfigureAwait(false);
-                                      },
-                                      cancellationToken);
-
-            await resultTable.MarkAsDeleted(taskData.PayloadId,
-                                            CancellationToken.None)
-                             .ConfigureAwait(false);
-
-            logger.LogInformation("Remove input payload of {task}",
-                                  taskData.TaskId);
-          }
-        }
-
-        break;
-      case OutputStatus.Error:
-        // TODO FIXME: nothing will resubmit the task if there is a crash there
-        if (resubmit && taskData.RetryOfIds.Count < taskData.Options.MaxRetries)
-        {
-          // not done means that another pod put this task in retry so we do not need to do it a second time
-          // so nothing to do
-          if (!await taskTable.SetTaskRetryAsync(taskDataEnd,
-                                                 output.Error,
-                                                 cancellationToken)
-                              .ConfigureAwait(false))
-          {
-            return;
-          }
-
-          logger.LogWarning("Resubmit {task}",
-                            taskData.TaskId);
-
-          var newTaskId = await taskTable.RetryTask(taskData,
+      await ResultLifeCycleHelper.DeleteResultAsync(resultTable,
+                                                    objectStorage,
+                                                    taskData.PayloadId,
                                                     cancellationToken)
-                                         .ConfigureAwait(false);
-
-          await FinalizeTaskCreation(taskTable,
-                                     resultTable,
-                                     pushQueueStorage,
-                                     new List<TaskCreationRequest>
-                                     {
-                                       new(newTaskId,
-                                           taskData.PayloadId,
-                                           taskData.Options,
-                                           taskData.ExpectedOutputIds,
-                                           taskData.DataDependencies),
-                                     },
-                                     sessionData,
-                                     taskData.TaskId,
-                                     logger,
-                                     cancellationToken)
-            .ConfigureAwait(false);
-        }
-        else
-        {
-          // not done means that another pod put this task in error so we do not need to do it a second time
-          // so nothing to do
-          if (!await taskTable.SetTaskErrorAsync(taskDataEnd,
-                                                 output.Error,
-                                                 cancellationToken)
-                              .ConfigureAwait(false))
-          {
-            return;
-          }
-
-          await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
-                                                           resultTable,
-                                                           new[]
-                                                           {
-                                                             taskData.TaskId,
-                                                           },
-                                                           reason: $"Task {taskData.TaskId} failed:\n{output.Error}")
-                                     .ConfigureAwait(false);
-        }
-
-        break;
-      case OutputStatus.Timeout:
-        await taskTable.SetTaskTimeoutAsync(taskDataEnd,
-                                            output,
-                                            cancellationToken)
-                       .ConfigureAwait(false);
-
-
-        var payloadData2 = await resultTable.GetResult(taskData.PayloadId,
-                                                       CancellationToken.None)
-                                            .ConfigureAwait(false);
-
-        if (!payloadData2.ManualDeletion)
-        {
-          //Discard value is used to remove warnings CS4014 !!
-          _ = Task.Factory.StartNew(async () =>
-                                    {
-                                      await objectStorage.TryDeleteAsync(new[]
-                                                                         {
-                                                                           payloadData2.OpaqueId,
-                                                                         },
-                                                                         CancellationToken.None)
-                                                         .ConfigureAwait(false);
-                                    },
-                                    cancellationToken);
-
-
-          logger.LogInformation("Remove input payload of {task}",
-                                taskData.TaskId);
-
-          await resultTable.MarkAsDeleted(taskData.PayloadId,
-                                          CancellationToken.None)
-                           .ConfigureAwait(false);
-        }
-
-        await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
-                                                         resultTable,
-                                                         new[]
-                                                         {
-                                                           taskData.TaskId,
-                                                         },
-                                                         reason: $"Task {taskData.TaskId} timed-out:\n{output.Error}")
-                                   .ConfigureAwait(false);
-        break;
-      default:
-        throw new ArgumentOutOfRangeException();
+                                 .ConfigureAwait(false);
+      logger.LogInformation("Remove input payload of {task}",
+                            taskData.TaskId);
     }
+
+    return taskData with
+           {
+             Status = TaskStatus.Completed,
+             Output = new Output(OutputStatus.Success,
+                                 ""),
+           };
   }
+
+  /// <summary>
+  ///   Retry the task if all retries have not been consumed, or abort otherwise
+  /// </summary>
+  /// <param name="taskTable">Interface to manage task states</param>
+  /// <param name="resultTable">Interface to manage result states</param>
+  /// <param name="objectStorage">Interface to manage object data</param>
+  /// <param name="pushQueueStorage">Interface to push messages to the queue</param>
+  /// <param name="options">Submitter options</param>
+  /// <param name="taskData">Data of the task</param>
+  /// <param name="sessionData">Data of the session</param>
+  /// <param name="subtasks">
+  ///   Ids of the tasks that have been created by the current task. If null, they will be fetched from
+  ///   the TaskTable
+  /// </param>
+  /// <param name="errorMessage">Error message to record in the task output</param>
+  /// <param name="logger">Logger</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>The status of the processed task</returns>
+  public static Task<TaskData> AbortOrRetryTaskAsync(ITaskTable           taskTable,
+                                                     IResultTable         resultTable,
+                                                     IObjectStorage       objectStorage,
+                                                     IPushQueueStorage    pushQueueStorage,
+                                                     Submitter            options,
+                                                     TaskData             taskData,
+                                                     SessionData          sessionData,
+                                                     ICollection<string>? subtasks,
+                                                     string               errorMessage,
+                                                     ILogger              logger,
+                                                     CancellationToken    cancellationToken = default)
+    => taskData.RetryOfIds.Count < taskData.Options.MaxRetries
+         ? RetryTaskAsync(taskTable,
+                          resultTable,
+                          pushQueueStorage,
+                          taskData,
+                          sessionData,
+                          subtasks,
+                          errorMessage,
+                          logger,
+                          cancellationToken)
+         : AbortTaskAsync(taskTable,
+                          resultTable,
+                          objectStorage,
+                          options,
+                          taskData,
+                          OutputStatus.Error,
+                          errorMessage,
+                          logger,
+                          cancellationToken);
+
+  /// <summary>
+  ///   Retry the task if all retries have not been consumed, or abort otherwise
+  /// </summary>
+  /// <param name="taskTable">Interface to manage task states</param>
+  /// <param name="resultTable">Interface to manage result states</param>
+  /// <param name="pushQueueStorage">Interface to push messages to the queue</param>
+  /// <param name="taskData">Data of the task</param>
+  /// <param name="sessionData">Data of the session</param>
+  /// <param name="subtasks">
+  ///   Ids of the tasks that have been created by the current task. If null, they will be fetched from
+  ///   the TaskTable
+  /// </param>
+  /// <param name="errorMessage">Error message to record in the task output</param>
+  /// <param name="logger">Logger</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>The status of the processed task</returns>
+  public static async Task<TaskData> RetryTaskAsync(ITaskTable           taskTable,
+                                                    IResultTable         resultTable,
+                                                    IPushQueueStorage    pushQueueStorage,
+                                                    TaskData             taskData,
+                                                    SessionData          sessionData,
+                                                    ICollection<string>? subtasks,
+                                                    string               errorMessage,
+                                                    ILogger              logger,
+                                                    CancellationToken    cancellationToken = default)
+  {
+    taskData = taskData.WithEndDate();
+
+    subtasks ??= await taskTable.FindTasksAsync(td => td.CreatedBy == taskData.TaskId && td.InitialTaskId == td.TaskId,
+                                                td => td.TaskId,
+                                                cancellationToken)
+                                .ToListAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+    // Revert ExpectedOutputIds to current task to avoid aborting them while aborting subtasks
+    await resultTable.UpdateManyResults(td => taskData.ExpectedOutputIds.Contains(td.ResultId),
+                                        new UpdateDefinition<Result>().Set(td => td.OwnerTaskId,
+                                                                           taskData.TaskId),
+                                        cancellationToken)
+                     .ConfigureAwait(false);
+
+    var resultsToAbort = await resultTable.GetResults(r => r.CreatedBy == taskData.TaskId,
+                                                      r => r.ResultId,
+                                                      cancellationToken)
+                                          .ToListAsync(cancellationToken)
+                                          .ConfigureAwait(false);
+
+    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
+                                                     resultTable,
+                                                     subtasks,
+                                                     resultsToAbort,
+                                                     errorMessage,
+                                                     TaskStatus.Cancelled,
+                                                     cancellationToken)
+                               .ConfigureAwait(false);
+
+    // Change current task status to Retried
+    await taskTable.SetTaskRetryAsync(taskData,
+                                      errorMessage,
+                                      cancellationToken)
+                   .ConfigureAwait(false);
+
+    logger.LogWarning("Resubmit {task}",
+                      taskData.TaskId);
+
+    string retryId;
+
+    try
+    {
+      // Submit a new task that is a retry of current task
+      retryId = await taskTable.RetryTask(taskData,
+                                          cancellationToken)
+                               .ConfigureAwait(false);
+    }
+    catch (TaskAlreadyExistsException)
+    {
+      // If the retry task already exist, we just continue as-if we just submitted it
+      retryId = taskData.RetryId();
+    }
+
+    // Submit retry task into the queue
+    await FinalizeTaskCreation(taskTable,
+                               resultTable,
+                               pushQueueStorage,
+                               new List<TaskCreationRequest>
+                               {
+                                 new(retryId,
+                                     taskData.PayloadId,
+                                     taskData.Options,
+                                     taskData.ExpectedOutputIds,
+                                     taskData.DataDependencies),
+                               },
+                               sessionData,
+                               taskData.TaskId,
+                               logger,
+                               cancellationToken)
+      .ConfigureAwait(false);
+
+    return taskData with
+           {
+             Status = TaskStatus.Retried,
+             Output = new Output(OutputStatus.Error,
+                                 errorMessage),
+           };
+  }
+
+  /// <summary>
+  ///   Retry the task if all retries have not been consumed, or abort otherwise
+  /// </summary>
+  /// <param name="taskTable">Interface to manage task states</param>
+  /// <param name="resultTable">Interface to manage result states</param>
+  /// <param name="objectStorage">Interface to manage object data</param>
+  /// <param name="options">Submitter options</param>
+  /// <param name="taskData">Data of the task</param>
+  /// <param name="status">Output status of the task (cannot be success)</param>
+  /// <param name="errorMessage">Error message to record in the task output</param>
+  /// <param name="logger">Logger</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>The status of the processed task</returns>
+  public static async Task<TaskData> AbortTaskAsync(ITaskTable        taskTable,
+                                                    IResultTable      resultTable,
+                                                    IObjectStorage    objectStorage,
+                                                    Submitter         options,
+                                                    TaskData          taskData,
+                                                    OutputStatus      status,
+                                                    string            errorMessage,
+                                                    ILogger           logger,
+                                                    CancellationToken cancellationToken = default)
+  {
+    taskData = taskData.WithEndDate();
+
+    var (taskStatus, reason) = status switch
+                               {
+                                 OutputStatus.Error   => (TaskStatus.Error, "failed"),
+                                 OutputStatus.Timeout => (TaskStatus.Timeout, "timed-out"),
+                                 _ => throw new ArgumentOutOfRangeException(nameof(status),
+                                                                            status,
+                                                                            "Must be Error or Timeout"),
+                               };
+
+    if (options.DeletePayload)
+    {
+      await ResultLifeCycleHelper.DeleteResultAsync(resultTable,
+                                                    objectStorage,
+                                                    taskData.PayloadId,
+                                                    cancellationToken)
+                                 .ConfigureAwait(false);
+      logger.LogInformation("Remove input payload of {task}",
+                            taskData.TaskId);
+    }
+
+    var updated = await taskTable.UpdateOneTask(taskData.TaskId,
+                                                null,
+                                                new UpdateDefinition<TaskData>().Set(data => data.Output,
+                                                                                     new Output(status,
+                                                                                                errorMessage))
+                                                                                .Set(data => data.Status,
+                                                                                     taskStatus)
+                                                                                .Set(tdm => tdm.EndDate,
+                                                                                     taskData.EndDate)
+                                                                                .Set(tdm => tdm.ProcessedDate,
+                                                                                     taskData.ProcessedDate)
+                                                                                .Set(tdm => tdm.ReceivedToEndDuration,
+                                                                                     taskData.ReceivedToEndDuration)
+                                                                                .Set(tdm => tdm.CreationToEndDuration,
+                                                                                     taskData.CreationToEndDuration)
+                                                                                .Set(tdm => tdm.ProcessingToEndDuration,
+                                                                                     taskData.ProcessingToEndDuration),
+                                                cancellationToken: cancellationToken)
+                                 .ConfigureAwait(false);
+
+    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
+                                                     resultTable,
+                                                     new[]
+                                                     {
+                                                       taskData.TaskId,
+                                                     },
+                                                     reason: $"Task {taskData.TaskId} {reason}:\n{errorMessage}",
+                                                     cancellationToken: cancellationToken)
+                               .ConfigureAwait(false);
+
+    if (updated is null)
+    {
+      throw new TaskNotFoundException($"Task {taskData.TaskId} not found");
+    }
+
+    return updated;
+  }
+
+  /// <summary>
+  ///   Create a copy of the task data with the end date set
+  /// </summary>
+  /// <param name="taskData">Task data</param>
+  /// <returns>Updated task data</returns>
+  private static TaskData WithEndDate(this TaskData taskData)
+    => taskData with
+       {
+         EndDate = DateTime.UtcNow,
+         CreationToEndDuration = DateTime.UtcNow   - taskData.CreationDate,
+         ProcessingToEndDuration = DateTime.UtcNow - taskData.StartDate,
+         ReceivedToEndDuration = DateTime.UtcNow   - taskData.ReceptionDate,
+       };
+
 
   /// <summary>
   ///   Either finish completion of task if crashing pod was advanced enough, or retry task otherwise

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -470,8 +470,9 @@ public class TaskHandlerTest
     var taskData = await testServiceProvider.TaskTable.ReadTaskAsync("TaskRetry2")
                                             .ConfigureAwait(false);
 
-    await testServiceProvider.TaskTable.SetTaskRetryAsync(taskData,
-                                                          "Error for test : retried")
+    await testServiceProvider.TaskTable.EndTaskAsync(taskData,
+                                                     TaskStatus.Retried,
+                                                     "Error for test : retried")
                              .ConfigureAwait(false);
 
     var newTaskId = await testServiceProvider.TaskTable.RetryTask(taskData)
@@ -501,8 +502,9 @@ public class TaskHandlerTest
     taskData = await testServiceProvider.TaskTable.ReadTaskAsync("TaskRetry2+Submitted")
                                         .ConfigureAwait(false);
 
-    await testServiceProvider.TaskTable.SetTaskRetryAsync(taskData,
-                                                          "Error for test : submitted")
+    await testServiceProvider.TaskTable.EndTaskAsync(taskData,
+                                                     TaskStatus.Retried,
+                                                     "Error for test : submitted")
                              .ConfigureAwait(false);
 
     newTaskId = await testServiceProvider.TaskTable.RetryTask(taskData)
@@ -528,8 +530,9 @@ public class TaskHandlerTest
     taskData = await testServiceProvider.TaskTable.ReadTaskAsync("TaskRetry2+Creating")
                                         .ConfigureAwait(false);
 
-    await testServiceProvider.TaskTable.SetTaskRetryAsync(taskData,
-                                                          "Error for test : creating")
+    await testServiceProvider.TaskTable.EndTaskAsync(taskData,
+                                                     TaskStatus.Retried,
+                                                     "Error for test : creating")
                              .ConfigureAwait(false);
 
     newTaskId = await testServiceProvider.TaskTable.RetryTask(taskData)
@@ -539,16 +542,18 @@ public class TaskHandlerTest
     taskData = await testServiceProvider.TaskTable.ReadTaskAsync("TaskRetry2+NotFound")
                                         .ConfigureAwait(false);
 
-    await testServiceProvider.TaskTable.SetTaskRetryAsync(taskData,
-                                                          "Error for test : not found")
+    await testServiceProvider.TaskTable.EndTaskAsync(taskData,
+                                                     TaskStatus.Retried,
+                                                     "Error for test : not found")
                              .ConfigureAwait(false);
 
 
     taskData = await testServiceProvider.TaskTable.ReadTaskAsync("TaskRetry2+Pending")
                                         .ConfigureAwait(false);
 
-    await testServiceProvider.TaskTable.SetTaskRetryAsync(taskData,
-                                                          "Error for test : pending")
+    await testServiceProvider.TaskTable.EndTaskAsync(taskData,
+                                                     TaskStatus.Retried,
+                                                     "Error for test : pending")
                              .ConfigureAwait(false);
 
     newTaskId = await testServiceProvider.TaskTable.RetryTask(taskData)

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -993,21 +993,14 @@ public class TaskHandlerTest
   {
     get
     {
-      yield return new TestCaseData("TaskRetry2").Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsRetried,
-                                                                                TaskStatus.Retried,
-                                                                                QueueMessageStatus.Poisonous));
-      yield return new TestCaseData("TaskRetry2+Creating").Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsRetriedAndRetryIsCreating,
-                                                                                         TaskStatus.Retried,
-                                                                                         QueueMessageStatus.Poisonous));
-      yield return new TestCaseData("TaskRetry2+Submitted").Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsRetriedAndRetryIsSubmitted,
-                                                                                          TaskStatus.Retried,
-                                                                                          QueueMessageStatus.Poisonous));
-      yield return new TestCaseData("TaskRetry2+NotFound").Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsRetriedAndRetryIsNotFound,
-                                                                                         TaskStatus.Retried,
-                                                                                         QueueMessageStatus.Poisonous));
-      yield return new TestCaseData("TaskRetry2+Pending").Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsRetriedAndRetryIsPending,
-                                                                                        TaskStatus.Retried,
-                                                                                        QueueMessageStatus.Poisonous));
+      var expected = new AcquireTaskReturn(AcquisitionStatus.TaskIsRetried,
+                                           TaskStatus.Retried,
+                                           QueueMessageStatus.Poisonous);
+      yield return new TestCaseData("TaskRetry2").Returns(expected);
+      yield return new TestCaseData("TaskRetry2+Creating").Returns(expected);
+      yield return new TestCaseData("TaskRetry2+Submitted").Returns(expected);
+      yield return new TestCaseData("TaskRetry2+NotFound").Returns(expected);
+      yield return new TestCaseData("TaskRetry2+Pending").Returns(expected);
     }
   }
 

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -978,6 +978,76 @@ public class TaskLifeCycleHelperTest
                 Is.EqualTo(TaskStatus.Submitted));
   }
 
+  [Test]
+  public async Task RetryRace([Values] TaskStatus status,
+                              [Values(2,
+                                      3,
+                                      4)]
+                              int concurrency)
+  {
+    using var holder = new Holder();
+
+    while (holder.QueueStorage.Channel.Reader.TryRead(out var handler))
+    {
+      handler.Status = QueueMessageStatus.Processed;
+      await handler.DisposeAsync()
+                   .ConfigureAwait(false);
+    }
+
+    var taskData = await holder.TaskTable.FindTasksAsync(data => data.DataDependencies == new List<string>(),
+                                                         data => data)
+                               .FirstAsync()
+                               .ConfigureAwait(false);
+
+    var sessionData = await holder.SessionTable.GetSessionAsync(holder.Session)
+                                  .ConfigureAwait(false);
+
+    taskData = await holder.TaskTable.UpdateOneTask(taskData.TaskId,
+                                                    null,
+                                                    new UpdateDefinition<TaskData>().Set(td => td.Status,
+                                                                                         status))
+                           .ConfigureAwait(false)!;
+
+    Assert.That(() => Enumerable.Range(0,
+                                       concurrency)
+                                .Select(_ => TaskLifeCycleHelper.RetryTaskAsync(holder.TaskTable,
+                                                                                holder.ResultTable,
+                                                                                holder.PushQueueStorage,
+                                                                                taskData,
+                                                                                sessionData,
+                                                                                null,
+                                                                                "task has been retried",
+                                                                                holder.TaskTable.Logger))
+                                .WhenAll(),
+                Throws.Nothing);
+
+    taskData = await holder.TaskTable.ReadTaskAsync(taskData.TaskId)
+                           .ConfigureAwait(false);
+    var retryTaskData = await holder.TaskTable.ReadTaskAsync(taskData.RetryId())
+                                    .ConfigureAwait(false);
+
+    var messages = new List<IQueueMessageHandler>();
+    while (holder.QueueStorage.Channel.Reader.TryRead(out var handler))
+    {
+      messages.Add(handler);
+    }
+
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(taskData.Status,
+                                  Is.EqualTo(TaskStatus.Retried));
+                      Assert.That(retryTaskData.Status,
+                                  Is.EqualTo(TaskStatus.Submitted));
+                      Assert.That(retryTaskData.RetryOfIds,
+                                  Has.Member(taskData.TaskId));
+                      Assert.That(messages,
+                                  Has.Count.InRange(1,
+                                                    concurrency)
+                                     .And.All.Property("TaskId")
+                                     .EqualTo(retryTaskData.TaskId));
+                    });
+  }
+
   public enum CrashState
   {
     Processing,

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -701,13 +701,8 @@ public class TaskTableTestBase
   {
     if (RunTests)
     {
-      await TaskTable!.SetTaskSuccessAsync(taskProcessingData_ with
-                                           {
-                                             EndDate = DateTime.UtcNow,
-                                             CreationToEndDuration = DateTime.UtcNow   - taskProcessingData_.EndDate,
-                                             ProcessingToEndDuration = DateTime.UtcNow - taskProcessingData_.StartDate,
-                                           },
-                                           CancellationToken.None)
+      await TaskTable!.EndTaskAsync(taskProcessingData_,
+                                    TaskStatus.Completed)
                       .ConfigureAwait(false);
 
       var resStatus = await TaskTable!.GetTaskStatus(taskProcessingData_.TaskId,
@@ -735,14 +730,9 @@ public class TaskTableTestBase
   {
     if (RunTests)
     {
-      await TaskTable!.SetTaskErrorAsync(taskProcessingData_ with
-                                         {
-                                           EndDate = DateTime.UtcNow,
-                                           CreationToEndDuration = DateTime.UtcNow   - taskProcessingData_.EndDate,
-                                           ProcessingToEndDuration = DateTime.UtcNow - taskProcessingData_.StartDate,
-                                         },
-                                         "Testing SetTaskError",
-                                         CancellationToken.None)
+      await TaskTable!.EndTaskAsync(taskProcessingData_,
+                                    TaskStatus.Error,
+                                    "Testing SetTaskError")
                       .ConfigureAwait(false);
 
       var resStatus = await TaskTable!.GetTaskStatus("TaskProcessingId",
@@ -768,13 +758,8 @@ public class TaskTableTestBase
   {
     if (RunTests)
     {
-      await TaskTable!.SetTaskCanceledAsync(taskProcessingData_ with
-                                            {
-                                              EndDate = DateTime.UtcNow,
-                                              CreationToEndDuration = DateTime.UtcNow   - taskProcessingData_.EndDate,
-                                              ProcessingToEndDuration = DateTime.UtcNow - taskProcessingData_.StartDate,
-                                            },
-                                            CancellationToken.None)
+      await TaskTable!.EndTaskAsync(taskProcessingData_,
+                                    TaskStatus.Cancelled)
                       .ConfigureAwait(false);
 
       var resStatus = await TaskTable!.GetTaskStatus("TaskProcessingId",

--- a/Common/tests/TestBase/TaskWatcherTestBase.cs
+++ b/Common/tests/TestBase/TaskWatcherTestBase.cs
@@ -358,9 +358,9 @@ public class TaskWatcherTestBase
                                 cancellationToken)
                    .ConfigureAwait(false);
 
-    await taskTable.SetTaskErrorAsync(TaskProcessingData,
-                                      "Testing SetTaskError",
-                                      CancellationToken.None)
+    await taskTable.EndTaskAsync(TaskProcessingData,
+                                 TaskStatus.Error,
+                                 "Testing SetTaskError")
                    .ConfigureAwait(false);
 
     await taskTable.AcquireTask(TaskSubmittedData with


### PR DESCRIPTION
# Motivation

If 2 pods retry the same task, current code makes it that only of them will actually retry the task. In some cases, the pod that should be responsible for the retry crashes, and the retry is never submitted.

# Description

Avoid the election of a pod responsible for the retry, and let both of them submit the retry task.
Refactor task ending and retry to mutualize code.

# Testing

A unit test has been added that start multiple tasks retrying the same task concurrently, for all task status possible, even Retried. The test check that the retried task has successfully been created and submitted to the queue.

# Impact

This enables error recovery when an agent crashes while creating a retry task.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
