### PR TITLE
refactor: postpone message when task is processing elsewhere

### DIFF
--- a/Common/src/Injection/Options/Pollster.cs
+++ b/Common/src/Injection/Options/Pollster.cs
@@ -67,4 +67,10 @@ public class Pollster
   ///   Internal cache for data
   /// </summary>
   public string InternalCacheFolder { get; set; } = "/cache/internal";
+
+  /// <summary>
+  ///   When a message is detected to be duplicated during the acquisition,
+  ///   delays the message release to the queue.
+  /// </summary>
+  public TimeSpan MessageDuplicationDelay { get; set; } = TimeSpan.FromMinutes(2);
 }

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -804,7 +804,7 @@ public class TaskHandlerTest
                                     },
                                     true).Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsProcessingElsewhere,
                                                                         TaskStatus.Processing,
-                                                                        QueueMessageStatus.Processed))
+                                                                        QueueMessageStatus.Postponed))
                                          .SetArgDisplayNames("Processing task on another agent check true");
 
       yield return new TestCaseData(taskData with
@@ -813,7 +813,7 @@ public class TaskHandlerTest
                                     },
                                     true).Returns(new AcquireTaskReturn(AcquisitionStatus.TaskIsProcessingHere,
                                                                         TaskStatus.Processing,
-                                                                        QueueMessageStatus.Processed))
+                                                                        QueueMessageStatus.Postponed))
                                          .SetArgDisplayNames("Processing task same agent");
 
       // 12 is already tested
@@ -846,7 +846,7 @@ public class TaskHandlerTest
                                     },
                                     true).Returns(new AcquireTaskReturn(AcquisitionStatus.AcquisitionFailedMessageDuplicated,
                                                                         TaskStatus.Submitted,
-                                                                        QueueMessageStatus.Processed))
+                                                                        QueueMessageStatus.Postponed))
                                          .SetArgDisplayNames("Submitted task with another owner");
 
       yield return new TestCaseData(taskData with
@@ -856,7 +856,7 @@ public class TaskHandlerTest
                                     },
                                     true).Returns(new AcquireTaskReturn(AcquisitionStatus.AcquisitionFailedMessageDuplicated,
                                                                         TaskStatus.Dispatched,
-                                                                        QueueMessageStatus.Processed))
+                                                                        QueueMessageStatus.Postponed))
                                          .SetArgDisplayNames("Dispatched different owner");
 
       yield return new TestCaseData(taskData with
@@ -866,7 +866,7 @@ public class TaskHandlerTest
                                     },
                                     false).Returns(new AcquireTaskReturn(AcquisitionStatus.AcquisitionFailedMessageDuplicated,
                                                                          TaskStatus.Retried,
-                                                                         QueueMessageStatus.Processed))
+                                                                         QueueMessageStatus.Postponed))
                                           .SetArgDisplayNames("Dispatched different owner false check");
 
       yield return new TestCaseData(taskData with
@@ -877,7 +877,7 @@ public class TaskHandlerTest
                                     },
                                     false).Returns(new AcquireTaskReturn(AcquisitionStatus.AcquisitionFailedMessageDuplicated,
                                                                          TaskStatus.Retried,
-                                                                         QueueMessageStatus.Processed))
+                                                                         QueueMessageStatus.Postponed))
                                           .SetArgDisplayNames("Dispatched different owner false check date before");
 
       yield return new TestCaseData(taskData with
@@ -886,7 +886,7 @@ public class TaskHandlerTest
                                     },
                                     true).Returns(new AcquireTaskReturn(AcquisitionStatus.AcquisitionFailedProcessingHere,
                                                                         TaskStatus.Submitted,
-                                                                        QueueMessageStatus.Processed))
+                                                                        QueueMessageStatus.Postponed))
                                          .SetArgDisplayNames("Submitted task with same owner");
 
 

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -39,7 +39,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -199,22 +198,9 @@ public static class Program
                           });
 
       app.MapGet("/taskprocessing",
-                 async () =>
-                 {
-                   var pollster  = app.Services.GetRequiredService<Common.Pollster.Pollster>();
-                   var exManager = app.Services.GetRequiredService<ExceptionManager>();
-
-                   var check = await pollster.Check(HealthCheckTag.Liveness)
-                                             .ConfigureAwait(false);
-
-                   if (check.Status == HealthStatus.Unhealthy || exManager.LateCancellationToken.IsCancellationRequested)
-                   {
-                     return "";
-                   }
-
-                   return string.Join(",",
-                                      pollster.TaskProcessing);
-                 });
+                 () => string.Join(",",
+                                   app.Services.GetRequiredService<Common.Pollster.Pollster>()
+                                      .TaskProcessing));
 
       app.MapGet("/stopcancelledtask",
                  () => app.Services.GetRequiredService<Common.Pollster.Pollster>()


### PR DESCRIPTION
# Motivation

During task acquisition, if the agent detects that the task is processing elsewhere, it acknowledges the message with the reasonning that the other is still healthy and processing it. However, there are cases that we failed to detect where the other responds, but might crash at some point afterwards, leading to message loss.

# Description

Instead of acknowledging the message, we postpone it (release to the queue), but with a delay. After the delay, the message is released to the queue and another pod will try to acquire the task, and check again the current pod.
As a consequence, we check the status of the task on the pod at a regular interval until it either completes, or crashes/times out.

# Impact

This should avoid all message loss related to message duplication, transient queue failure, and the race conditions that could follow.
Performance impact should be rather low thanks to the delay (by default 2 minutes).

If a pod crashes during its delay, the message will be available in the queue, thus avoiding message loss.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
