### PR TITLE
docs: add xml-doc for Common/src/gRPC/ExpressionBuilders.cs

### DIFF
--- a/Common/src/gRPC/ExpressionBuilders.cs
+++ b/Common/src/gRPC/ExpressionBuilders.cs
@@ -28,6 +28,15 @@ namespace ArmoniK.Core.Common.gRPC;
 /// </summary>
 public class ExpressionBuilders
 {
+  /// <summary>
+  ///   Extracts the member expression from a field selector expression.
+  /// </summary>
+  /// <typeparam name="TIn">The type of the input parameter for the selector expression.</typeparam>
+  /// <param name="selector">The field selector expression.</param>
+  /// <returns>
+  ///   The <see cref="Expression" /> representing the accessed member or method call.
+  /// </returns>
+  /// <exception cref="NotImplementedException">Thrown if the selector's body is not a supported expression type.</exception>
   public static Expression GetMemberExpression<TIn>(Expression<Func<TIn, object?>> selector)
   {
     switch (selector.Body.NodeType)
@@ -147,7 +156,7 @@ public class ExpressionBuilders
                                        typeof(string));
 
     var methodInfo = typeof(string).GetMethods()
-                                   .First(m => m.Name == method                                   && m.GetParameters()
+                                   .First(m => m.Name == method                  && m.GetParameters()
                                                                                      .Length == 1 && m.GetParameters()
                                                                                                       .First()
                                                                                                       .ParameterType == typeof(string));


### PR DESCRIPTION
# Motivation

Complete code documentation. This PR adds missing xml-doc for the file: Common/src/gRPC/ExpressionBuilders.cs.

# Description

This pull request includes documentation improvements for several exception classes in the ArmoniK.Core namespace. The changes add XML documentation comments to provide better descriptions and explanations.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.