### PR TITLE
chore: embed replica set and partition setup into init script

### DIFF
--- a/terraform/modules/storage/database/mongo/main.tf
+++ b/terraform/modules/storage/database/mongo/main.tf
@@ -51,16 +51,12 @@ resource "time_sleep" "wait" {
 locals {
   linux_run = "docker exec ${docker_container.database.name} mongosh mongodb://127.0.0.1:27017/${var.mongodb_params.database_name} --tls --tlsCAFile /mongo-certificate/ca.pem"
   // mongosh is not installed in windows docker images so we need it to be installed locally
-  windows_run       = "mongosh.exe mongodb://127.0.0.1:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name}?serverSelectionTimeoutMS=10000 --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
-  prefix_run        = var.mongodb_params.windows ? local.windows_run : local.linux_run
-  mongo_init_repset = <<EOT
-rs.initiate({
-  _id: "${var.mongodb_params.replica_set_name}",
-  members: [
-    {_id: 0, host: "127.0.0.1:27017"}
-  ]
-});
-EOT
+  windows_run = "mongosh.exe mongodb://127.0.0.1:${var.mongodb_params.exposed_port}/${var.mongodb_params.database_name}?serverSelectionTimeoutMS=10000 --tls --tlsCAFile ${local_sensitive_file.ca.filename}"
+  prefix_run  = var.mongodb_params.windows ? local.windows_run : local.linux_run
+  mongo_init_repset = templatefile("${path.module}/mongo_init.tpl.js", {
+    replica_set_name = var.mongodb_params.replica_set_name
+    partition_data   = jsonencode(values(var.partition_list))
+  })
 }
 resource "local_file" "mongo_init" {
   content  = local.mongo_init_repset
@@ -72,13 +68,4 @@ resource "null_resource" "init_replica" {
     command = var.mongodb_params.windows ? "${local.windows_run} --file ${local_file.mongo_init.filename}" : "${local.linux_run} --file /mongo-init.js"
   }
   depends_on = [time_sleep.wait]
-}
-
-
-resource "null_resource" "partitions_in_db" {
-  for_each = var.partition_list
-  provisioner "local-exec" {
-    command = "${local.prefix_run} --eval 'db.PartitionData.insertOne(${jsonencode(each.value)})'"
-  }
-  depends_on = [null_resource.init_replica]
 }

--- a/terraform/modules/storage/database/mongo/mongo_init.tpl.js
+++ b/terraform/modules/storage/database/mongo/mongo_init.tpl.js
@@ -1,0 +1,22 @@
+rs.initiate(
+{
+  _id: "${replica_set_name}",
+  members: [
+    {_id: 0, host: "127.0.0.1:27017"}
+  ]
+});
+
+let initialized = false;
+while(initialized === false)
+{
+  try {
+    if (rs.status().myState === 1) {
+      initialized = true;
+      sleep(10000);
+    }
+  } catch (e) {
+    sleep(1000);
+  }
+}
+
+db.PartitionData.insertMany(${partition_data});

--- a/terraform/modules/storage/database/mongo/outputs.tf
+++ b/terraform/modules/storage/database/mongo/outputs.tf
@@ -22,7 +22,7 @@ output "generated_env_vars" {
     "MongoDB__ServerSelectionTimeout"        = "00:00:20"
   }
 
-  depends_on = [null_resource.partitions_in_db]
+  depends_on = [null_resource.init_replica]
 }
 
 output "core_mounts" {


### PR DESCRIPTION
# Motivation

When deploying Core, a MongoDB restart required manually re-inserting the partition data by hand. This process was tedious and error-prone, especially since it was triggered automatically via Terraform. This PR aims to improve deployment resilience and developer experience by automating this step.

# Description

This PR integrates the partition insertion logic directly into the MongoDB replica set init script. It includes a loop that waits for the replica set to be ready before proceeding, ensuring a reliable setup even after a database restart.

# Testing

Tested locally by restarting MongoDB after deployment and verifying that the replica set is correctly initialized and that partition data is inserted automatically without requiring manual intervention.

# Impact

Improves reliability of deployments involving MongoDB by ensuring the system can recover cleanly after restarts. Reduces manual steps and potential errors. No external dependencies added. No change in ArmoniK Core behavior.

# Additional Information

Partition data is injected using Terraform variables, making the script generic and reusable across environments.

# Checklist

* [x] My code adheres to the coding and style guidelines of the project.
* [x] I have performed a self-review of my code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [x] I have made corresponding changes to the documentation.
* [x] I have thoroughly tested my modifications and added tests when necessary.
* [x] Tests pass locally and in the CI.
* [x] I have assessed the performance impact of my modifications.

