### PR TITLE
fix: end application when all services have been stopped

### DIFF
--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -200,6 +200,7 @@ public class Pollster : IInitializable
                                             "Seconds",
                                             "Start time of the oldest task still processing by the Pollster",
                                             meterHolder_.Tags);
+    exceptionManager.Register();
   }
 
   /// <summary>

--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -200,7 +200,6 @@ public class Pollster : IInitializable
                                             "Seconds",
                                             "Start time of the oldest task still processing by the Pollster",
                                             meterHolder_.Tags);
-    exceptionManager.Register();
   }
 
   /// <summary>
@@ -287,6 +286,7 @@ public class Pollster : IInitializable
   {
     try
     {
+      exceptionManager_.Register();
       await Init(exceptionManager_.EarlyCancellationToken)
         .ConfigureAwait(false);
 
@@ -498,9 +498,6 @@ public class Pollster : IInitializable
                                         "Error while processing the messages from the queue");
         }
       }
-
-      exceptionManager_.Stop(logger_,
-                             "End of Pollster main loop: Stop the application");
     }
     catch (Exception e)
     {
@@ -513,6 +510,8 @@ public class Pollster : IInitializable
     }
     finally
     {
+      exceptionManager_.Stop(logger_,
+                             "End of Pollster main loop: Stop the application");
       runningTaskQueue_.CloseWriter();
       endLoopReached_ = true;
     }

--- a/Common/src/Pollster/PostProcessor.cs
+++ b/Common/src/Pollster/PostProcessor.cs
@@ -54,6 +54,7 @@ public class PostProcessor : BackgroundService
     postProcessingTaskQueue_ = postProcessingTaskQueue;
     logger_                  = logger;
     exceptionManager_        = exceptionManager;
+    exceptionManager.Register();
   }
 
   /// <inheritdoc />
@@ -99,6 +100,7 @@ public class PostProcessor : BackgroundService
       }
     }
 
-    logger_.LogWarning("End of task post processor; no more tasks will be finalized");
+    exceptionManager_.Stop(logger_,
+                           "End of task post processor; no more tasks will be finalized");
   }
 }

--- a/Common/src/Pollster/PostProcessor.cs
+++ b/Common/src/Pollster/PostProcessor.cs
@@ -54,12 +54,12 @@ public class PostProcessor : BackgroundService
     postProcessingTaskQueue_ = postProcessingTaskQueue;
     logger_                  = logger;
     exceptionManager_        = exceptionManager;
-    exceptionManager.Register();
   }
 
   /// <inheritdoc />
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
+    exceptionManager_.Register();
     await using var closeReader = new Deferrer(postProcessingTaskQueue_.CloseReader);
 
     while (!exceptionManager_.LateCancellationToken.IsCancellationRequested)

--- a/Common/src/Pollster/RunningTaskProcessor.cs
+++ b/Common/src/Pollster/RunningTaskProcessor.cs
@@ -58,12 +58,12 @@ public class RunningTaskProcessor : BackgroundService
     postProcessingTaskQueue_ = postProcessingTaskQueue;
     logger_                  = logger;
     exceptionManager_        = exceptionManager;
-    exceptionManager.Register();
   }
 
   /// <inheritdoc />
   protected override async Task ExecuteAsync(CancellationToken stoppingToken)
   {
+    exceptionManager_.Register();
     await using var closeWriter = new Deferrer(postProcessingTaskQueue_.CloseWriter);
     await using var closeReader = new Deferrer(runningTaskQueue_.CloseReader);
 

--- a/Common/src/Pollster/RunningTaskProcessor.cs
+++ b/Common/src/Pollster/RunningTaskProcessor.cs
@@ -58,6 +58,7 @@ public class RunningTaskProcessor : BackgroundService
     postProcessingTaskQueue_ = postProcessingTaskQueue;
     logger_                  = logger;
     exceptionManager_        = exceptionManager;
+    exceptionManager.Register();
   }
 
   /// <inheritdoc />
@@ -121,6 +122,7 @@ public class RunningTaskProcessor : BackgroundService
       }
     }
 
-    logger_.LogWarning("End of running task processor; no more tasks will be executed");
+    exceptionManager_.Stop(logger_,
+                           "End of running task processor; no more tasks will be executed");
   }
 }

--- a/Common/tests/ExceptionManagerTests.cs
+++ b/Common/tests/ExceptionManagerTests.cs
@@ -332,10 +332,11 @@ public class ExceptionManagerTests
     await using var d0 = lifetime_.ApplicationStarted.Register(() => events.Enqueue(0));
     await using var d1 = em.EarlyCancellationToken.Register(() => events.Enqueue(1));
     await using var d2 = lifetime_.ApplicationStopping.Register(() => events.Enqueue(2));
-    await using var d3 = lifetime_.ApplicationStopped.Register(() => events.Enqueue(3));
-    await using var d4 = em.LateCancellationToken.Register(() => events.Enqueue(4));
+    await using var d3 = em.LateCancellationToken.Register(() => events.Enqueue(3));
+    await using var d4 = lifetime_.ApplicationStopped.Register(() => events.Enqueue(4));
 
     lifetime_.NotifyStarted();
+    em.Register();
 
     await Task.Delay(10)
               .ConfigureAwait(false);
@@ -345,8 +346,8 @@ public class ExceptionManagerTests
 
     try
     {
-      await lifetime_.ApplicationStopping.AsTask()
-                     .ConfigureAwait(false);
+      await em.LateCancellationToken.AsTask()
+              .ConfigureAwait(false);
     }
     catch (OperationCanceledException)
     {


### PR DESCRIPTION
# Motivation

If there is a fatal error in the agent, all background services in the agent are stopped thanks to the ExceptionManager. Unfortunately, the application is completely stopped only when the grace delay expires, even if all the background services are all stopped.

# Description

Add an atomic counter to know if there is any remaining background service running, and stop the application once all the background services are stopped.

# Testing

This was tested by deploying a misconfigured worker and disabling agent probes. After a given amount of time, the pollster init generate a fatal error. After that, it has been verified that the agent was completely stopped immediately instead of waiting the grace delay.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
