### PR TITLE
refactor: MongoDB BaseTable and read preference

### DIFF
--- a/Adaptors/MongoDB/src/Common/BaseTable.cs
+++ b/Adaptors/MongoDB/src/Common/BaseTable.cs
@@ -1,0 +1,156 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Data;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Utils;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+using MongoDB.Driver;
+
+namespace ArmoniK.Core.Adapters.MongoDB.Common;
+
+/// <summary>
+///   Base class for tables
+/// </summary>
+/// <typeparam name="TData">Model stored in the table</typeparam>
+/// <typeparam name="TModelMapping">Mapping between the model and the document</typeparam>
+public abstract class BaseTable<TData, TModelMapping> : IInitializable
+  where TModelMapping : IMongoDataModelMapping<TData>, new()
+{
+  private readonly ActivitySource                                activitySource_;
+  private readonly MongoCollectionProvider<TData, TModelMapping> collectionProvider_;
+  private readonly bool                                          isReadOnly_;
+  private readonly SessionProvider                               sessionProvider_;
+  private          bool                                          isInitialized_;
+
+  /// <summary>
+  ///   Construct a new table
+  /// </summary>
+  /// <param name="sessionProvider">Provider for <see cref="IClientSessionHandle" /></param>
+  /// <param name="collectionProvider">Provider for <see cref="IMongoCollection{TDocument}" /></param>
+  /// <param name="activitySource">Source for the activities when querying the table</param>
+  /// <param name="logger">Logger used to produce logs when querying the table</param>
+  protected BaseTable(SessionProvider                               sessionProvider,
+                      MongoCollectionProvider<TData, TModelMapping> collectionProvider,
+                      ActivitySource                                activitySource,
+                      ILogger                                       logger)
+  {
+    sessionProvider_    = sessionProvider;
+    collectionProvider_ = collectionProvider;
+    activitySource_     = activitySource;
+    Logger              = logger;
+    isReadOnly_         = false;
+    isInitialized_      = false;
+  }
+
+  /// <summary>
+  ///   Construct a copy of the table adjusting the read preference
+  /// </summary>
+  /// <param name="baseTable">Source table</param>
+  /// <param name="readOnly">Whether the new table is read only</param>
+  protected BaseTable(BaseTable<TData, TModelMapping> baseTable,
+                      bool                            readOnly)
+  {
+    sessionProvider_    = baseTable.sessionProvider_;
+    collectionProvider_ = baseTable.collectionProvider_;
+    activitySource_     = baseTable.activitySource_;
+    Logger              = baseTable.Logger;
+    isReadOnly_         = readOnly;
+    isInitialized_      = true;
+  }
+
+  /// <summary>
+  ///   Logger used to produce logs when querying the table
+  /// </summary>
+  protected ILogger Logger { get; }
+
+  private static string TableName
+    => $"BaseTable<{typeof(TData).Name}>";
+
+
+  /// <inheritdoc />
+  public async Task Init(CancellationToken cancellationToken)
+  {
+    if (!isInitialized_)
+    {
+      await sessionProvider_.Init(cancellationToken)
+                            .ConfigureAwait(false);
+      sessionProvider_.Get();
+      await collectionProvider_.Init(cancellationToken)
+                               .ConfigureAwait(false);
+      collectionProvider_.Get();
+      isInitialized_ = true;
+    }
+  }
+
+  /// <inheritdoc />
+  public async Task<HealthCheckResult> Check(HealthCheckTag tag)
+  {
+    var result = await HealthCheckResultCombiner.Combine(tag,
+                                                         $"{TableName} is not initialized",
+                                                         sessionProvider_,
+                                                         collectionProvider_)
+                                                .ConfigureAwait(false);
+
+    return isInitialized_ && result.Status == HealthStatus.Healthy
+             ? HealthCheckResult.Healthy()
+             : HealthCheckResult.Unhealthy(result.Description);
+  }
+
+  /// <summary>
+  ///   Get a Read/Write <see cref="IMongoCollection{TDocument}" /> from the collection provider
+  /// </summary>
+  /// <returns>Collection</returns>
+  /// <exception cref="ConstraintException">Table is read-only</exception>
+  protected IMongoCollection<TData> GetCollection()
+    => isReadOnly_
+         ? throw new ConstraintException($"{TableName} is read-only, but read-write access has been requested")
+         : collectionProvider_.Get();
+
+  /// <summary>
+  ///   Get a Read-only <see cref="IMongoCollection{TDocument}" /> from the collection provider
+  /// </summary>
+  /// <remarks>
+  ///   If table is marked read-only, read preference is set to secondary-preferred
+  /// </remarks>
+  /// <returns>Collection</returns>
+  protected IMongoCollection<TData> GetReadCollection()
+    => isReadOnly_
+         ? collectionProvider_.Get()
+                              .WithReadPreference(ReadPreference.SecondaryPreferred)
+         : collectionProvider_.Get();
+
+  /// <inheritdoc cref="ActivitySource.StartActivity(string, ActivityKind)" />
+  protected Activity? StartActivity([CallerMemberName] string name = "")
+    => activitySource_.StartActivity(name);
+
+  /// <summary>
+  ///   Get a <see cref="IClientSessionHandle" />
+  /// </summary>
+  /// <returns>session handle</returns>
+  protected IClientSessionHandle GetSession()
+    => sessionProvider_.Get();
+}

--- a/Adaptors/MongoDB/src/PartitionTable.cs
+++ b/Adaptors/MongoDB/src/PartitionTable.cs
@@ -60,7 +60,7 @@ public class PartitionTable : BaseTable<PartitionData, PartitionDataModelMapping
   }
 
   /// <inheritdoc />
