### PR TITLE
fix: Mark the agent unhealthy if all background services have been stopped

### DIFF
--- a/Common/src/Utils/ExceptionManager.cs
+++ b/Common/src/Utils/ExceptionManager.cs
@@ -19,9 +19,14 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
 
 using JetBrains.Annotations;
 
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -33,7 +38,7 @@ namespace ArmoniK.Core.Common.Utils;
 ///   When the application is stopped, a grace delay is in place to let
 ///   all the running services to stop properly.
 /// </summary>
-public class ExceptionManager : IDisposable
+public class ExceptionManager : IDisposable, IHealthCheckProvider
 {
   private readonly IHostApplicationLifetime applicationLifetime_;
   private readonly IList<IDisposable>       disposables_;
@@ -130,6 +135,12 @@ public class ExceptionManager : IDisposable
     earlyCts_.Cancel();
     lateCts_.Cancel();
   }
+
+  /// <inheritdoc />
+  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => Task.FromResult(lateCts_.IsCancellationRequested
+                         ? HealthCheckResult.Unhealthy()
+                         : HealthCheckResult.Healthy());
 
   /// <summary>
   ///   Record an error at the application level

--- a/Common/tests/ExceptionManagerTests.cs
+++ b/Common/tests/ExceptionManagerTests.cs
@@ -21,10 +21,12 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 
+using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.Tests.Helpers;
 using ArmoniK.Core.Common.Utils;
 using ArmoniK.Utils;
 
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -84,6 +86,10 @@ public class ExceptionManagerTests
                                         new ExceptionManager.Options(TimeSpan.FromSeconds(5),
                                                                      maxError));
 
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Healthy));
+
     Assert.That(em.EarlyCancellationToken,
                 Is.Not.EqualTo(em.LateCancellationToken));
 
@@ -107,6 +113,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.False);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Healthy));
 
     lifetime_.StopApplication();
 
@@ -128,6 +137,9 @@ public class ExceptionManagerTests
     Assert.That(events,
                 Is.EqualTo(Enumerable.Range(0,
                                             5)));
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
   }
 
   [Test]
@@ -167,6 +179,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.False);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Healthy));
 
     var sw = Stopwatch.StartNew();
     lifetime_.StopApplication();
@@ -187,6 +202,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.False);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
 
     lifetime_.NotifyStopped();
 
@@ -235,6 +253,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.True);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Healthy));
 
     try
     {
@@ -248,6 +269,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.True);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
 
     lifetime_.NotifyStopped();
 
@@ -291,6 +315,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.True);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Healthy));
 
     em.RecordError(logger,
                    new ApplicationException("Error"),
@@ -308,6 +335,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.True);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
 
     lifetime_.NotifyStopped();
 
@@ -356,6 +386,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.False);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
 
     lifetime_.NotifyStopped();
 
@@ -395,6 +428,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.True);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
   }
 
   [Test]
@@ -443,6 +479,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.False);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Healthy));
 
     em.RecordError(logger,
                    new ApplicationException("Final Error"),
@@ -450,6 +489,9 @@ public class ExceptionManagerTests
 
     Assert.That(em.Failed,
                 Is.True);
+    Assert.That(() => em.Check(HealthCheckTag.Liveness),
+                Has.Property(nameof(HealthCheckResult.Status))
+                   .EqualTo(HealthStatus.Unhealthy));
 
     em.RecordSuccess();
 

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -112,7 +112,7 @@ public static class Program
              .AddSingleton(pollsterOptions)
              .AddSingleton(new ExceptionManager.Options(pollsterOptions.GraceDelay,
                                                         pollsterOptions.MaxErrorAllowed))
-             .AddSingleton<ExceptionManager>()
+             .AddSingletonWithHealthCheck<ExceptionManager>(nameof(ExceptionManager))
              .AddSingleton<HealthCheckRecord>()
              .AddSingleton<IHealthCheckPublisher, HealthCheckRecord.Publisher>()
              .AddSingleton<IAgentHandler, AgentHandler>()

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -102,7 +102,7 @@ public static class Program
              .AddSingleton(sp => new ExceptionManager.Options(TimeSpan.Zero,
                                                               sp.GetRequiredService<Common.Injection.Options.Submitter>()
                                                                 .MaxErrorAllowed))
-             .AddSingleton<ExceptionManager>()
+             .AddSingletonWithHealthCheck<ExceptionManager>(nameof(ExceptionManager))
              .AddGrpcReflection()
              .AddSingleton<MeterHolder>()
              .AddSingleton<AgentIdentifier>()


### PR DESCRIPTION
# Motivation

PR #949 seems to have introduced a bug where it is possible for the polling-agent to stay terminating.
Reason is still unclear, but it might be because the pod is not marked unhealthy when background services are stopped.

# Description

Make the ExceptionManager an IHealthCheckProvider that is unhealthy as soon as the lateCancellationToken is triggered, which happens either after the grace delay, or when all background services have stopped (whichever happens first).

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
