### PR TITLE
refactor: Expose attributes parameter when creating SQS

### DIFF
--- a/Adaptors/SQS/src/AmazonSQSClient.cs
+++ b/Adaptors/SQS/src/AmazonSQSClient.cs
@@ -29,6 +29,7 @@ internal static class AmazonSqsClientExt
   public static async Task<string> GetOrCreateQueueUrlAsync(this AmazonSQSClient       client,
                                                             string                     queueName,
                                                             Dictionary<string, string> tags,
+                                                            Dictionary<string, string> attributes,
                                                             CancellationToken          cancellationToken)
   {
     try
@@ -41,8 +42,9 @@ internal static class AmazonSqsClientExt
     {
       return (await client.CreateQueueAsync(new CreateQueueRequest
                                             {
-                                              QueueName = queueName,
-                                              Tags      = tags,
+                                              QueueName  = queueName,
+                                              Tags       = tags,
+                                              Attributes = attributes,
                                             },
                                             cancellationToken)
                           .ConfigureAwait(false)).QueueUrl;

--- a/Adaptors/SQS/src/PullQueueStorage.cs
+++ b/Adaptors/SQS/src/PullQueueStorage.cs
@@ -121,6 +121,7 @@ internal class PullQueueStorage : IPullQueueStorage
                                              options_.PartitionId);
         queueUrls_[i] = await client_.GetOrCreateQueueUrlAsync(queueName,
                                                                options_.Tags,
+                                                               options_.Attributes,
                                                                cancellationToken)
                                      .ConfigureAwait(false);
       }

--- a/Adaptors/SQS/src/PushQueueStorage.cs
+++ b/Adaptors/SQS/src/PushQueueStorage.cs
@@ -74,6 +74,7 @@ internal class PushQueueStorage : IPushQueueStorage
                                                            var queueUrl = await cache_.GetOrCreateAsync(queueName,
                                                                                                         _ => client_.GetOrCreateQueueUrlAsync(queueName,
                                                                                                                                               options_.Tags,
+                                                                                                                                              options_.Attributes,
                                                                                                                                               cancellationToken))
                                                                                       .ConfigureAwait(false);
                                                            return (queueUrl, chunk);

--- a/Adaptors/SQS/src/SQS.cs
+++ b/Adaptors/SQS/src/SQS.cs
@@ -70,4 +70,16 @@ internal class SQS
   ///   Number of priority levels supported. Each priority level will create its own SQS topic.
   /// </summary>
   public int MaxPriority { get; set; } = 0;
+
+  /// <summary>
+  ///   Attributes of the created SQS
+  /// </summary>
+  /// <remarks>
+  ///   Attributes reference can be found in
+  ///   <a
+  ///     href="https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_CreateQueue.html#SQS-CreateQueue-request-Attributes">
+  ///     AWS documentation
+  ///   </a>
+  /// </remarks>
+  public Dictionary<string, string> Attributes { get; set; } = new();
 }


### PR DESCRIPTION
# Motivation

SQS supports many options when creating SQS queues that ArmoniK does not expose.

# Description

Expose the dictionary config to be passed when creating SQS queues.

# Testing

Deploying on AWS with attribute to set max message size to 1024 works as expected.

# Impact

Enable more customization when creating the SQS, be it SQS policy, retention, or KMS configuration.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
