### PR TITLE
chore: precise WaitTimeSecond and MaxPriority for SQS test

### DIFF
--- a/terraform/modules/storage/queue/sqs/outputs.tf
+++ b/terraform/modules/storage/queue/sqs/outputs.tf
@@ -8,6 +8,8 @@ output "generated_env_vars" {
     "SQS__Tags__deployment"                                 = "docker"
     "AWS_ACCESS_KEY_ID"                                     = "localkey"
     "AWS_SECRET_ACCESS_KEY"                                 = "localsecret"
+    "SQS__WaitTimeSeconds"                                  = "0"
+    "SQS__MaxPrioriry"                                      = "9"
   })
 }
 output "core_mounts" {


### PR DESCRIPTION
## 🔧 chore: precise WaitTimeSecond and MaxPriority for SQS test

### Motivation

Ensure test behavior is consistent and not dependent on implicit defaults when testing SQS queues.

### Description

Explicitly sets the following environment variables in the test setup:

* `SQS__MaxPriority = 9`
* `SQS__WaitTimeSeconds = 0`

These values will serve as a stable baseline for future priority queue testing.

### Testing

Tested locally to confirm no regression.
Tests continue to pass with the updated configuration.

### Impact

No impact on production or runtime behavior.
Improves clarity and prepares the test environment for upcoming SQS priority handling validations.
