### PR TITLE
fix: Properly handle cancellation in worker RPC

### DIFF
--- a/Common/src/HealthCheckRecord.cs
+++ b/Common/src/HealthCheckRecord.cs
@@ -1,0 +1,87 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base.DataStructures;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ArmoniK.Core.Common;
+
+/// <summary>
+///   Records the health check results to be retrieved at any time by other components of the application.
+/// </summary>
+public class HealthCheckRecord
+{
+  private readonly Dictionary<HealthCheckTag, HealthReport> records_ = new();
+
+  /// <summary>
+  ///   Records a HealthCheckResult.
+  /// </summary>
+  /// <param name="tag">The type of health check to record.</param>
+  /// <param name="report">The result of the health check.</param>
+  public void Record(HealthCheckTag tag,
+                     HealthReport   report)
+    => records_[tag] = report;
+
+  /// <summary>
+  ///   Retrieves the last HealthCheckResult.
+  /// </summary>
+  /// <param name="tag">The type of health check.</param>
+  /// <returns>The result of the health check.</returns>
+  public HealthReport LastCheck(HealthCheckTag tag = HealthCheckTag.Liveness)
+  {
+    if (records_.TryGetValue(tag,
+                             out var report))
+    {
+      return report;
+    }
+
+    return new HealthReport(new Dictionary<string, HealthReportEntry>(),
+                            HealthStatus.Unhealthy,
+                            TimeSpan.Zero);
+  }
+
+  public class Publisher(HealthCheckRecord healthCheckRecord) : IHealthCheckPublisher
+  {
+    /// <inheritdoc />
+    public Task PublishAsync(HealthReport      report,
+                             CancellationToken cancellationToken)
+    {
+      var tags = report.Entries.SelectMany(entry => entry.Value.Tags)
+                       .ToHashSet();
+
+      foreach (var tag in Enum.GetValues<HealthCheckTag>())
+      {
+        if (tags.Contains(tag.ToString()))
+        {
+          healthCheckRecord.Record(tag,
+                                   new HealthReport(report.Entries.Where(kv => kv.Value.Tags.Contains(tag.ToString()))
+                                                          .ToDictionary(),
+                                                    report.TotalDuration));
+        }
+      }
+
+      return Task.CompletedTask;
+    }
+  }
+}

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -1015,7 +1015,7 @@ public sealed class TaskHandler : IAsyncDisposable
                   };
       await HandleErrorResubmitAsync(e,
                                      taskData_,
-                                     earlyCts_.Token)
+                                     lateCts_.Token)
         .ConfigureAwait(false);
     }
   }
@@ -1122,7 +1122,10 @@ public sealed class TaskHandler : IAsyncDisposable
     {
       messageHandler_.Status = QueueMessageStatus.Processed;
     }
