### PR TITLE
fix: Check dependencies at the end of submission

### DIFF
--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -287,7 +287,7 @@ public class TaskTable : ITaskTable
     return taskId2TaskData_.AsQueryable()
                            .Select(pair => pair.Value)
                            .Where(data => taskIds.Contains(data.TaskId) && (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
-                                          data.RemainingDataDependencies == new Dictionary<string, bool>())
+                                          data.RemainingDataDependencies.Count == 0)
                            .Select(selector)
                            .ToAsyncEnumerable();
   }

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -118,9 +118,9 @@ public class ResultTable : IResultTable
                                                             cancellationToken)
                                             .ConfigureAwait(false);
 
-    if (writeResult.ModifiedCount != dependencies.Count)
+    if (writeResult.MatchedCount != dependencies.Count)
     {
-      throw new ResultNotFoundException($"One of the input result was not found: expected: {dependencies.Count}, found: {writeResult.ModifiedCount}");
+      throw new ResultNotFoundException($"One of the input result was not found: expected: {dependencies.Count}, found: {writeResult.MatchedCount}");
     }
   }
 

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -20,6 +20,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -106,7 +107,7 @@ public class TaskTable : ITaskTable
                                      .Project(selector)
                                      .SingleAsync(cancellationToken)
                                      .ConfigureAwait(false);
-      Logger.LogDebug("Read {id} matching {condition} returns {task}",
+      Logger.LogDebug("Read {id} matching {condition} returns {@task}",
                       taskId,
                       selector,
                       task);
@@ -355,11 +356,13 @@ public class TaskTable : ITaskTable
   }
 
   /// <inheritdoc />
-  public async Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskIds,
-                                                         ICollection<string> dependenciesToRemove,
-                                                         CancellationToken   cancellationToken = default)
+  public async IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>                        taskIds,
+                                                                           ICollection<string>                        dependenciesToRemove,
+                                                                           Expression<Func<TaskData, T>>              selector,
+                                                                           [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
     using var activity       = activitySource_.StartActivity($"{nameof(RemoveRemainingDataDependenciesAsync)}");
+    var       sessionHandle  = sessionProvider_.Get();
     var       taskCollection = taskCollectionProvider_.Get();
 
     // MongoDB driver does not support to unset a list, so Unset should be called multiple times.
@@ -368,7 +371,7 @@ public class TaskTable : ITaskTable
     using var deps = dependenciesToRemove.GetEnumerator();
     if (!deps.MoveNext())
     {
-      return;
+      yield break;
     }
 
 
@@ -384,10 +387,22 @@ public class TaskTable : ITaskTable
                     dependenciesToRemove,
                     taskIds);
 
-    await taskCollection.UpdateManyAsync(data => taskIds.Contains(data.TaskId),
+    await taskCollection.UpdateManyAsync(sessionHandle,
+                                         data => taskIds.Contains(data.TaskId),
                                          update,
                                          cancellationToken: cancellationToken)
                         .ConfigureAwait(false);
+
+    var readyTasks = taskCollection.Find(sessionHandle,
+                                         data => taskIds.Contains(data.TaskId) && (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
+                                                 data.RemainingDataDependencies == new Dictionary<string, bool>())
+                                   .Project(selector)
+                                   .ToAsyncEnumerable(cancellationToken);
+
+    await foreach (var task in readyTasks.ConfigureAwait(false))
+    {
+      yield return task;
+    }
   }
 
   /// <inheritdoc />

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -243,15 +243,17 @@ public interface ITaskTable : IInitializable
 
 
   /// <summary>
-  ///   Remove data dependencies from remaining data dependencies
+  ///   Remove data dependencies from remaining data dependencies, and returns tasks that are ready
   /// </summary>
   /// <param name="taskIds">Tasks</param>
   /// <param name="dependenciesToRemove">Dependencies</param>
+  /// <param name="selector">Expression to select part of the returned task data</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
-  ///   Task representing the asynchronous execution of the method
+  ///   Projected tasks that are ready after the dependencies removal
   /// </returns>
-  Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskIds,
-                                            ICollection<string> dependenciesToRemove,
-                                            CancellationToken   cancellationToken = default);
+  IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>           taskIds,
+                                                              ICollection<string>           dependenciesToRemove,
+                                                              Expression<Func<TaskData, T>> selector,
+                                                              CancellationToken             cancellationToken = default);
 }

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -380,14 +380,15 @@ public static class TaskLifeCycleHelper
     // If the agent completes the dependencies _before_ the GetResults, both will try to remove it,
     // and both will queue the task.
     // This is benign as it will be handled during dequeue with message deduplication.
