### PR TITLE
chore: status is set to default for all queues

### DIFF
--- a/Adaptors/PubSub/src/QueueMessageHandler.cs
+++ b/Adaptors/PubSub/src/QueueMessageHandler.cs
@@ -52,7 +52,6 @@ internal class QueueMessageHandler : IQueueMessageHandler
     MessageId                   = message.Message.MessageId;
     TaskId                      = Encoding.UTF8.GetString(message.Message.Data.ToByteArray());
     ReceptionDateTime           = DateTime.UtcNow;
-    Status                      = QueueMessageStatus.Running;
     ackId_                      = message.AckId;
     ackDeadlinePeriod_          = ackDeadlinePeriod;
     logger_                     = logger;

--- a/Adaptors/SQS/src/QueueMessageHandler.cs
+++ b/Adaptors/SQS/src/QueueMessageHandler.cs
@@ -49,7 +49,6 @@ internal class QueueMessageHandler : IQueueMessageHandler
     MessageId          = message.MessageId;
     TaskId             = message.Body;
     ReceptionDateTime  = DateTime.UtcNow;
-    Status             = QueueMessageStatus.Running;
     client_            = client;
     queueUrl_          = queueUrl;
     receiptHandle_     = message.ReceiptHandle;


### PR DESCRIPTION
## 🔧 chore: align message status default for SQS/PubSub

### Motivation

Ensure consistency across queue adapters by standardizing the initial message status.

### Description

Sets `Status = QueueMessageStatus.Waiting` as the default for both `SQS` and `PubSub` adapters, aligning them with the behavior of other queues in the system.

### Testing

Confirmed locally that both adapters produce messages with the correct initial status.
No impact on existing functionality.

### Impact

* Improves consistency across all queue implementations
* No breaking changes
* Simplifies reasoning and maintenance around message lifecycle

### Checklist

[x] My code adheres to the coding and style guidelines of the project
[x] I have performed a self-review of my code
[x] I have commented my code, particularly in hard-to-understand areas
[x] I have thoroughly tested my modifications and added tests when necessary
[x] Tests pass locally and in the CI
[x] I have assessed the performance impact of my modifications