-  public IPartitionTable ReadOnly
+  public IPartitionTable Secondary
     => new PartitionTable(this,
                           true);
 

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -61,7 +61,7 @@ public class ResultTable : BaseTable<Result, ResultDataModelMapping>, IResultTab
   }
 
   /// <inheritdoc />
-  public IResultTable ReadOnly
+  public IResultTable Secondary
     => new ResultTable(this,
                        true);
 

--- a/Adaptors/MongoDB/src/SessionTable.cs
+++ b/Adaptors/MongoDB/src/SessionTable.cs
@@ -60,7 +60,7 @@ public class SessionTable : BaseTable<SessionData, SessionDataModelMapping>, ISe
   }
 
   /// <inheritdoc />
-  public ISessionTable ReadOnly
+  public ISessionTable Secondary
     => new SessionTable(this,
                         true);
 

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -64,7 +64,7 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
   }
 
   /// <inheritdoc />
-  public ITaskTable ReadOnly
+  public ITaskTable Secondary
     => new TaskTable(this,
                      true);
 

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -25,16 +25,12 @@ using System.Threading;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Adapters.MongoDB.Common;
-using ArmoniK.Core.Adapters.MongoDB.Options;
 using ArmoniK.Core.Adapters.MongoDB.Table.DataModel;
-using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Core.Utils;
 using ArmoniK.Utils;
 
-using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
 using MongoDB.Driver;
@@ -44,28 +40,33 @@ using TaskStatus = ArmoniK.Core.Common.Storage.TaskStatus;
 
 namespace ArmoniK.Core.Adapters.MongoDB;
 
-/// <inheritdoc />
-public class TaskTable : ITaskTable
+/// <inheritdoc cref="ITaskTable" />
+public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
 {
-  private readonly ActivitySource                                          activitySource_;
-  private readonly SessionProvider                                         sessionProvider_;
-  private readonly MongoCollectionProvider<TaskData, TaskDataModelMapping> taskCollectionProvider_;
-
-  private bool isInitialized_;
-
+  /// <inheritdoc />
   public TaskTable(SessionProvider                                         sessionProvider,
                    MongoCollectionProvider<TaskData, TaskDataModelMapping> taskCollectionProvider,
-                   ILogger<TaskTable>                                      logger,
                    ActivitySource                                          activitySource,
-                   TableStorage                                            option)
+                   ILogger<TaskTable>                                      logger)
+    : base(sessionProvider,
+           taskCollectionProvider,
+           activitySource,
+           logger)
   {
-    sessionProvider_        = sessionProvider;
-    taskCollectionProvider_ = taskCollectionProvider;
-    Logger                  = logger;
-    activitySource_         = activitySource;
-    PollingDelayMin         = option.PollingDelayMin;
-    PollingDelayMax         = option.PollingDelayMax;
   }
+
+  /// <inheritdoc />
+  private TaskTable(TaskTable taskTable,
+                    bool      readOnly)
+    : base(taskTable,
+           readOnly)
+  {
+  }
+
+  /// <inheritdoc />
+  public ITaskTable ReadOnly
+    => new TaskTable(this,
+                     true);
 
   public TimeSpan PollingDelayMin { get; set; }
   public TimeSpan PollingDelayMax { get; set; }
@@ -74,9 +75,8 @@ public class TaskTable : ITaskTable
   public async Task CreateTasks(IEnumerable<TaskData> tasks,
                                 CancellationToken     cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(CreateTasks)}");
-
-    var taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       taskCollection = GetCollection();
 
     try
     {
@@ -96,10 +96,10 @@ public class TaskTable : ITaskTable
                                         Expression<Func<TaskData, T>> selector,
                                         CancellationToken             cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(ReadTaskAsync)}");
+    using var activity = StartActivity();
     activity?.SetTag("ReadTaskId",
                      taskId);
-    var taskCollection = taskCollectionProvider_.Get();
+    var taskCollection = GetReadCollection();
 
     try
     {
@@ -123,10 +123,10 @@ public class TaskTable : ITaskTable
   public async Task<IEnumerable<TaskStatusCount>> CountTasksAsync(Expression<Func<TaskData, bool>> filter,
                                                                   CancellationToken                cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(CountTasksAsync)}");
+    using var activity = StartActivity();
 
-    var sessionHandle  = sessionProvider_.Get();
-    var taskCollection = taskCollectionProvider_.Get();
+    var sessionHandle  = GetSession();
+    var taskCollection = GetReadCollection();
 
     var res = await taskCollection.AsQueryable(sessionHandle)
                                   .Where(filter)
@@ -142,10 +142,10 @@ public class TaskTable : ITaskTable
   /// <inheritdoc />
   public async Task<IEnumerable<PartitionTaskStatusCount>> CountPartitionTasksAsync(CancellationToken cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(CountPartitionTasksAsync)}");
+    using var activity = StartActivity();
 
-    var sessionHandle  = sessionProvider_.Get();
-    var taskCollection = taskCollectionProvider_.Get();
+    var sessionHandle  = GetSession();
+    var taskCollection = GetReadCollection();
 
 
     var res = await taskCollection.AsQueryable(sessionHandle)
@@ -167,10 +167,10 @@ public class TaskTable : ITaskTable
   public async Task DeleteTaskAsync(string            id,
                                     CancellationToken cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(DeleteTaskAsync)}");
+    using var activity = StartActivity();
     activity?.SetTag($"{nameof(DeleteTaskAsync)}_TaskId",
                      id);
-    var taskCollection = taskCollectionProvider_.Get();
+    var taskCollection = GetCollection();
 
     var result = await taskCollection.DeleteOneAsync(tdm => tdm.TaskId == id,
                                                      cancellationToken)
@@ -190,10 +190,10 @@ public class TaskTable : ITaskTable
   public async Task DeleteTasksAsync(string            sessionId,
                                      CancellationToken cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(DeleteTasksAsync)}");
+    using var activity = StartActivity();
     activity?.SetTag($"{nameof(DeleteTaskAsync)}_SessionId",
                      sessionId);
-    var taskCollection = taskCollectionProvider_.Get();
+    var taskCollection = GetCollection();
 
     var res = await taskCollection.DeleteManyAsync(tdm => tdm.SessionId == sessionId,
                                                    cancellationToken)
@@ -215,9 +215,9 @@ public class TaskTable : ITaskTable
                                                                                int                                 pageSize,
                                                                                CancellationToken                   cancellationToken = default)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(ListTasksAsync)}");