-    else if (cancellationToken.IsCancellationRequested && e is OperationCanceledException)
+    else if (cancellationToken.IsCancellationRequested && e is OperationCanceledException or RpcException
+                                                                                             {
+                                                                                               InnerException: OperationCanceledException,
+                                                                                             })
     {
       logger_.LogWarning(e,
                          "Cancellation triggered, task cancelled here and re executed elsewhere");

--- a/Common/tests/HealCheckRecordExt.cs
+++ b/Common/tests/HealCheckRecordExt.cs
@@ -1,0 +1,44 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+
+using ArmoniK.Core.Base.DataStructures;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace ArmoniK.Core.Common.Tests;
+
+public static class HealCheckRecordExt
+{
+  public static void Record(this HealthCheckRecord record,
+                            HealthCheckTag         tag,
+                            HealthStatus           status)
+    => record.Record(tag,
+                     new HealthReport(new Dictionary<string, HealthReportEntry>
+                                      {
+                                        {
+                                          "test", new HealthReportEntry(status,
+                                                                        "test",
+                                                                        TimeSpan.Zero,
+                                                                        null,
+                                                                        null)
+                                        },
+                                      },
+                                      TimeSpan.Zero));
+}

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -27,6 +27,7 @@ using ArmoniK.Api.Common.Options;
 using ArmoniK.Core.Adapters.Memory;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -41,6 +42,7 @@ using EphemeralMongo;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -64,6 +66,7 @@ public class TestPollsterProvider : IDisposable
   public readonly ExceptionManager ExceptionManager;
 
   private readonly TimeSpan?                graceDelay_;
+  public readonly  HealthCheckRecord        HealthCheckRecord;
   public readonly  IHostApplicationLifetime Lifetime;
   private readonly IObjectStorage           objectStorage_;
   public readonly  IPartitionTable          PartitionTable;
@@ -205,15 +208,19 @@ public class TestPollsterProvider : IDisposable
     app_ = builder.Build();
     app_.Start();
 
-    ResultTable      = app_.Services.GetRequiredService<IResultTable>();
-    TaskTable        = app_.Services.GetRequiredService<ITaskTable>();
-    PartitionTable   = app_.Services.GetRequiredService<IPartitionTable>();
-    SessionTable     = app_.Services.GetRequiredService<ISessionTable>();
-    Submitter        = app_.Services.GetRequiredService<ISubmitter>();
-    Pollster         = app_.Services.GetRequiredService<Common.Pollster.Pollster>();
-    objectStorage_   = app_.Services.GetRequiredService<IObjectStorage>();
-    ExceptionManager = app_.Services.GetRequiredService<ExceptionManager>();
-    Lifetime         = app_.Lifetime;
+    ResultTable       = app_.Services.GetRequiredService<IResultTable>();
+    TaskTable         = app_.Services.GetRequiredService<ITaskTable>();
+    PartitionTable    = app_.Services.GetRequiredService<IPartitionTable>();
+    SessionTable      = app_.Services.GetRequiredService<ISessionTable>();
+    Submitter         = app_.Services.GetRequiredService<ISubmitter>();
+    Pollster          = app_.Services.GetRequiredService<Common.Pollster.Pollster>();
+    objectStorage_    = app_.Services.GetRequiredService<IObjectStorage>();
+    ExceptionManager  = app_.Services.GetRequiredService<ExceptionManager>();
+    HealthCheckRecord = app_.Services.GetRequiredService<HealthCheckRecord>();
+    Lifetime          = app_.Lifetime;
+
+    HealthCheckRecord.Record(HealthCheckTag.Liveness,
+                             HealthStatus.Healthy);
 
     ResultTable.Init(CancellationToken.None)
                .Wait();

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -194,6 +194,7 @@ public class TestPollsterProvider : IDisposable
            .AddSingleton<MeterHolder>()
            .AddSingleton<AgentIdentifier>()
            .AddScoped(typeof(FunctionExecutionMetrics<>))
+           .AddSingleton<HealthCheckRecord>()
            .AddSingleton(workerStreamHandler)
            .AddSingleton(agentHandler)
            .AddSingleton(pullQueueStorage);

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -25,6 +25,7 @@ using ArmoniK.Api.Common.Options;
 using ArmoniK.Core.Adapters.Memory;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -39,6 +40,7 @@ using EphemeralMongo;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -54,6 +56,7 @@ public class TestTaskHandlerProvider : IDisposable
   private static readonly ActivitySource    ActivitySource = new("ArmoniK.Core.Common.Tests.TestTaskHandlerProvider");
   private readonly        WebApplication    app_;
   private readonly        IMongoClient      client_;
+  public readonly         HealthCheckRecord HealthCheckRecord;
   public readonly         ILogger           Logger;
   private readonly        LoggerFactory     loggerFactory_;
   private readonly        IObjectStorage    objectStorage_;
@@ -221,15 +224,19 @@ public class TestTaskHandlerProvider : IDisposable
 
     app_ = builder.Build();
 
-    ResultTable      = app_.Services.GetRequiredService<IResultTable>();
-    TaskTable        = app_.Services.GetRequiredService<ITaskTable>();
-    PartitionTable   = app_.Services.GetRequiredService<IPartitionTable>();
-    SessionTable     = app_.Services.GetRequiredService<ISessionTable>();
-    Submitter        = app_.Services.GetRequiredService<ISubmitter>();
-    TaskHandler      = app_.Services.GetRequiredService<TaskHandler>();
-    Lifetime         = app_.Services.GetRequiredService<IHostApplicationLifetime>();
-    objectStorage_   = app_.Services.GetRequiredService<IObjectStorage>();
-    PushQueueStorage = app_.Services.GetRequiredService<IPushQueueStorage>();
+    ResultTable       = app_.Services.GetRequiredService<IResultTable>();
+    TaskTable         = app_.Services.GetRequiredService<ITaskTable>();
+    PartitionTable    = app_.Services.GetRequiredService<IPartitionTable>();
+    SessionTable      = app_.Services.GetRequiredService<ISessionTable>();
+    Submitter         = app_.Services.GetRequiredService<ISubmitter>();
+    TaskHandler       = app_.Services.GetRequiredService<TaskHandler>();
+    Lifetime          = app_.Services.GetRequiredService<IHostApplicationLifetime>();
+    objectStorage_    = app_.Services.GetRequiredService<IObjectStorage>();
+    PushQueueStorage  = app_.Services.GetRequiredService<IPushQueueStorage>();
+    HealthCheckRecord = app_.Services.GetRequiredService<HealthCheckRecord>();
+
+    HealthCheckRecord.Record(HealthCheckTag.Liveness,
+                             HealthStatus.Healthy);
 
     ResultTable.Init(CancellationToken.None)
                .Wait();

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -169,6 +169,7 @@ public class TestTaskHandlerProvider : IDisposable
            .AddSingleton<ExceptionManager.Options>()
            .AddSingleton<ExceptionManager>()
            .AddScoped(typeof(FunctionExecutionMetrics<>))
+           .AddSingleton<HealthCheckRecord>()
            .AddSingleton(provider => new TaskHandler(provider.GetRequiredService<ISessionTable>(),
                                                      provider.GetRequiredService<ITaskTable>(),
                                                      provider.GetRequiredService<IResultTable>(),
@@ -187,7 +188,8 @@ public class TestTaskHandlerProvider : IDisposable
                                                      {
                                                      },
                                                      provider.GetRequiredService<ExceptionManager>(),
-                                                     provider.GetRequiredService<FunctionExecutionMetrics<TaskHandler>>()))
+                                                     provider.GetRequiredService<FunctionExecutionMetrics<TaskHandler>>(),
+                                                     provider.GetRequiredService<HealthCheckRecord>()))
            .AddSingleton<DataPrefetcher>();
 
     if (taskProcessingChecker is not null)

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Common;
 using ArmoniK.Core.Common.DynamicLoading;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Injection;
