### PR TITLE
fix: seq deploiment set correctly

### DIFF
--- a/terraform/modules/monitoring/seq/main.tf
+++ b/terraform/modules/monitoring/seq/main.tf
@@ -12,7 +12,8 @@ resource "docker_container" "seq" {
   }
 
   env = [
-    "ACCEPT_EULA=Y"
+    "ACCEPT_EULA=Y",
+    "SEQ_FIRSTRUN_NOAUTHENTICATION=true"
   ]
 
   ports {


### PR DESCRIPTION
# Description

Added an environment variable to disable Seq’s forced admin authentication on first run.

# Impact

Allows Seq to start without requiring an admin password, useful for dev/test environments.

# Checklist

* [x] Code follows project guidelines
* [x] Local testing done (Seq starts without errors)
* [x] Documentation updated if needed