-    var       sessionHandle  = sessionProvider_.Get();
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       sessionHandle  = GetSession();
+    var       taskCollection = GetReadCollection();
 
     var taskList = Task.FromResult(new List<T>());
     if (pageSize > 0)
@@ -248,9 +248,9 @@ public class TaskTable : ITaskTable
                                                Expression<Func<TaskData, T>>    selector,
                                                CancellationToken                cancellationToken = default)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(FindTasksAsync)}");
-    var       sessionHandle  = sessionProvider_.Get();
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       sessionHandle  = GetSession();
+    var       taskCollection = GetReadCollection();
 
     return taskCollection.Find(sessionHandle,
                                filter)
@@ -263,8 +263,8 @@ public class TaskTable : ITaskTable
                                           Core.Common.Storage.UpdateDefinition<TaskData> updates,
                                           CancellationToken                              cancellationToken = default)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(UpdateOneTask)}");
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       taskCollection = GetCollection();
 
     var updateDefinition = new UpdateDefinitionBuilder<TaskData>().Combine();
 
@@ -292,8 +292,8 @@ public class TaskTable : ITaskTable
   async Task<long> ITaskTable.BulkUpdateTasks(IEnumerable<(Expression<Func<TaskData, bool>> filter, Core.Common.Storage.UpdateDefinition<TaskData> updates)> bulkUpdates,
                                               CancellationToken cancellationToken)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(ITaskTable.BulkUpdateTasks)}");
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       taskCollection = GetCollection();
 
     var requests = bulkUpdates.Select(item =>
                                       {
@@ -332,9 +332,9 @@ public class TaskTable : ITaskTable
                                                                                                    int pageSize,
                                                                                                    CancellationToken cancellationToken = default)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(ListApplicationsAsync)}");
-    var       sessionHandle  = sessionProvider_.Get();
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       sessionHandle  = GetSession();
+    var       taskCollection = GetReadCollection();
 
     var queryable = taskCollection.AsQueryable(sessionHandle)
                                   .Where(filter)
@@ -361,9 +361,9 @@ public class TaskTable : ITaskTable
                                                                            Expression<Func<TaskData, T>>              selector,
                                                                            [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(RemoveRemainingDataDependenciesAsync)}");
-    var       sessionHandle  = sessionProvider_.Get();
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       sessionHandle  = GetSession();
+    var       taskCollection = GetCollection();
 
     // MongoDB driver does not support to unset a list, so Unset should be called multiple times.
     // However, Unset on an UpdateDefinitionBuilder returns an UpdateDefinition.
@@ -412,8 +412,8 @@ public class TaskTable : ITaskTable
                                              bool                                           before,
                                              CancellationToken                              cancellationToken = default)
   {
-    using var activity       = activitySource_.StartActivity($"{nameof(UpdateOneTask)}");
-    var       taskCollection = taskCollectionProvider_.Get();
+    using var activity       = StartActivity();
+    var       taskCollection = GetCollection();
 
     var updateDefinition = new UpdateDefinitionBuilder<TaskData>().Combine();
 
@@ -452,45 +452,17 @@ public class TaskTable : ITaskTable
   }
 
   /// <inheritdoc />
