### PR TITLE
refactor: Add S3 implicit retry

### DIFF
--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -48,6 +48,16 @@ public class S3
   public bool UseChecksum { get; set; } = true;
 
   /// <summary>
+  ///   Number of retry in case of a connection error
+  /// </summary>
+  public int MaxRetry { get; set; } = 5;
+
+  /// <summary>
+  ///   Delay in milliseconds after an error
+  /// </summary>
+  public int MsAfterRetry { get; set; } = 500;
+
+  /// <summary>
   ///   Get a copy of the options with confidential fields removed
   /// </summary>
   /// <returns>Confidential copy</returns>


### PR DESCRIPTION
# Motivation

When there is a connectivity issue when downloading an S3 object, the whole task is retried.

# Description

Add a retry mechanism within the S3 plugin itself to limit the number of task retry consumed in case of connectivity error.

# Impact

This makes transient network errors transparent. It also reduce the latency of S3 downloading as it avoids a few requests.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
