### PR TITLE
fix: Consider application healthy if no health check has ran

### DIFF
--- a/Common/src/HealthCheckRecord.cs
+++ b/Common/src/HealthCheckRecord.cs
@@ -57,7 +57,7 @@ public class HealthCheckRecord
     }
 
     return new HealthReport(new Dictionary<string, HealthReportEntry>(),
-                            HealthStatus.Unhealthy,
+                            HealthStatus.Healthy,
                             TimeSpan.Zero);
   }
 

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -27,7 +27,6 @@ using ArmoniK.Api.Common.Options;
 using ArmoniK.Core.Adapters.Memory;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
-using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -42,7 +41,6 @@ using EphemeralMongo;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -221,9 +219,6 @@ public class TestPollsterProvider : IDisposable
     ExceptionManager  = app_.Services.GetRequiredService<ExceptionManager>();
     HealthCheckRecord = app_.Services.GetRequiredService<HealthCheckRecord>();
     Lifetime          = app_.Lifetime;
-
-    HealthCheckRecord.Record(HealthCheckTag.Liveness,
-                             HealthStatus.Healthy);
 
     ResultTable.Init(CancellationToken.None)
                .Wait();

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -25,7 +25,6 @@ using ArmoniK.Api.Common.Options;
 using ArmoniK.Core.Adapters.Memory;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
-using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -40,7 +39,6 @@ using EphemeralMongo;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -244,9 +242,6 @@ public class TestTaskHandlerProvider : IDisposable
     objectStorage_    = app_.Services.GetRequiredService<IObjectStorage>();
     PushQueueStorage  = app_.Services.GetRequiredService<IPushQueueStorage>();
     HealthCheckRecord = app_.Services.GetRequiredService<HealthCheckRecord>();
-
-    HealthCheckRecord.Record(HealthCheckTag.Liveness,
-                             HealthStatus.Healthy);
 
     ResultTable.Init(CancellationToken.None)
                .Wait();


### PR DESCRIPTION
# Motivation

If pod stopping is requested before the first liveness probe, the report is empty and was considered unhealthy.

# Description

HealthCheckRecord is now initialized with an empty *healthy* report.
In case the agent self destroys, the failure status of the exception manager is also checked to consider the agent unhealthy even though the last health check report was healthy.

# Testing

Unit tests continue to pass.

# Impact

It should reduce the number of false positive when downscaling too soon.
It is not a fix for the pods staying in the terminating state during the whole duration of the terminationGracePeriod of Kubernetes.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