-  public ILogger Logger { get; }
-
-  /// <inheritdoc />
-  public async Task<HealthCheckResult> Check(HealthCheckTag tag)
-  {
-    var result = await HealthCheckResultCombiner.Combine(tag,
-                                                         $"{nameof(TaskTable)} is not initialized",
-                                                         sessionProvider_,
-                                                         taskCollectionProvider_)
-                                                .ConfigureAwait(false);
-
-    return isInitialized_ && result.Status == HealthStatus.Healthy
-             ? HealthCheckResult.Healthy()
-             : HealthCheckResult.Unhealthy(result.Description);
-  }
-
-  /// <inheritdoc />
-  public async Task Init(CancellationToken cancellationToken)
-  {
-    if (!isInitialized_)
-    {
-      await sessionProvider_.Init(cancellationToken)
-                            .ConfigureAwait(false);
-      sessionProvider_.Get();
-      await taskCollectionProvider_.Init(cancellationToken)
-                                   .ConfigureAwait(false);
-      taskCollectionProvider_.Get();
-      isInitialized_ = true;
-    }
-  }
+  ILogger ITaskTable.Logger
+    => base.Logger;
 
   /// <inheritdoc />
   public Task<int> CountAllTasksAsync(TaskStatus        status,
                                       CancellationToken cancellationToken = default)
   {
-    using var activity = activitySource_.StartActivity($"{nameof(CountAllTasksAsync)}");
+    using var activity = StartActivity($"{nameof(CountAllTasksAsync)}");
 
-    var sessionHandle  = sessionProvider_.Get();
-    var taskCollection = taskCollectionProvider_.Get();
+    var sessionHandle  = GetSession();
+    var taskCollection = GetReadCollection();
 
     var res = taskCollection.AsQueryable(sessionHandle)
                             .Count(model => model.Status == status);

--- a/Common/src/Storage/IPartitionTable.cs
+++ b/Common/src/Storage/IPartitionTable.cs
@@ -33,9 +33,9 @@ namespace ArmoniK.Core.Common.Storage;
 public interface IPartitionTable : IInitializable
 {
   /// <summary>
-  ///   Read optimized version of the table.
+  ///   Table targeting a secondary server for read operations
   /// </summary>
-  public IPartitionTable ReadOnly
+  public IPartitionTable Secondary
     => this;
 
   /// <summary>

--- a/Common/src/Storage/IPartitionTable.cs
+++ b/Common/src/Storage/IPartitionTable.cs
@@ -33,6 +33,12 @@ namespace ArmoniK.Core.Common.Storage;
 public interface IPartitionTable : IInitializable
 {
   /// <summary>
+  ///   Read optimized version of the table.
+  /// </summary>
+  public IPartitionTable ReadOnly
+    => this;
+
+  /// <summary>
   ///   Inserts a collection of partitions in the data base
   /// </summary>
   /// <param name="partitions">Collection of partitions to be inserted</param>

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -40,6 +40,12 @@ public interface IResultTable : IInitializable
   public ILogger Logger { get; }
 
   /// <summary>
+  ///   Read optimized version of the table.
+  /// </summary>
+  public IResultTable ReadOnly
+    => this;
+
+  /// <summary>
   ///   Change ownership (in batch) of the results in the given request
   /// </summary>
   /// <param name="oldTaskId">Task Id of the previous owner</param>

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -40,9 +40,9 @@ public interface IResultTable : IInitializable
   public ILogger Logger { get; }
 
   /// <summary>
-  ///   Read optimized version of the table.
+  ///   Table targeting a secondary server for read operations
   /// </summary>
-  public IResultTable ReadOnly
+  public IResultTable Secondary
     => this;
 
   /// <summary>

--- a/Common/src/Storage/ISessionTable.cs
+++ b/Common/src/Storage/ISessionTable.cs
@@ -39,9 +39,9 @@ public interface ISessionTable : IInitializable
   ILogger Logger { get; }
 
   /// <summary>
-  ///   Read optimized version of the table.
+  ///   Table targeting a secondary server for read operations
   /// </summary>
-  public ISessionTable ReadOnly
+  public ISessionTable Secondary
     => this;
 
   /// <summary>

--- a/Common/src/Storage/ISessionTable.cs
+++ b/Common/src/Storage/ISessionTable.cs
@@ -39,6 +39,12 @@ public interface ISessionTable : IInitializable
   ILogger Logger { get; }
 
   /// <summary>
+  ///   Read optimized version of the table.
+  /// </summary>
+  public ISessionTable ReadOnly
+    => this;
+
+  /// <summary>
   ///   Set metadata for a new session
   /// </summary>
   /// <param name="partitionIds">List of partitions allowed to be used during the session</param>

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -53,6 +53,12 @@ public interface ITaskTable : IInitializable
   public ILogger Logger { get; }
 
   /// <summary>
+  ///   Read optimized version of the table.
+  /// </summary>
+  public ITaskTable ReadOnly
+    => this;
+
+  /// <summary>
   ///   Inserts a collection of tasks in the data base
   /// </summary>
   /// <param name="tasks">Collection of tasks to be inserted</param>

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -53,9 +53,9 @@ public interface ITaskTable : IInitializable
   public ILogger Logger { get; }
 
   /// <summary>
-  ///   Read optimized version of the table.
+  ///   Table targeting a secondary server for read operations
   /// </summary>
-  public ITaskTable ReadOnly
+  public ITaskTable Secondary
     => this;
 
   /// <summary>

--- a/Common/src/gRPC/Services/GrpcApplicationsService.cs
+++ b/Common/src/gRPC/Services/GrpcApplicationsService.cs
@@ -65,20 +65,20 @@ public class GrpcApplicationsService : Applications.ApplicationsBase
                                                                         ServerCallContext       context)
   {
     using var measure = meter_.CountAndTime();
-    var (applications, totalCount) = await taskTable_.ReadOnly.ListApplicationsAsync(request.Filters is null
-                                                                                       ? data => true
-                                                                                       : request.Filters.ToApplicationFilter(),
-                                                                                     request.Sort is null
-                                                                                       ? new List<Expression<Func<Application, object?>>>
-                                                                                         {
-                                                                                           application => application.Name,
-                                                                                         }
-                                                                                       : request.Sort.Fields.Select(field => field.ToField())
-                                                                                                .ToList(),
-                                                                                     request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                                     request.Page,
-                                                                                     request.PageSize,
-                                                                                     context.CancellationToken)
+    var (applications, totalCount) = await taskTable_.Secondary.ListApplicationsAsync(request.Filters is null
+                                                                                        ? data => true
+                                                                                        : request.Filters.ToApplicationFilter(),
+                                                                                      request.Sort is null
+                                                                                        ? new List<Expression<Func<Application, object?>>>
+                                                                                          {
+                                                                                            application => application.Name,
+                                                                                          }
+                                                                                        : request.Sort.Fields.Select(field => field.ToField())
+                                                                                                 .ToList(),
+                                                                                      request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                                                      request.Page,
+                                                                                      request.PageSize,
+                                                                                      context.CancellationToken)
                                                      .ConfigureAwait(false);
     return new ListApplicationsResponse
            {

--- a/Common/src/gRPC/Services/GrpcApplicationsService.cs
+++ b/Common/src/gRPC/Services/GrpcApplicationsService.cs
@@ -65,20 +65,20 @@ public class GrpcApplicationsService : Applications.ApplicationsBase
                                                                         ServerCallContext       context)
   {
     using var measure = meter_.CountAndTime();
-    var (applications, totalCount) = await taskTable_.ListApplicationsAsync(request.Filters is null
-                                                                              ? data => true
-                                                                              : request.Filters.ToApplicationFilter(),
-                                                                            request.Sort is null
-                                                                              ? new List<Expression<Func<Application, object?>>>
-                                                                                {
-                                                                                  application => application.Name,
-                                                                                }
-                                                                              : request.Sort.Fields.Select(field => field.ToField())
-                                                                                       .ToList(),
-                                                                            request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                            request.Page,
-                                                                            request.PageSize,
-                                                                            context.CancellationToken)
+    var (applications, totalCount) = await taskTable_.ReadOnly.ListApplicationsAsync(request.Filters is null
+                                                                                       ? data => true
+                                                                                       : request.Filters.ToApplicationFilter(),
+                                                                                     request.Sort is null
+                                                                                       ? new List<Expression<Func<Application, object?>>>
+                                                                                         {
+                                                                                           application => application.Name,
+                                                                                         }
+                                                                                       : request.Sort.Fields.Select(field => field.ToField())
+                                                                                                .ToList(),
+                                                                                     request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                                                     request.Page,
+                                                                                     request.PageSize,
+                                                                                     context.CancellationToken)
                                                      .ConfigureAwait(false);
     return new ListApplicationsResponse
            {

--- a/Common/src/gRPC/Services/GrpcEventsService.cs
+++ b/Common/src/gRPC/Services/GrpcEventsService.cs
@@ -75,9 +75,9 @@ public class GrpcEventsService : Events.EventsBase
                                        ServerCallContext                              context)
   {
     using var measure = meter_.CountAndTime();
-    var wtg = new WatchToGrpc(taskTable_,
+    var wtg = new WatchToGrpc(taskTable_.ReadOnly,
                               taskWatcher_,
-                              resultTable_,
+                              resultTable_.ReadOnly,
                               resultWatcher_,
                               logger_);
 

--- a/Common/src/gRPC/Services/GrpcEventsService.cs
+++ b/Common/src/gRPC/Services/GrpcEventsService.cs
@@ -75,9 +75,9 @@ public class GrpcEventsService : Events.EventsBase
                                        ServerCallContext                              context)
   {
     using var measure = meter_.CountAndTime();
-    var wtg = new WatchToGrpc(taskTable_.ReadOnly,
+    var wtg = new WatchToGrpc(taskTable_.Secondary,
                               taskWatcher_,
-                              resultTable_.ReadOnly,
+                              resultTable_.Secondary,
                               resultWatcher_,
                               logger_);
 

--- a/Common/src/gRPC/Services/GrpcPartitionsService.cs
+++ b/Common/src/gRPC/Services/GrpcPartitionsService.cs
@@ -95,16 +95,16 @@ public class GrpcPartitionsService : Partitions.PartitionsBase
                                                                     ServerCallContext     context)
   {
     using var measure = meter_.CountAndTime();
-    var partitions = await partitionTable_.ListPartitionsAsync(request.Filters is null
-                                                                 ? data => true
-                                                                 : request.Filters.ToPartitionFilter(),
-                                                               request.Sort is null
-                                                                 ? data => data.PartitionId
-                                                                 : request.Sort.ToField(),
-                                                               request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                               request.Page,
-                                                               request.PageSize,
-                                                               context.CancellationToken)
+    var partitions = await partitionTable_.ReadOnly.ListPartitionsAsync(request.Filters is null
+                                                                          ? data => true
+                                                                          : request.Filters.ToPartitionFilter(),
+                                                                        request.Sort is null
+                                                                          ? data => data.PartitionId
+                                                                          : request.Sort.ToField(),
+                                                                        request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                                        request.Page,
+                                                                        request.PageSize,
+                                                                        context.CancellationToken)
                                           .ConfigureAwait(false);
     return new ListPartitionsResponse
            {

--- a/Common/src/gRPC/Services/GrpcPartitionsService.cs
+++ b/Common/src/gRPC/Services/GrpcPartitionsService.cs
@@ -95,16 +95,16 @@ public class GrpcPartitionsService : Partitions.PartitionsBase
                                                                     ServerCallContext     context)
   {
     using var measure = meter_.CountAndTime();
-    var partitions = await partitionTable_.ReadOnly.ListPartitionsAsync(request.Filters is null
-                                                                          ? data => true
-                                                                          : request.Filters.ToPartitionFilter(),
-                                                                        request.Sort is null
-                                                                          ? data => data.PartitionId
-                                                                          : request.Sort.ToField(),
-                                                                        request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                        request.Page,
-                                                                        request.PageSize,
-                                                                        context.CancellationToken)
+    var partitions = await partitionTable_.Secondary.ListPartitionsAsync(request.Filters is null
+                                                                           ? data => true
+                                                                           : request.Filters.ToPartitionFilter(),
+                                                                         request.Sort is null
+                                                                           ? data => data.PartitionId
+                                                                           : request.Sort.ToField(),
+                                                                         request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                                         request.Page,
+                                                                         request.PageSize,
+                                                                         context.CancellationToken)
                                           .ConfigureAwait(false);
     return new ListPartitionsResponse
            {

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -126,17 +126,22 @@ public class GrpcResultsService : Results.ResultsBase
                                                               ServerCallContext  context)
   {
     using var measure = meter_.CountAndTime();
-    var results = await resultTable_.ListResultsAsync(request.Filters is null
-                                                        ? data => true
-                                                        : request.Filters.ToResultFilter(),
-                                                      request.Sort is null
-                                                        ? result => result.ResultId
-                                                        : request.Sort.ToField(),
-                                                      request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                      request.Page,
-                                                      request.PageSize,
-                                                      context.CancellationToken)
-                                    .ConfigureAwait(false);
+
+    var resultTable = request.PageSize == 0
+                        ? resultTable_.ReadOnly
+                        : resultTable_;
+
+    var results = await resultTable.ListResultsAsync(request.Filters is null
+                                                       ? data => true
+                                                       : request.Filters.ToResultFilter(),
+                                                     request.Sort is null
+                                                       ? result => result.ResultId
+                                                       : request.Sort.ToField(),
+                                                     request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                     request.Page,
+                                                     request.PageSize,
+                                                     context.CancellationToken)
+                                   .ConfigureAwait(false);
     return new ListResultsResponse
            {
              PageSize = request.PageSize,

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -128,7 +128,7 @@ public class GrpcResultsService : Results.ResultsBase
     using var measure = meter_.CountAndTime();
 
     var resultTable = request.PageSize == 0
-                        ? resultTable_.ReadOnly
+                        ? resultTable_.Secondary
                         : resultTable_;
 
     var results = await resultTable.ListResultsAsync(request.Filters is null

--- a/Common/src/gRPC/Services/GrpcSessionsService.cs
+++ b/Common/src/gRPC/Services/GrpcSessionsService.cs
@@ -184,19 +184,24 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                 ServerCallContext   context)
   {
     using var measure = meter_.CountAndTime();
+
+    var sessionTable = request.PageSize == 0
+                         ? sessionTable_.ReadOnly
+                         : sessionTable_;
+
     try
     {
-      var (sessions, totalCount) = await sessionTable_.ListSessionsAsync(request.Filters is null
-                                                                           ? data => true
-                                                                           : request.Filters.ToSessionDataFilter(),
-                                                                         request.Sort is null
-                                                                           ? data => data.SessionId
-                                                                           : request.Sort.ToField(),
-                                                                         request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                         request.Page,
-                                                                         request.PageSize,
-                                                                         context.CancellationToken)
-                                                      .ConfigureAwait(false);
+      var (sessions, totalCount) = await sessionTable.ListSessionsAsync(request.Filters is null
+                                                                          ? data => true
+                                                                          : request.Filters.ToSessionDataFilter(),
+                                                                        request.Sort is null
+                                                                          ? data => data.SessionId
+                                                                          : request.Sort.ToField(),
+                                                                        request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                                        request.Page,
+                                                                        request.PageSize,
+                                                                        context.CancellationToken)
+                                                     .ConfigureAwait(false);
 
       return new ListSessionsResponse
              {

--- a/Common/src/gRPC/Services/GrpcSessionsService.cs
+++ b/Common/src/gRPC/Services/GrpcSessionsService.cs
@@ -186,7 +186,7 @@ public class GrpcSessionsService : Sessions.SessionsBase
     using var measure = meter_.CountAndTime();
 
     var sessionTable = request.PageSize == 0
-                         ? sessionTable_.ReadOnly
+                         ? sessionTable_.Secondary
                          : sessionTable_;
 
     try

--- a/Common/src/gRPC/Services/GrpcSubmitterService.cs
+++ b/Common/src/gRPC/Services/GrpcSubmitterService.cs
@@ -391,8 +391,8 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
              {
                Values =
                {
-                 (await taskTable_.CountTasksAsync(request,
-                                                   context.CancellationToken)
+                 (await taskTable_.ReadOnly.CountTasksAsync(request,
+                                                            context.CancellationToken)
                                   .ConfigureAwait(false)).Select(count => count.ToGrpcStatusCount()),
                },
              };

--- a/Common/src/gRPC/Services/GrpcSubmitterService.cs
+++ b/Common/src/gRPC/Services/GrpcSubmitterService.cs
@@ -391,8 +391,8 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
              {
                Values =
                {
-                 (await taskTable_.ReadOnly.CountTasksAsync(request,
-                                                            context.CancellationToken)
+                 (await taskTable_.Secondary.CountTasksAsync(request,
+                                                             context.CancellationToken)
                                   .ConfigureAwait(false)).Select(count => count.ToGrpcStatusCount()),
                },
              };

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -200,6 +200,11 @@ public class GrpcTasksService : Task.TasksBase
                                                           ServerCallContext context)
   {
     using var measure = meter_.CountAndTime();
+
+    var taskTable = request.PageSize == 0
+                      ? taskTable_.ReadOnly
+                      : taskTable_;
+
     try
     {
       if (request.Sort is not null && request.Sort.Field.FieldCase == TaskField.FieldOneofCase.TaskOptionGenericField)
@@ -208,18 +213,18 @@ public class GrpcTasksService : Task.TasksBase
                            request.Sort.Field.TaskOptionGenericField.Field);
       }
 
-      var (tasks, totalCount) = await taskTable_.ListTasksAsync(request.Filters is null
-                                                                  ? data => true
-                                                                  : request.Filters.ToTaskDataFilter(),
-                                                                request.Sort is null
-                                                                  ? data => data.TaskId
-                                                                  : request.Sort.ToField(),
-                                                                taskSummaryMask_.GetProjection(),
-                                                                request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                request.Page,
-                                                                request.PageSize,
-                                                                context.CancellationToken)
-                                                .ConfigureAwait(false);
+      var (tasks, totalCount) = await taskTable.ListTasksAsync(request.Filters is null
+                                                                 ? data => true
+                                                                 : request.Filters.ToTaskDataFilter(),
+                                                               request.Sort is null
+                                                                 ? data => data.TaskId
+                                                                 : request.Sort.ToField(),
+                                                               taskSummaryMask_.GetProjection(),
+                                                               request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                               request.Page,
+                                                               request.PageSize,
+                                                               context.CancellationToken)
+                                               .ConfigureAwait(false);
 
       return new ListTasksResponse
              {
@@ -390,10 +395,10 @@ public class GrpcTasksService : Task.TasksBase
              {
                Status =
                {
-                 (await taskTable_.CountTasksAsync(request.Filters is null
-                                                     ? data => true
-                                                     : request.Filters.ToTaskDataFilter(),
-                                                   context.CancellationToken)
+                 (await taskTable_.ReadOnly.CountTasksAsync(request.Filters is null
+                                                              ? data => true
+                                                              : request.Filters.ToTaskDataFilter(),
+                                                            context.CancellationToken)
                                   .ConfigureAwait(false)).Select(count => new StatusCount
                                                                           {
                                                                             Status = count.Status.ToGrpcStatus(),
@@ -425,6 +430,11 @@ public class GrpcTasksService : Task.TasksBase
                                                                           ServerCallContext context)
   {
     using var measure = meter_.CountAndTime();
+
+    var taskTable = request.PageSize == 0
+                      ? taskTable_.ReadOnly
+                      : taskTable_;
+
     try
     {
       if (request.Sort is not null && request.Sort.Field.FieldCase == TaskField.FieldOneofCase.TaskOptionGenericField)
@@ -433,18 +443,18 @@ public class GrpcTasksService : Task.TasksBase
                            request.Sort.Field.TaskOptionGenericField.Field);
       }
 
-      var (tasks, totalCount) = await taskTable_.ListTasksAsync(request.Filters is null
-                                                                  ? data => true
-                                                                  : request.Filters.ToTaskDataFilter(),
-                                                                request.Sort is null
-                                                                  ? data => data.TaskId
-                                                                  : request.Sort.ToField(),
-                                                                taskDetailedMask_.GetProjection(),
-                                                                request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                request.Page,
-                                                                request.PageSize,
-                                                                context.CancellationToken)
-                                                .ConfigureAwait(false);
+      var (tasks, totalCount) = await taskTable.ListTasksAsync(request.Filters is null
+                                                                 ? data => true
+                                                                 : request.Filters.ToTaskDataFilter(),
+                                                               request.Sort is null
+                                                                 ? data => data.TaskId
+                                                                 : request.Sort.ToField(),
+                                                               taskDetailedMask_.GetProjection(),
+                                                               request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                               request.Page,
+                                                               request.PageSize,
+                                                               context.CancellationToken)
+                                               .ConfigureAwait(false);
 
       return new ListTasksDetailedResponse
              {

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -202,7 +202,7 @@ public class GrpcTasksService : Task.TasksBase
     using var measure = meter_.CountAndTime();
 
     var taskTable = request.PageSize == 0
-                      ? taskTable_.ReadOnly
+                      ? taskTable_.Secondary
                       : taskTable_;
 
     try
@@ -395,10 +395,10 @@ public class GrpcTasksService : Task.TasksBase
              {
                Status =
                {
-                 (await taskTable_.ReadOnly.CountTasksAsync(request.Filters is null
-                                                              ? data => true
-                                                              : request.Filters.ToTaskDataFilter(),
-                                                            context.CancellationToken)
+                 (await taskTable_.Secondary.CountTasksAsync(request.Filters is null
+                                                               ? data => true
+                                                               : request.Filters.ToTaskDataFilter(),
+                                                             context.CancellationToken)
                                   .ConfigureAwait(false)).Select(count => new StatusCount
                                                                           {
                                                                             Status = count.Status.ToGrpcStatus(),
@@ -432,7 +432,7 @@ public class GrpcTasksService : Task.TasksBase
     using var measure = meter_.CountAndTime();
 
     var taskTable = request.PageSize == 0
-                      ? taskTable_.ReadOnly
+                      ? taskTable_.Secondary
                       : taskTable_;
 
     try

--- a/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
+++ b/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
@@ -59,6 +59,12 @@ public class GrpcSubmitterServiceTests
   [SetUp]
   public void SetUp()
   {
+    mockResultTable_.Setup(resultTable => resultTable.ReadOnly)
+                    .Returns(mockResultTable_.Object);
+    mockSessionTable_.Setup(sessionTable => sessionTable.ReadOnly)
+                     .Returns(mockSessionTable_.Object);
+    mockTaskTable_.Setup(taskTable => taskTable.ReadOnly)
+                  .Returns(mockTaskTable_.Object);
   }
 
   [TearDown]
@@ -389,6 +395,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetTaskOutputArmonikExceptionShouldThrowRpcException()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.ReadTaskAsync(It.IsAny<string>(),
                                                     It.IsAny<Expression<Func<TaskData, Output>>>(),
                                                     It.IsAny<CancellationToken>()))
@@ -423,6 +431,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetTaskOutputShouldSucceed()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(taskTable => taskTable.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.ReadTaskAsync(It.IsAny<string>(),
                                                     It.IsAny<Expression<Func<TaskData, Output>>>(),
                                                     It.IsAny<CancellationToken>()))
@@ -451,6 +461,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetTaskOutputShouldSucceed2()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.ReadTaskAsync(It.IsAny<string>(),
                                                     It.IsAny<Expression<Func<TaskData, Output>>>(),
                                                     It.IsAny<CancellationToken>()))
@@ -1552,6 +1564,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetStatusShouldSucceed()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, TaskIdStatus>>>(),
                                                      It.IsAny<CancellationToken>()))
@@ -1586,6 +1600,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetStatusTaskNotFoundExceptionShouldThrow()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, TaskIdStatus>>>(),
                                                      It.IsAny<CancellationToken>()))
@@ -1622,6 +1638,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetStatusArmonikExceptionShouldThrow()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, TaskIdStatus>>>(),
                                                      It.IsAny<CancellationToken>()))
@@ -1694,6 +1712,8 @@ public class GrpcSubmitterServiceTests
   public async Task ListTasksShouldSucceed()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, string>>>(),
                                                      It.IsAny<CancellationToken>()))
@@ -1771,6 +1791,8 @@ public class GrpcSubmitterServiceTests
   public async Task ListTaskArmonikExceptionShouldThrow()
   {
     var mock = new Mock<ITaskTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, string>>>(),
                                                      It.IsAny<CancellationToken>()))
@@ -1811,6 +1833,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetResultStatusAsyncArmoniKNotFoundExceptionShouldThrow()
   {
     var mock = new Mock<IResultTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(resultTable => resultTable.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                                      It.IsAny<Expression<Func<Result, ResultIdStatus>>>(),
                                                      It.IsAny<CancellationToken>()))
@@ -1849,6 +1873,8 @@ public class GrpcSubmitterServiceTests
   public async Task GetResultStatusShouldSucceed()
   {
     var mock = new Mock<IResultTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     mock.Setup(resultTable => resultTable.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                                      It.IsAny<Expression<Func<Result, ResultIdStatus>>>(),
                                                      It.IsAny<CancellationToken>()))

--- a/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
+++ b/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
@@ -59,11 +59,11 @@ public class GrpcSubmitterServiceTests
   [SetUp]
   public void SetUp()
   {
-    mockResultTable_.Setup(resultTable => resultTable.ReadOnly)
+    mockResultTable_.Setup(resultTable => resultTable.Secondary)
                     .Returns(mockResultTable_.Object);
-    mockSessionTable_.Setup(sessionTable => sessionTable.ReadOnly)
+    mockSessionTable_.Setup(sessionTable => sessionTable.Secondary)
                      .Returns(mockSessionTable_.Object);
-    mockTaskTable_.Setup(taskTable => taskTable.ReadOnly)
+    mockTaskTable_.Setup(taskTable => taskTable.Secondary)
                   .Returns(mockTaskTable_.Object);
   }
 
@@ -395,7 +395,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetTaskOutputArmonikExceptionShouldThrowRpcException()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.ReadTaskAsync(It.IsAny<string>(),
                                                     It.IsAny<Expression<Func<TaskData, Output>>>(),
@@ -431,7 +431,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetTaskOutputShouldSucceed()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(taskTable => taskTable.ReadOnly)
+    mock.Setup(taskTable => taskTable.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.ReadTaskAsync(It.IsAny<string>(),
                                                     It.IsAny<Expression<Func<TaskData, Output>>>(),
@@ -461,7 +461,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetTaskOutputShouldSucceed2()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.ReadTaskAsync(It.IsAny<string>(),
                                                     It.IsAny<Expression<Func<TaskData, Output>>>(),
@@ -1564,7 +1564,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetStatusShouldSucceed()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, TaskIdStatus>>>(),
@@ -1600,7 +1600,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetStatusTaskNotFoundExceptionShouldThrow()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, TaskIdStatus>>>(),
@@ -1638,7 +1638,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetStatusArmonikExceptionShouldThrow()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, TaskIdStatus>>>(),
@@ -1712,7 +1712,7 @@ public class GrpcSubmitterServiceTests
   public async Task ListTasksShouldSucceed()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, string>>>(),
@@ -1791,7 +1791,7 @@ public class GrpcSubmitterServiceTests
   public async Task ListTaskArmonikExceptionShouldThrow()
   {
     var mock = new Mock<ITaskTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(taskTable => taskTable.FindTasksAsync(It.IsAny<Expression<Func<TaskData, bool>>>(),
                                                      It.IsAny<Expression<Func<TaskData, string>>>(),
@@ -1833,7 +1833,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetResultStatusAsyncArmoniKNotFoundExceptionShouldThrow()
   {
     var mock = new Mock<IResultTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(resultTable => resultTable.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                                      It.IsAny<Expression<Func<Result, ResultIdStatus>>>(),
@@ -1873,7 +1873,7 @@ public class GrpcSubmitterServiceTests
   public async Task GetResultStatusShouldSucceed()
   {
     var mock = new Mock<IResultTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     mock.Setup(resultTable => resultTable.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                                      It.IsAny<Expression<Func<Result, ResultIdStatus>>>(),

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -943,6 +943,8 @@ internal class IntegrationGrpcSubmitterServiceTest
   private static IResultTable CreateResultTableMock(Action<ISetup<IResultTable, IAsyncEnumerable<ResultIdStatus>>> setupAction)
   {
     var mock = new Mock<IResultTable>();
+    mock.Setup(table => table.ReadOnly)
+        .Returns(mock.Object);
     var setup = mock.Setup(table => table.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                                      It.IsAny<Expression<Func<Result, ResultIdStatus>>>(),
                                                      It.IsAny<CancellationToken>()));

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -943,7 +943,7 @@ internal class IntegrationGrpcSubmitterServiceTest
   private static IResultTable CreateResultTableMock(Action<ISetup<IResultTable, IAsyncEnumerable<ResultIdStatus>>> setupAction)
   {
     var mock = new Mock<IResultTable>();
-    mock.Setup(table => table.ReadOnly)
+    mock.Setup(table => table.Secondary)
         .Returns(mock.Object);
     var setup = mock.Setup(table => table.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                                      It.IsAny<Expression<Func<Result, ResultIdStatus>>>(),


### PR DESCRIPTION
# Motivation

Monitoring RPCs (like list and count) are heavy on the database, but do not target secondary servers.
This imposes a high load on the primary server, while those RPCs do not require the consistency offered by the primary.

# Description

Refactor MongoDB Adapter to mutualize code between tables, and implement read-only optimizations to target read replicas for monitoring services.

# Testing

Deploy ArmoniK with 3 MongoDB replicas.
Populate the database with many tasks (> 100k), and go to the list of session page on the GUI.
Configure the auto refresh to 0.1s.

With main, only the primary has some loads. with this PR, only secondaries have load.
If there is a single replicas, it still works and the load goes (obviously) to the primary.

# Impact

Read RPCs are configured to target read replicas. It might be possible to have inconsistencies with writes that are done on the primary if the read RPC is performed too quickly after the write. To limit this impact, read preference has been enabled only on Count RPCs.

# Additional Information

More refactor can be done to integrate SessionProvider and CollectionProvider within BaseTable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.