### PR TITLE
fix: Abort tasks on retry

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -351,8 +351,8 @@ public sealed class TaskHandler : IAsyncDisposable
                                                          {
                                                            messageHandler_.TaskId,
                                                          },
-                                                         $"Task {messageHandler_.TaskId} has been cancelled because its session {taskData_.SessionId} is {sessionData_.Status}",
-                                                         CancellationToken.None)
+                                                         reason:
+                                                         $"Task {messageHandler_.TaskId} has been cancelled because its session {taskData_.SessionId} is {sessionData_.Status}")
                                    .ConfigureAwait(false);
 
         // Propagate cancelled status to TaskHandler
@@ -390,8 +390,7 @@ public sealed class TaskHandler : IAsyncDisposable
                                                            {
                                                              messageHandler_.TaskId,
                                                            },
-                                                           $"Task {messageHandler_.TaskId} has been cancelled",
-                                                           CancellationToken.None)
+                                                           reason: $"Task {messageHandler_.TaskId} has been cancelled:\n{taskData_.Output.Error}")
                                      .ConfigureAwait(false);
 
           // Propagate cancelled status to TaskHandler
@@ -430,8 +429,7 @@ public sealed class TaskHandler : IAsyncDisposable
                                                            {
                                                              messageHandler_.TaskId,
                                                            },
-                                                           $"Task {messageHandler_.TaskId} was on error",
-                                                           CancellationToken.None)
+                                                           reason: $"Task {messageHandler_.TaskId} was on error:\n{taskData_.Output.Error}")
                                      .ConfigureAwait(false);
           return AcquisitionStatus.TaskIsError;
         case TaskStatus.Timeout:
@@ -447,8 +445,7 @@ public sealed class TaskHandler : IAsyncDisposable
                                                            {
                                                              messageHandler_.TaskId,
                                                            },
-                                                           $"Task {messageHandler_.TaskId} was cancelled",
-                                                           CancellationToken.None)
+                                                           reason: $"Task {messageHandler_.TaskId} was cancelled:\n{taskData_.Output.Error}")
                                      .ConfigureAwait(false);
           return AcquisitionStatus.TaskIsCancelled;
         case TaskStatus.Processing:
@@ -764,8 +761,8 @@ public sealed class TaskHandler : IAsyncDisposable
                                                              {
                                                                messageHandler_.TaskId,
                                                              },
-                                                             $"Task {messageHandler_.TaskId} has been cancelled while acquired on another pod",
-                                                             CancellationToken.None)
+                                                             reason:
+                                                             $"Task {messageHandler_.TaskId} has been cancelled while acquired on another pod:\n{taskData_.Output.Error}")
                                        .ConfigureAwait(false);
             return AcquisitionStatus.AcquisitionFailedTaskCancelling;
           }

--- a/Common/src/Storage/ResultLifeCycleHelper.cs
+++ b/Common/src/Storage/ResultLifeCycleHelper.cs
@@ -40,93 +40,122 @@ public static class ResultLifeCycleHelper
   /// <param name="taskTable">Interface to manage task states</param>
   /// <param name="resultTable">Interface to manage result states</param>
   /// <param name="taskIds">Root tasks that must be aborted</param>
+  /// <param name="resultIds">Root results that must be aborted</param>
   /// <param name="reason">Abortion message</param>
+  /// <param name="status">Put aborted tasks into the given status</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>
   ///   Task representing the asynchronous execution of the method
   /// </returns>
