### PR TITLE
fix: Check session status before checking task status

### DIFF
--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -581,7 +581,7 @@ public class TaskHandlerTest
     var acquired = await testServiceProvider.TaskHandler.AcquireTask()
                                             .ConfigureAwait(false);
 
-    Assert.AreEqual(AcquisitionStatus.TaskIsCancelling,
+    Assert.AreEqual(AcquisitionStatus.SessionNotExecutable,
                     acquired);
     Assert.AreEqual(taskId,
                     testServiceProvider.TaskHandler.GetAcquiredTaskInfo()


### PR DESCRIPTION
# Motivation

If a task is pending and the session is closed, the task is requeued indefinitely because the check of the session status is done after the check of the task status.

# Description

Check the session status before checking the task status.

# Impact

There should be no impact on regular workloads, and avoid infinite loops on buggy workloads.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