@@ -39,6 +40,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -111,6 +113,8 @@ public static class Program
              .AddSingleton(new ExceptionManager.Options(pollsterOptions.GraceDelay,
                                                         pollsterOptions.MaxErrorAllowed))
              .AddSingleton<ExceptionManager>()
+             .AddSingleton<HealthCheckRecord>()
+             .AddSingleton<IHealthCheckPublisher, HealthCheckRecord.Publisher>()
              .AddSingleton<IAgentHandler, AgentHandler>()
              .AddSingleton<DataPrefetcher>()
              .AddSingleton<MeterHolder>()


### PR DESCRIPTION
# Motivation

When a cancellation is triggered during a RPC, the RPC throws a `RpcException` instead of an `OperationCanceledException` as expected. Consequently, tasks were retried when the agent was shutting down instead of just being requeued.

# Description

The check to know whether we are stopping the agent now also checks `RpcException` when the `InnerException` is an `OperationCanceledException`. It also uses the correct cancellationToken to verify.

# Testing

This has been tested locally, and a Unit test has been added to ensure both `OperationCanceledException` and `RpcException` are detected.

# Impact

During scale-down, tasks will now just be requeued without incrementing the retry counter. This will avoid task errors just for being retried too many times while being retried on scaling down pods.

# Additional information

If a task somehow makes the pod unhealthy without generating any direct error, this change might make it retry indefinitely.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