-    return await taskTable.RemoveRemainingDataDependenciesAsync(taskDependencies.Keys,
-                                                                completedDependencies,
-                                                                data => new MessageData(data.TaskId,
-                                                                                        data.SessionId,
-                                                                                        data.Options),
-                                                                cancellationToken)
-                          .ToListAsync(cancellationToken)
-                          .ConfigureAwait(false);
+    var x = await taskTable.RemoveRemainingDataDependenciesAsync(taskDependencies.Keys,
+                                                                 completedDependencies,
+                                                                 data => new MessageData(data.TaskId,
+                                                                                         data.SessionId,
+                                                                                         data.Options),
+                                                                 cancellationToken)
+                           .ToListAsync(cancellationToken)
+                           .ConfigureAwait(false);
+    return x;
   }
 
   /// <summary>

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -153,27 +153,27 @@ public class SimpleTaskTable : ITaskTable
                                                Expression<Func<TaskData, T>>    selector,
                                                CancellationToken                cancellationToken = default)
     => new List<TaskData>
-      {
-        new(SessionId,
-            TaskId,
-            OwnerPodId,
-            PodName,
-            PayloadId,
-            CreatedBy,
-            new List<string>(),
-            new List<string>(),
-            new List<string>
-            {
-              OutputId,
-            },
-            new List<string>(),
-            TaskStatus.Completed,
-            TaskOptions,
-            new Output(OutputStatus.Success,
-                       "")),
-      }.Where(filter.Compile())
-       .Select(selector.Compile())
-       .ToAsyncEnumerable();
+       {
+         new(SessionId,
+             TaskId,
+             OwnerPodId,
+             PodName,
+             PayloadId,
+             CreatedBy,
+             new List<string>(),
+             new List<string>(),
+             new List<string>
+             {
+               OutputId,
+             },
+             new List<string>(),
+             TaskStatus.Completed,
+             TaskOptions,
+             new Output(OutputStatus.Success,
+                        "")),
+       }.Where(filter.Compile())
+        .Select(selector.Compile())
+        .ToAsyncEnumerable();
 
   public Task<long> UpdateManyTasks(Expression<Func<TaskData, bool>> filter,
                                     UpdateDefinition<TaskData>       updates,

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -153,27 +153,27 @@ public class SimpleTaskTable : ITaskTable
                                                Expression<Func<TaskData, T>>    selector,
                                                CancellationToken                cancellationToken = default)
     => new List<TaskData>
-       {
-         new(SessionId,
-             TaskId,
-             OwnerPodId,
-             PodName,
-             PayloadId,
-             CreatedBy,
-             new List<string>(),
-             new List<string>(),
-             new List<string>
-             {
-               OutputId,
-             },
-             new List<string>(),
-             TaskStatus.Completed,
-             TaskOptions,
-             new Output(OutputStatus.Success,
-                        "")),
-       }.Where(filter.Compile())
-        .Select(selector.Compile())
-        .ToAsyncEnumerable();
+      {
+        new(SessionId,
+            TaskId,
+            OwnerPodId,
+            PodName,
+            PayloadId,
+            CreatedBy,
+            new List<string>(),
+            new List<string>(),
+            new List<string>
+            {
+              OutputId,
+            },
+            new List<string>(),
+            TaskStatus.Completed,
+            TaskOptions,
+            new Output(OutputStatus.Success,
+                       "")),
+      }.Where(filter.Compile())
+       .Select(selector.Compile())
+       .ToAsyncEnumerable();
 
   public Task<long> UpdateManyTasks(Expression<Func<TaskData, bool>> filter,
                                     UpdateDefinition<TaskData>       updates,
@@ -194,10 +194,11 @@ public class SimpleTaskTable : ITaskTable
                                                                                                    TaskOptions.ApplicationService),
                                                                                  }, 1));
 
