### PR TITLE
docs: Add inherit docs and ignore warning on main

### DIFF
--- a/Adaptors/MongoDB/src/Common/SessionProvider.cs
+++ b/Adaptors/MongoDB/src/Common/SessionProvider.cs
@@ -41,6 +41,7 @@ public class SessionProvider : IInitializable
   public SessionProvider(IMongoClient client)
     => client_ = client;
 
+  /// <inheritdoc />
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
     => tag switch
        {
@@ -55,6 +56,7 @@ public class SessionProvider : IInitializable
                                                     null),
        };
 
+  /// <inheritdoc />
   public Task Init(CancellationToken cancellationToken)
   {
     if (clientSessionHandle_ is not null)

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -259,6 +259,7 @@ public class ResultTable : BaseTable<Result, ResultDataModelMapping>, IResultTab
     }
   }
 
+  /// <inheritdoc />
   public IAsyncEnumerable<T> GetResults<T>(Expression<Func<Result, bool>> filter,
                                            Expression<Func<Result, T>>    convertor,
                                            CancellationToken              cancellationToken = default)

--- a/Adaptors/MongoDB/src/SessionTable.cs
+++ b/Adaptors/MongoDB/src/SessionTable.cs
@@ -65,6 +65,7 @@ public class SessionTable : BaseTable<SessionData, SessionDataModelMapping>, ISe
                         true);
 
 
+  /// <inheritdoc />
   [PublicAPI]
   public async Task<string> SetSessionDataAsync(IEnumerable<string> partitionIds,
                                                 TaskOptions         defaultOptions,

--- a/Adaptors/MongoDB/src/Table/DataModel/Auth/AuthDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/Auth/AuthDataModelMapping.cs
@@ -78,6 +78,7 @@ public class AuthDataModelMapping : IMongoDataModelMapping<AuthData>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                    Options.MongoDB      options)
     => Task.CompletedTask;

--- a/Adaptors/MongoDB/src/Table/DataModel/Auth/RoleDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/Auth/RoleDataModelMapping.cs
@@ -74,6 +74,7 @@ public class RoleDataModelMapping : IMongoDataModelMapping<RoleData>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                    Options.MongoDB      options)
     => Task.CompletedTask;

--- a/Adaptors/MongoDB/src/Table/DataModel/Auth/UserDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/Auth/UserDataModelMapping.cs
@@ -74,6 +74,7 @@ public class UserDataModelMapping : IMongoDataModelMapping<UserData>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                    Options.MongoDB      options)
     => Task.CompletedTask;

--- a/Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs
@@ -91,6 +91,7 @@ public class PartitionDataModelMapping : IMongoDataModelMapping<PartitionData>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                    Options.MongoDB      options)
     => Task.CompletedTask;

--- a/Adaptors/MongoDB/src/Table/DataModel/ResultDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/ResultDataModelMapping.cs
@@ -109,6 +109,7 @@ public record ResultDataModelMapping : IMongoDataModelMapping<Result>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public async Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                          Options.MongoDB      options)
     => await sessionHandle.shardCollection(options,

--- a/Adaptors/MongoDB/src/Table/DataModel/SessionDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/SessionDataModelMapping.cs
@@ -138,6 +138,7 @@ public record SessionDataModelMapping : IMongoDataModelMapping<SessionData>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public async Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                          Options.MongoDB      options)
     => await sessionHandle.shardCollection(options,

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -212,6 +212,7 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
                     .ConfigureAwait(false);
   }
 
+  /// <inheritdoc />
   public async Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                          Options.MongoDB      options)
     => await sessionHandle.shardCollection(options,

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -68,7 +68,10 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
     => new TaskTable(this,
                      true);
 
+  /// <inheritdoc />
   public TimeSpan PollingDelayMin { get; set; }
+
+  /// <inheritdoc />
   public TimeSpan PollingDelayMax { get; set; }
 
   /// <inheritdoc />
@@ -187,6 +190,7 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
     }
   }
 
