### PR TITLE
fix: Dispose taskHandler on acquire timeout

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -428,6 +428,9 @@ public class Pollster : IInitializable
                       // We dispose early the messages in order to avoid blocking them while not trying to acquire their corresponding tasks
                       // Disposing twice is safe as the second dispose (from the using) will just do nothing.
                       // ReSharper disable once DisposeOnUsingVariable
+                      await taskHandlerDispose.DisposeAsync()
+                                              .ConfigureAwait(false);
+                      // ReSharper disable once DisposeOnUsingVariable
                       await messagesDispose.DisposeAsync()
                                            .ConfigureAwait(false);
                       await runningTaskQueue_.WaitForReader(Timeout.InfiniteTimeSpan,


### PR DESCRIPTION
# Motivation

If too many acquire timeouts happen during the processing of a single task, the currently acquired task will be marked for release, but the release will be effective only once the task handler is disposed, which happens *after* the processing task has finished.
This blocks the task message in the agent for no good reason.

# Description

Add task handler dispose before waiting for the next pipeline stage to be ready.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