-  public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
-                                                   ICollection<string> dependenciesToRemove,
-                                                   CancellationToken   cancellationToken = default)
-    => Task.CompletedTask;
+  public IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>           taskIds,
+                                                                     ICollection<string>           dependenciesToRemove,
+                                                                     Expression<Func<TaskData, T>> selector,
+                                                                     CancellationToken             cancellationToken = default)
+    => AsyncEnumerable.Empty<T>();
 
   public Task<TaskData?> UpdateOneTask(string                            taskId,
                                        Expression<Func<TaskData, bool>>? filter,

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -390,43 +390,53 @@ public class TaskHandlerTest
     var tasks = new List<TaskCreationRequest>
                 {
                   new("TaskRetry2",
-                      results[0].ResultId,
+                      results[0]
+                        .ResultId,
                       options,
                       new List<string>
                       {
-                        results[1].ResultId,
+                        results[1]
+                          .ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+Creating",
-                      results[0].ResultId,
+                      results[0]
+                        .ResultId,
                       options,
                       new List<string>
                       {
-                        results[1].ResultId,
+                        results[1]
+                          .ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+Submitted",
-                      results[0].ResultId,
+                      results[0]
+                        .ResultId,
                       options,
                       new List<string>
                       {
-                        results[1].ResultId,
+                        results[1]
+                          .ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+NotFound",
-                      results[0].ResultId,
+                      results[0]
+                        .ResultId,
                       options,
                       new List<string>
                       {
-                        results[1].ResultId,
+                        results[1]
+                          .ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+Pending",
-                      results[0].ResultId,
+                      results[0]
+                        .ResultId,
                       options,
                       new List<string>
                       {
-                        results[1].ResultId,
+                        results[1]
+                          .ResultId,
                       },
                       new List<string>()),
                 };
@@ -1293,10 +1303,10 @@ public class TaskHandlerTest
                        cancellationToken)
                 .ConfigureAwait(false);
       var enumerable = new[]
-        {
-          sessionData_!,
-        }.Select(selector.Compile())
-         .ToAsyncEnumerable();
+                       {
+                         sessionData_!,
+                       }.Select(selector.Compile())
+                        .ToAsyncEnumerable();
 
       await foreach (var d in enumerable.ConfigureAwait(false))
       {

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -390,53 +390,43 @@ public class TaskHandlerTest
     var tasks = new List<TaskCreationRequest>
                 {
                   new("TaskRetry2",
-                      results[0]
-                        .ResultId,
+                      results[0].ResultId,
                       options,
                       new List<string>
                       {
-                        results[1]
-                          .ResultId,
+                        results[1].ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+Creating",
-                      results[0]
-                        .ResultId,
+                      results[0].ResultId,
                       options,
                       new List<string>
                       {
-                        results[1]
-                          .ResultId,
+                        results[1].ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+Submitted",
-                      results[0]
-                        .ResultId,
+                      results[0].ResultId,
                       options,
                       new List<string>
                       {
-                        results[1]
-                          .ResultId,
+                        results[1].ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+NotFound",
-                      results[0]
-                        .ResultId,
+                      results[0].ResultId,
                       options,
                       new List<string>
                       {
-                        results[1]
-                          .ResultId,
+                        results[1].ResultId,
                       },
                       new List<string>()),
                   new("TaskRetry2+Pending",
-                      results[0]
-                        .ResultId,
+                      results[0].ResultId,
                       options,
                       new List<string>
                       {
-                        results[1]
-                          .ResultId,
+                        results[1].ResultId,
                       },
                       new List<string>()),
                 };
@@ -1248,10 +1238,11 @@ public class TaskHandlerTest
                                                                                                CancellationToken cancellationToken = default)
       => throw new NotImplementedException();
 
-    public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
-                                                     ICollection<string> dependenciesToRemove,
-                                                     CancellationToken   cancellationToken = default)
-      => Task.CompletedTask;
+    public IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>           taskIds,
+                                                                       ICollection<string>           dependenciesToRemove,
+                                                                       Expression<Func<TaskData, T>> selector,
+                                                                       CancellationToken             cancellationToken = default)
+      => AsyncEnumerable.Empty<T>();
   }
 
   public class WaitSessionTable : ISessionTable
@@ -1302,10 +1293,10 @@ public class TaskHandlerTest
                        cancellationToken)
                 .ConfigureAwait(false);
       var enumerable = new[]
-                       {
-                         sessionData_!,
-                       }.Select(selector.Compile())
-                        .ToAsyncEnumerable();
+        {
+          sessionData_!,
+        }.Select(selector.Compile())
+         .ToAsyncEnumerable();
 
       await foreach (var d in enumerable.ConfigureAwait(false))
       {

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -915,9 +915,10 @@ internal class IntegrationGrpcSubmitterServiceTest
                                                                                                CancellationToken cancellationToken = default)
       => throw new T();
 
-    public Task RemoveRemainingDataDependenciesAsync(ICollection<string> taskId,
-                                                     ICollection<string> dependenciesToRemove,
-                                                     CancellationToken   cancellationToken = default)
+    public IAsyncEnumerable<TData> RemoveRemainingDataDependenciesAsync<TData>(ICollection<string>               taskIds,
+                                                                               ICollection<string>               dependenciesToRemove,
+                                                                               Expression<Func<TaskData, TData>> selector,
+                                                                               CancellationToken                 cancellationToken = default)
       => throw new T();
   }
 

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -2185,24 +2185,35 @@ public class TaskTableTestBase
                                    })
                       .ConfigureAwait(false);
 