+  /// <inheritdoc />
   public async Task DeleteTasksAsync(string            sessionId,
                                      CancellationToken cancellationToken = default)
   {

--- a/Adaptors/PubSub/src/QueueBuilder.cs
+++ b/Adaptors/PubSub/src/QueueBuilder.cs
@@ -33,6 +33,7 @@ namespace ArmoniK.Core.Adapters.PubSub;
 [PublicAPI]
 public class QueueBuilder : IDependencyInjectionBuildable
 {
+  /// <inheritdoc />
   public void Build(IServiceCollection   serviceCollection,
                     ConfigurationManager configuration,
                     ILogger              logger)

--- a/Adaptors/S3/src/ObjectStorage.cs
+++ b/Adaptors/S3/src/ObjectStorage.cs
@@ -212,6 +212,7 @@ public class ObjectStorage : IObjectStorage
                                                       cancellationToken))
                 .ConfigureAwait(false);
 
+  /// <inheritdoc />
   public async Task<IDictionary<byte[], long?>> GetSizesAsync(IEnumerable<byte[]> ids,
                                                               CancellationToken   cancellationToken = default)
     => await ids.ParallelSelect(async id => (id, await GetSizeAsync(id,

--- a/Adaptors/SQS/src/QueueBuilder.cs
+++ b/Adaptors/SQS/src/QueueBuilder.cs
@@ -32,6 +32,7 @@ namespace ArmoniK.Core.Adapters.SQS;
 [PublicAPI]
 public class QueueBuilder : IDependencyInjectionBuildable
 {
+  /// <inheritdoc />
   public void Build(IServiceCollection   serviceCollection,
                     ConfigurationManager configuration,
                     ILogger              logger)

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -53,6 +53,8 @@ using Serilog;
 using Pollster = ArmoniK.Core.Common.Injection.Options.Pollster;
 using Submitter = ArmoniK.Core.Common.Injection.Options.Submitter;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace ArmoniK.Core.Compute.PollingAgent;
 
 public static class Program

--- a/Compute/PollingAgent/src/Worker.cs
+++ b/Compute/PollingAgent/src/Worker.cs
@@ -22,6 +22,8 @@ using ArmoniK.Core.Common.Pollster;
 
 using Microsoft.Extensions.Hosting;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace ArmoniK.Core.Compute.PollingAgent;
 
 public class Worker : BackgroundService

--- a/Control/Metrics/src/ArmoniKMeter.cs
+++ b/Control/Metrics/src/ArmoniKMeter.cs
@@ -32,6 +32,8 @@ using Microsoft.Extensions.Logging;
 
 using TaskStatus = ArmoniK.Core.Common.Storage.TaskStatus;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace ArmoniK.Core.Control.Metrics;
 
 public class ArmoniKMeter : Meter, IHostedService
@@ -137,6 +139,7 @@ public class ArmoniKMeter : Meter, IHostedService
     }
   }
 
+  /// <inheritdoc />
   public async Task StartAsync(CancellationToken cancellationToken)
   {
     // Call an aggregate gauge in order to populate all gauges.
@@ -148,6 +151,7 @@ public class ArmoniKMeter : Meter, IHostedService
                      gauges_.Values.Select(reader => reader.Name));
   }
 
+  /// <inheritdoc />
   public Task StopAsync(CancellationToken cancellationToken)
     => Task.CompletedTask;
 

--- a/Control/Metrics/src/Program.cs
+++ b/Control/Metrics/src/Program.cs
@@ -39,6 +39,8 @@ using OpenTelemetry.Resources;
 
 using Serilog;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace ArmoniK.Core.Control.Metrics;
 
 public static class Program

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -53,6 +53,8 @@ using OpenTelemetry.Trace;
 
 using Serilog;
 
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
 namespace ArmoniK.Core.Control.Submitter;
 
 public static class Program


### PR DESCRIPTION
# Motivation

We still have warnings about public fields not documented.

# Description

Add inheritdoc wherever possible.
Ignore XML doc warnings on Program.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
