### PR TITLE
fix: Avoid unhealthy pollster during downscaling

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -219,7 +219,7 @@ public class Pollster : IInitializable
       return healthCheckFailedResult_ ?? HealthCheckResult.Unhealthy("Health Check failed previously so this polling agent should be destroyed.");
     }
 
-    if (endLoopReached_)
+    if (endLoopReached_ && tag != HealthCheckTag.Liveness)
     {
       return HealthCheckResult.Unhealthy("End of main loop reached, no more tasks will be executed.");
     }
@@ -480,6 +480,9 @@ public class Pollster : IInitializable
     }
     catch (Exception e)
     {
+      healthCheckFailedResult_ = HealthCheckResult.Unhealthy("Error in pollster",
+                                                             e);
+
       exceptionManager_.FatalError(logger_,
                                    e,
                                    "Error in pollster: Stop the application");


### PR DESCRIPTION
# Motivation

During scale down, the Pollster becomes unhealthy because it exists the main loop. If the processing task does not finishes within the grace delay, it will be retried instead of just requeued because of this health check.

# Description

Mark the Pollster unhealthy only in the case the loop exits with an exception.

# Testing
Launch long tasks (through Bench client), and force a scale down using `kubectl scale`. Tasks are requeued properly without being retried, even when the health check happened during the grace period.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