-      await TaskTable.RemoveRemainingDataDependenciesAsync(new[]
-                                                           {
-                                                             taskId,
-                                                           },
-                                                           new[]
-                                                           {
-                                                             dd1,
-                                                             dd2,
-                                                             "PayloadId",
-                                                           },
-                                                           CancellationToken.None)
-                     .ConfigureAwait(false);
+      var readyTasks = await TaskTable.RemoveRemainingDataDependenciesAsync(new[]
+                                                                            {
+                                                                              taskId,
+                                                                            },
+                                                                            new[]
+                                                                            {
+                                                                              dd1,
+                                                                              dd2,
+                                                                              "PayloadId",
+                                                                            },
+                                                                            td => td.TaskId,
+                                                                            CancellationToken.None)
+                                      .ToListAsync(CancellationToken.None)
+                                      .ConfigureAwait(false);
 
       var taskData = await TaskTable.ReadTaskAsync(taskId,
                                                    CancellationToken.None)
                                     .ConfigureAwait(false);
 
-      Assert.IsEmpty(taskData.RemainingDataDependencies);
+      Assert.Multiple(() =>
+                      {
+                        Assert.That(readyTasks,
+                                    Is.EquivalentTo(new[]
+                                                    {
+                                                      taskId,
+                                                    }));
+                        Assert.That(taskData.RemainingDataDependencies,
+                                    Is.Empty);
+                      });
     }
   }
 
@@ -2241,24 +2252,37 @@ public class TaskTableTestBase
                                    })
                       .ConfigureAwait(false);
 
-      await TaskTable.RemoveRemainingDataDependenciesAsync(new[]
-                                                           {
-                                                             taskId,
-                                                           },
-                                                           new[]
-                                                           {
-                                                             "PayloadId",
-                                                             dd1,
-                                                           },
-                                                           CancellationToken.None)
-                     .ConfigureAwait(false);
+      var readyTasks = await TaskTable.RemoveRemainingDataDependenciesAsync(new[]
+                                                                            {
+                                                                              taskId,
+                                                                            },
+                                                                            new[]
+                                                                            {
+                                                                              "PayloadId",
+                                                                              dd1,
+                                                                            },
+                                                                            td => td.TaskId,
+                                                                            CancellationToken.None)
+                                      .ToListAsync(CancellationToken.None)
+                                      .ConfigureAwait(false);
 
       var taskData = await TaskTable.ReadTaskAsync(taskId,
                                                    CancellationToken.None)
                                     .ConfigureAwait(false);
 
-      Assert.IsEmpty(taskData.RemainingDataDependencies);
-      Assert.IsEmpty(taskData.DataDependencies);
+      Assert.Multiple(() =>
+                      {
+                        Assert.That(readyTasks,
+                                    Is.EqualTo(new[]
+                                               {
+                                                 taskId,
+                                               }));
+
+                        Assert.That(taskData.RemainingDataDependencies,
+                                    Is.Empty);
+                        Assert.That(taskData.DataDependencies,
+                                    Is.Empty);
+                      });
     }
   }
 }


### PR DESCRIPTION
# Motivation

If a result is completed during the submission of a dependent task, the task could end-up in a state where all its dependencies are completed, but the task remains pending.

# Description

During submission, add a check of the task dependencies after the removal of completed dependencies.

# Testing

Matrix multiplication with Pymonik was failling frequently before this patch, but always finishes with it.

# Impact

As dependency resolution incurs a new DB query, it might increase the scheduling overhead and reduce total throughput achievable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
