### PR TITLE
fix: Add a Retry(3) to ExecuteTaskWithExceptionDuringCancellationShouldSucceed

### DIFF
--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -1606,6 +1606,7 @@ public class TaskHandlerTest
   }
 
   [Test]
+  [Retry(3)]
   [TestCaseSource(nameof(TestCaseOuptut))]
   public async Task<(TaskStatus taskStatus, QueueMessageStatus messageStatus)> ExecuteTaskWithExceptionDuringCancellationShouldSucceed<TEx>(
     ExceptionWorkerStreamHandler<TEx> workerStreamHandler,


### PR DESCRIPTION
# Motivation

The ExecuteTaskWithExceptionDuringCancellationShouldSucceed Test passed after two checks, add a retry(3) so we don't have to run it manually 3 times

# Description

Add a retry(3)
# Testing

Pipeline

# Impact

Improving the pipeline 

# Additional Information

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