-  public static async Task AbortTasksAndResults(ITaskTable          taskTable,
-                                                IResultTable        resultTable,
-                                                ICollection<string> taskIds,
-                                                string?             reason,
-                                                CancellationToken   cancellationToken)
+  public static async Task AbortTasksAndResults(ITaskTable           taskTable,
+                                                IResultTable         resultTable,
+                                                ICollection<string>? taskIds           = null,
+                                                ICollection<string>? resultIds         = null,
+                                                string?              reason            = null,
+                                                TaskStatus           status            = TaskStatus.Error,
+                                                CancellationToken    cancellationToken = default)
   {
-    // Early exit if no task is requested for abortion
-    if (!taskIds.Any())
+    taskIds   ??= Array.Empty<string>();
+    resultIds ??= Array.Empty<string>();
+
+    // Early exit if no abortion is actually requested
+    if (!taskIds.Any() && !resultIds.Any())
     {
       return;
     }
 
-    reason ??= $"Tasks {string.Join(", ", taskIds)} have been explicitly aborted";
-
-    taskTable.Logger.LogInformation("Abort tasks {@tasks}: {reason}",
-                                    taskIds,
-                                    reason);
-
-    // Find all metadata about the tasks that must be aborted
-    var tasks = await taskTable.FindTasksAsync(task => taskIds.Contains(task.TaskId) &&
-                                                       (task.Status == TaskStatus.Creating  || task.Status == TaskStatus.Pending || task.Status == TaskStatus.Paused ||
-                                                        task.Status == TaskStatus.Cancelled || task.Status == TaskStatus.Cancelling || task.Status == TaskStatus.Error ||
-                                                        task.Status == TaskStatus.Timeout),
-                                               task => new
-                                                       {
-                                                         task.TaskId,
-                                                         task.Status,
-                                                         task.ExpectedOutputIds,
-                                                         task.CreationDate,
-                                                         task.ProcessedDate,
-                                                         task.ReceptionDate,
-                                                       },
-                                               cancellationToken)
-                               .ToListAsync(cancellationToken)
-                               .ConfigureAwait(false);
-
-    // No eligible task for abortion
-    if (!tasks.Any())
+    if (reason is null)
     {
-      return;
+      if (taskIds.Count == 0)
+      {
+        reason = $"Results {string.Join(", ", resultIds)} have been explicitly aborted.";
+      }
+      else if (resultIds.Count == 0)
+      {
+        reason = $"Tasks {string.Join(", ", taskIds)} have been explicitly aborted";
+      }
+      else
+      {
+        reason = $"Tasks {string.Join(", ", taskIds)} and Results {string.Join(", ", resultIds)} have been explicitly aborted";
+      }
     }
 
-    // Abort all the eligible tasks
-    var now = DateTime.UtcNow;
-    await taskTable.BulkUpdateTasks(tasks.Select(task =>
-                                                 {
-                                                   Expression<Func<TaskData, bool>> filter =
-                                                     td => td.TaskId == task.TaskId && (td.Status == TaskStatus.Creating || td.Status == TaskStatus.Pending);
-                                                   var updates = new UpdateDefinition<TaskData>().Set(td => td.Status,
-                                                                                                      TaskStatus.Error)
-                                                                                                 .Set(td => td.Output,
-                                                                                                      new Output(Error: reason,
-                                                                                                                 Status: OutputStatus.Error))
-                                                                                                 .Set(td => td.EndDate,
-                                                                                                      now)
-                                                                                                 .Set(td => td.CreationToEndDuration,
-                                                                                                      now - task.CreationDate)
-                                                                                                 .Set(td => td.ProcessingToEndDuration,
-                                                                                                      now - task.ProcessedDate)
-                                                                                                 .Set(td => td.ReceivedToEndDuration,
-                                                                                                      now - task.ReceptionDate);
-                                                   return (filter, updates);
-                                                 }),
-                                    cancellationToken)
-                   .ConfigureAwait(false);
+    if (taskIds.Any())
+    {
+      taskTable.Logger.LogInformation("Abort tasks {@tasks}: {reason}",
+                                      taskIds,
+                                      reason);
 
-    // All dependent results
-    var resultIds = tasks.SelectMany(task => task.ExpectedOutputIds)
+      // Find all metadata about the tasks that must be aborted
+      var tasks = await taskTable.FindTasksAsync(task => taskIds.Contains(task.TaskId) &&
+                                                         (task.Status == TaskStatus.Creating  || task.Status == TaskStatus.Pending || task.Status == TaskStatus.Paused ||
+                                                          task.Status == TaskStatus.Cancelled || task.Status == TaskStatus.Cancelling ||
+                                                          task.Status == TaskStatus.Error     || task.Status == TaskStatus.Timeout),
+                                                 task => new
+                                                         {
+                                                           task.TaskId,
+                                                           task.Status,
+                                                           task.ExpectedOutputIds,
+                                                           task.CreationDate,
+                                                           task.ProcessedDate,
+                                                           task.ReceptionDate,
+                                                         },
+                                                 cancellationToken)
+                                 .ToListAsync(cancellationToken)
+                                 .ConfigureAwait(false);
+
+      if (tasks.Any())
+      {
+        // Abort all the eligible tasks
+        var now = DateTime.UtcNow;
+        await taskTable.BulkUpdateTasks(tasks.Select(task =>
+                                                     {
+                                                       Expression<Func<TaskData, bool>> filter =
+                                                         td => td.TaskId == task.TaskId && (td.Status == TaskStatus.Creating || td.Status == TaskStatus.Pending);
+                                                       var updates = new UpdateDefinition<TaskData>().Set(td => td.Status,
+                                                                                                          status)
+                                                                                                     .Set(td => td.Output,
+                                                                                                          new Output(Error: reason,
+                                                                                                                     Status: OutputStatus.Error))
+                                                                                                     .Set(td => td.EndDate,
+                                                                                                          now)
+                                                                                                     .Set(td => td.CreationToEndDuration,
+                                                                                                          now - task.CreationDate)
+                                                                                                     .Set(td => td.ProcessingToEndDuration,
+                                                                                                          now - task.ProcessedDate)
+                                                                                                     .Set(td => td.ReceivedToEndDuration,
+                                                                                                          now - task.ReceptionDate);
+                                                       return (filter, updates);
+                                                     }),
+                                        cancellationToken)
+                       .ConfigureAwait(false);
+
+        // All dependent results
+        resultIds = tasks.SelectMany(task => task.ExpectedOutputIds)
+                         .Concat(resultIds)
                          .ToHashSet();
+      }
+    }
+
+    // Early exit if no results need to be aborted (recursion is not needed)
+    if (!resultIds.Any())
+    {
+      return;
+    }
 
     taskTable.Logger.LogInformation("Abort results {@results}: {reason}",
                                     resultIds,
                                     reason);
 
-    var count = await resultTable
-                      .UpdateManyResults(result => resultIds.Contains(result.ResultId) && taskIds.Contains(result.OwnerTaskId) && result.Status == ResultStatus.Created,
-                                         new UpdateDefinition<Result>().Set(result => result.Status,
-                                                                            ResultStatus.Aborted)
-                                                                       .Set(result => result.CompletionDate,
-                                                                            DateTime.UtcNow),
-                                         cancellationToken)
-                      .ConfigureAwait(false);
+    var count = await resultTable.UpdateManyResults(result => resultIds.Contains(result.ResultId)                                                &&
+                                                              (taskIds.Contains(result.OwnerTaskId) || string.IsNullOrEmpty(result.OwnerTaskId)) &&
+                                                              result.Status == ResultStatus.Created,
+                                                    new UpdateDefinition<Result>().Set(result => result.Status,
+                                                                                       ResultStatus.Aborted)
+                                                                                  .Set(result => result.CompletionDate,
+                                                                                       DateTime.UtcNow),
+                                                    cancellationToken)
+                                 .ConfigureAwait(false);
 
     // Early exit if no result has been aborted
     if (count == 0)
@@ -149,7 +178,9 @@ public static class ResultLifeCycleHelper
     await AbortTasksAndResults(taskTable,
                                resultTable,
                                nextTasks,
+                               Array.Empty<string>(),
                                reason,
+                               status,
                                cancellationToken)
       .ConfigureAwait(false);
   }

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -728,8 +728,7 @@ public static class TaskLifeCycleHelper
                                                            {
                                                              taskData.TaskId,
                                                            },
