### PR TITLE
test: add delay to wait for tasks to have the proper status in Stream tests

### DIFF
--- a/Tests/Stream/Client/TaskSubmissionTests.cs
+++ b/Tests/Stream/Client/TaskSubmissionTests.cs
@@ -186,6 +186,9 @@ internal class TaskSubmissionTests
                                           CancellationToken.None)
                      .ConfigureAwait(false);
 
+    await Task.Delay(50)
+              .ConfigureAwait(false);
+
     taskData = await tasksClient.GetTaskAsync(new GetTaskRequest
                                               {
                                                 TaskId = tasks.TaskInfos.Single()
@@ -322,6 +325,9 @@ internal class TaskSubmissionTests
                                           CancellationToken.None)
                      .ConfigureAwait(false);
 
+    await Task.Delay(50)
+              .ConfigureAwait(false);
+
     taskData = await tasksClient.GetTaskAsync(new GetTaskRequest
                                               {
                                                 TaskId = tasks.TaskInfos.Single()
@@ -423,6 +429,9 @@ internal class TaskSubmissionTests
                                           results.Results.ViewSelect(result => result.ResultId),
                                           CancellationToken.None)
                      .ConfigureAwait(false);
+
+    await Task.Delay(50)
+              .ConfigureAwait(false);
 
     var taskData = await tasksClient.GetTaskAsync(new GetTaskRequest
                                                   {


### PR DESCRIPTION
# Motivation

Improve test reliability. The Stream tests were failing regularly on https://github.com/aneoconsulting/ArmoniK pipelines.

# Description

This PRs adds a small delay between the wait for the result completion and the check of the task status as the result change status a little bit before the task change status.

# Testing

Core pipeline is working fine. We'll see how it goes in the future.

# Impact

- Less retried tests and less time waiting for failed tests.


