### PR TITLE
ci: Use the tag name instead of the tag computed by codacy

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -67,7 +67,7 @@ jobs:
     needs:
       - versionning
     env:
-      VERSION: ${{ needs.versionning.outputs.release }}
+      VERSION: ${{ github.ref_name }}
     strategy:
       fail-fast: true
       matrix:
@@ -106,7 +106,7 @@ jobs:
     needs:
       - versionning
     env:
-      VERSION: ${{ needs.versionning.outputs.release }}
+      VERSION: ${{ github.ref_name }}
     steps:
     - name: Checkout
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
# Motivation

#998 is not implemented correctly, and even though the check pass, the wrong version is used.

# Description

Use the tag name instead of the version computed from codacy to publish docker images and nugets.

# Testing

Will be tested on the next release.