-                                                           "One of the input data is aborted.",
-                                                           CancellationToken.None)
+                                                           reason: $"Task {taskData.TaskId} failed:\n{output.Error}")
                                      .ConfigureAwait(false);
         }
 
@@ -774,8 +773,7 @@ public static class TaskLifeCycleHelper
                                                          {
                                                            taskData.TaskId,
                                                          },
-                                                         "One of the dependent tasks timed out.",
-                                                         CancellationToken.None)
+                                                         reason: $"Task {taskData.TaskId} timed-out:\n{output.Error}")
                                    .ConfigureAwait(false);
         break;
       default:
@@ -811,6 +809,8 @@ public static class TaskLifeCycleHelper
                                                                         ILogger           logger,
                                                                         CancellationToken cancellationToken)
   {
+    var retry = taskData.RetryOfIds.Count < taskData.Options.MaxRetries;
+
     logger.LogDebug("Other pod has crashed while processing {TaskId}. Wait {ProcessingCrashedDelay} to ensure crashing pod {OtherPodId} has finished what it was doing, and check subtasks status",
                     taskData.TaskId,
                     processingCrashedDelay,
@@ -947,55 +947,42 @@ public static class TaskLifeCycleHelper
     {
       // If there is no subtask or they are all in creating, we are guaranteed that no subtask has started,
       // So we can safely cancel the subtasks, and retry the current task.
-      errorMessage = "Other pod seems to have crashed, resubmitting task";
 
-      logger.LogInformation("Resubmitting task {TaskId} on another pod, and cancel subtasks",
-                            taskData.TaskId);
+      var action = retry
+                     ? "retried"
+                     : "aborted";
+      errorMessage = $"Task {taskData.TaskId} has been {action} because pod {taskData.OwnerPodId} seems to have crashed";
+
+      logger.LogInformation("{Action} task {TaskId} on another pod, and cancel subtasks",
+                            taskData.TaskId,
+                            retry
+                              ? "Retry"
+                              : "Abort");
     }
 
-    var utcNow = DateTime.UtcNow;
-
-    if (subtasks.Any())
-    {
-      var subtaskIds = subtasks.Select(td => td.TaskId)
-                               .ToList();
-
-      var message = $"Task {taskData.TaskId} has been retried because pod {taskData.OwnerPodId} seems to have crashed";
-
-      // Revert ExpectedOutputIds to current task to avoid aborting them while aborting subtasks
-      await resultTable.UpdateManyResults(td => taskData.ExpectedOutputIds.Contains(td.ResultId),
-                                          new UpdateDefinition<Result>().Set(td => td.OwnerTaskId,
-                                                                             taskData.TaskId),
-                                          cancellationToken)
-                       .ConfigureAwait(false);
-
-      // Cancel subtasks
-      // As subtasks have not been started, there is no tasks that depends on these subtasks that would need to be aborted.
-      await taskTable.UpdateManyTasks(td => subtaskIds.Contains(td.TaskId),
-                                      new UpdateDefinition<TaskData>().Set(td => td.Status,
-                                                                           TaskStatus.Cancelled)
-                                                                      .Set(td => td.EndDate,
-                                                                           utcNow)
-                                                                      .Set(td => td.Output,
-                                                                           new Output(OutputStatus.Error,
-                                                                                      message)),
-                                      cancellationToken)
-                     .ConfigureAwait(false);
-    }
-
-    // Abort all results that have been created by the current task
-    // As subtasks have not been started, there is no tasks that depends on these results that would need to be aborted.
-    await resultTable.UpdateManyResults(r => r.CreatedBy == taskData.TaskId && r.Status == ResultStatus.Created,
-                                        new UpdateDefinition<Result>().Set(r => r.Status,
-                                                                           ResultStatus.Aborted)
-                                                                      .Set(r => r.CompletionDate,
-                                                                           utcNow)
-                                                                      .Set(r => r.CompletedBy,
+    // Revert ExpectedOutputIds to current task to avoid aborting them while aborting subtasks
+    await resultTable.UpdateManyResults(td => taskData.ExpectedOutputIds.Contains(td.ResultId),
+                                        new UpdateDefinition<Result>().Set(td => td.OwnerTaskId,
                                                                            taskData.TaskId),
                                         cancellationToken)
                      .ConfigureAwait(false);
 
-    // Retry of abort the current task
+    var resultsToAbort = await resultTable.GetResults(r => r.CreatedBy == taskData.TaskId,
+                                                      r => r.ResultId,
+                                                      cancellationToken)
+                                          .ToListAsync(cancellationToken)
+                                          .ConfigureAwait(false);
+
+    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
+                                                     resultTable,
+                                                     subtasks.ViewSelect(td => td.TaskId),
+                                                     resultsToAbort,
+                                                     errorMessage,
+                                                     TaskStatus.Cancelled,
+                                                     cancellationToken)
+                               .ConfigureAwait(false);
+
+    // Retry or abort the current task
     await CompleteTaskAsync(taskTable,
                             resultTable,
                             objectStorage,
@@ -1010,7 +997,7 @@ public static class TaskLifeCycleHelper
                             cancellationToken)
       .ConfigureAwait(false);
 
-    return taskData.RetryOfIds.Count < taskData.Options.MaxRetries
+    return retry
              ? TaskStatus.Retried
              : TaskStatus.Error;
   }

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -345,8 +345,8 @@ public class GrpcTasksService : Task.TasksBase
       await ResultLifeCycleHelper.AbortTasksAndResults(taskTable_,
                                                        resultTable_,
                                                        request.TaskIds,
-                                                       $"Client requested cancellation of tasks {string.Join(", ", request.TaskIds)}",
-                                                       context.CancellationToken)
+                                                       reason: $"Client requested cancellation of tasks {string.Join(", ", request.TaskIds)}",
+                                                       cancellationToken: context.CancellationToken)
                                  .ConfigureAwait(false);
 
       return new CancelTasksResponse

--- a/Common/tests/Submitter/SubmitterTests.cs
+++ b/Common/tests/Submitter/SubmitterTests.cs
@@ -1101,7 +1101,7 @@ public class SubmitterTests
 
     Assert.AreEqual(TaskStatus.Error,
                     taskData.Status);
-    Assert.AreEqual("One of the input data is aborted.",
+    Assert.AreEqual($"Task {abortedTask} failed:\nThis error should be propagated to other tasks",
                     taskData.Output.Error);
   }
 

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -1280,7 +1280,7 @@ public class TaskLifeCycleHelperTest
                       Assert.That(outputRoot.Status,
                                   Is.EqualTo(ResultStatus.Created));
                       Assert.That(outputRoot.OwnerTaskId,
-                                  Is.EqualTo(committed || !subtask
+                                  Is.EqualTo(committed
                                                ? "B"
                                                : "root###1"));
 


### PR DESCRIPTION
# Motivation

While handling a processing task from a crashed pod, if there is no way to complete the task on behalf of the crashed pod, results created by the task were not aborted, and OwnerTaskId of ExpectedOutputKeys were not reset.

# Description

Restore the OwnerTaskId and abort all created tasks and results before retrying the task.
The implementation of AbortTasksAndResults has also been refactored to support aborting specific results in addition to tasks.
The reason messages for the abortion have also been adjusted to better reflect the actual reason.

# Impact

In case of retry after crash, there should be no more cases of pending tasks and results.
Error recovery will be a bit slower because of the additional queries.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
