### PR TITLE
ci: Support for OVERRIDE_RELEASE_VERSION

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -55,7 +55,7 @@ jobs:
         echo RELASE   => ${{ steps.release.outputs.version }} >> $GITHUB_STEP_SUMMARY
 
     - name: Validate tag
-      run : test ${{ steps.release.outputs.version }} == ${{ github.ref_name }}
+      run : test "${{ steps.release.outputs.version }}" == "${{ github.ref_name }}" -o "${{ vars.OVERRIDE_RELEASE_VERSION }}" == "${{ github.ref_name }}"
 
     - name: Delete tag if invalid
       if: failure() || cancelled()


### PR DESCRIPTION
# Motivation

In some cases, the version computed by codacy does not match what we really want.

# Description

Add a possibility to override the release version by specifying a project variable named `OVERRIDE_RELEASE_VERSION` with the expected version.

# Testing

To be tested for the next release.

# Additional Information

The override variable must be emptied after the release.
