### PR TITLE
feat: Add NATS adapter with JetStream support to ArmoniK queues

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,8 @@ jobs:
           - rabbitmq
           - rabbitmq091
           - sqs
-          - pubsub     
+          - pubsub
+          - nats
       fail-fast: false
     runs-on: ubuntu-latest
     steps:
@@ -361,6 +362,7 @@ jobs:
           - rabbitmq091
           - sqs
           - pubsub
+          - nats
         log-level:
           - Information
           - Verbose
@@ -466,30 +468,35 @@ jobs:
           - { queue: rabbitmq091, object: redis, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
           - { queue: pubsub, object: redis, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
           - { queue: sqs, object: redis, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
+          - { queue: nats, object: redis, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
 
           - { queue: activemq, object: redis, log-level: Information, socket_type: tcp, cinit: true  }
           - { queue: rabbitmq, object: redis, log-level: Information, socket_type: tcp, cinit: true  }
           - { queue: rabbitmq091, object: redis, log-level: Information, socket_type: tcp, cinit: true  }
           - { queue: pubsub, object: redis, log-level: Information, socket_type: tcp, cinit: true  }
           - { queue: sqs, object: redis, log-level: Information, socket_type: tcp, cinit: true  }
+          - { queue: nats, object: redis, log-level: Information, socket_type: tcp, cinit: true  }
 
           - { queue: activemq, object: redis, log-level: Verbose, socket_type: unixdomainsocket, cinit: true }
           - { queue: rabbitmq, object: redis, log-level: Verbose, socket_type: unixdomainsocket, cinit: true  }
           - { queue: rabbitmq091, object: redis, log-level: Verbose, socket_type: unixdomainsocket, cinit: true  }
           - { queue: pubsub, object: redis, log-level: Verbose, socket_type: unixdomainsocket, cinit: true  }
           - { queue: sqs, object: redis, log-level: Verbose, socket_type: unixdomainsocket, cinit: true  }
+          - { queue: nats, object: redis, log-level: Verbose, socket_type: unixdomainsocket, cinit: true  }
 
           - { queue: activemq, object: minio, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
           - { queue: rabbitmq, object: minio, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
           - { queue: rabbitmq091, object: minio, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
           - { queue: pubsub, object: minio, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
           - { queue: sqs, object: minio, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
+          - { queue: nats, object: minio, log-level: Information, socket_type: unixdomainsocket, cinit: true  }
 
           - { queue: activemq, object: embed, log-level: Information, socket_type: unixdomainsocket, cinit: true }
           - { queue: rabbitmq, object: embed, log-level: Information, socket_type: unixdomainsocket, cinit: true }
           - { queue: rabbitmq091, object: embed, log-level: Information, socket_type: unixdomainsocket, cinit: true }
           - { queue: pubsub, object: embed, log-level: Information, socket_type: unixdomainsocket, cinit: true }
           - { queue: sqs, object: embed, log-level: Information, socket_type: unixdomainsocket, cinit: true }
+          - { queue: nats, object: embed, log-level: Information, socket_type: unixdomainsocket, cinit: true }
 
           - { queue: activemq, object: redis, log-level: Information, socket_type: unixdomainsocket, cinit: true }
           - { queue: activemq, object: redis, log-level: Information, socket_type: unixdomainsocket, cinit: false }

--- a/Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj
+++ b/Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj
@@ -1,0 +1,51 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;linux-x64;linux-arm64</RuntimeIdentifiers>
+    <Company>ANEO</Company>
+    <Copyright>Copyright (C) ANEO, 2021-2021</Copyright>
+    <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
+    <PackageRequireLicenseAcceptance>True</PackageRequireLicenseAcceptance>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <IsPackable>true</IsPackable>
+    <Nullable>enable</Nullable>
+    <EnableDynamicLoading>true</EnableDynamicLoading>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>Embedded</DebugType>
+    <IncludeSymbols>true</IncludeSymbols>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <Optimize>true</Optimize>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ArmoniK.Utils.Diagnostics" Version="0.6.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NATS.Client" Version="1.1.8" />
+    <PackageReference Include="NATS.Client.JetStream" Version="2.6.6" />
+    <PackageReference Include="NATS.Net" Version="2.6.6" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Base\src\ArmoniK.Core.Base.csproj">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\Utils\src\ArmoniK.Core.Utils.csproj">
+      <Private>false</Private>
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </ProjectReference>
+  </ItemGroup>
+</Project>
+
+

--- a/Adaptors/Nats/src/Heart.cs
+++ b/Adaptors/Nats/src/Heart.cs
@@ -1,0 +1,113 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ArmoniK.Core.Adapters.Nats;
+
+/// <summary>
+///   Represents a heartbeat mechanism that executes a specified function at regular intervals.
+/// </summary>
+public class Heart
+{
+  private readonly TimeSpan          beatPeriod_;
+  private readonly CancellationToken cancellationToken_;
+
+  private readonly Func<CancellationToken, Task> pulse_;
+
+  private Task? runningTask_;
+
+  private CancellationTokenSource? stoppedHeartCts_;
+
+  /// <summary>
+  ///   <param name="pulse">
+  ///     The function to execute at each beat
+  ///     It returns a predicate indicating if the heart must continue beating
+  ///   </param>
+  ///   <param name="beatPeriod">Defines the timespan between two heartbeats</param>
+  ///   <param name="cancellationToken"></param>
+  ///   <returns></returns>
+  /// </summary>
+  public Heart(Func<CancellationToken, Task> pulse,
+               TimeSpan                      beatPeriod,
+               CancellationToken             cancellationToken = default)
+  {
+    cancellationToken_ = cancellationToken;
+    pulse_             = pulse;
+    beatPeriod_        = beatPeriod;
+  }
+
+  /// <summary>
+  ///   Stops the heart
+  /// </summary>
+  /// <returns>A task finishing with the last heartbeat</returns>
+  public async Task Stop()
+  {
+    stoppedHeartCts_?.Cancel();
+    try
+    {
+      if (runningTask_ is not null)
+      {
+        await runningTask_;
+      }
+    }
+    catch (OperationCanceledException)
+    {
+    }
+    catch (AggregateException ae)
+    {
+      ae.Handle(exception => exception is not OperationCanceledException);
+    }
+    finally
+    {
+      stoppedHeartCts_?.Dispose();
+      stoppedHeartCts_ = null;
+    }
+  }
+
+  /// <summary>
+  ///   Start the heart. If the heart is beating, it has no effect.
+  /// </summary>
+  public void Start()
+  {
+    if (stoppedHeartCts_ is not null) // already running with infinite loop
+    {
+      return;
+    }
+
+    stoppedHeartCts_ = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken_);
+
+    runningTask_ = Task<Task>.Factory.StartNew(async () =>
+                                               {
+                                                 while (!stoppedHeartCts_.IsCancellationRequested)
+                                                 {
+                                                   var delayTask = Task.Delay(beatPeriod_,
+                                                                              stoppedHeartCts_.Token);
+                                                   await pulse_(cancellationToken_)
+                                                     .ConfigureAwait(false);
+
+                                                   await delayTask.ConfigureAwait(false);
+                                                 }
+                                               },
+                                               CancellationToken.None,
+                                               TaskCreationOptions.LongRunning,
+                                               TaskScheduler.Current)
+                             .Unwrap();
+  }
+}

--- a/Adaptors/Nats/src/Nats.cs
+++ b/Adaptors/Nats/src/Nats.cs
@@ -1,0 +1,54 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace ArmoniK.Core.Adapters.Nats;
+
+/// <summary>
+///   All Allowed option for Nats queue in ArmoniK.
+///   Can be set through configuration sources.
+/// </summary>
+internal class Nats
+{
+  /// <summary>
+  ///   The configuration section name used to bind NATS settings from configuration sources.
+  /// </summary>
+  public const string SettingSection = nameof(Nats);
+
+  /// <summary>
+  ///   The URL of the NATS server to connect to.
+  ///   This should include protocol, host, and port, e.g. "nats://localhost:4222".
+  /// </summary>
+  public string Url { get; set; } = string.Empty;
+
+  /// <summary>
+  ///   Acknowledgment deadline in seconds: If a message wasn't acknowledged within this deadline, it will be
+  ///   redelivered .
+  /// </summary>
+  public int AckWait { get; set; } = 120;
+
+  /// <summary>
+  ///   Time  in seconds between two modifications of acknowledgment deadline
+  /// </summary>
+  public int AckExtendDeadlineStep { get; set; } = 60;
+
+  /// <summary>
+  ///   Limit on the level of parallelism for operations.
+  ///   If DegreeOfParallelism is 0, the number of threads is used as the limit.
+  ///   If DegreeOfParallelism is negative, no limit is enforced.
+  /// </summary>
+  public int DegreeOfParallelism { get; set; }
+}

--- a/Adaptors/Nats/src/PullQueueStorage.cs
+++ b/Adaptors/Nats/src/PullQueueStorage.cs
@@ -1,0 +1,157 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace ArmoniK.Core.Adapters.Nats;
+
+/// <summary>
+///   Retrieve messages from the queue.
+/// </summary>
+internal class PullQueueStorage : IPullQueueStorage
+{
+  private readonly INatsJSContext js_;
+  private readonly ILogger        logger_;
+  private readonly Nats           options_;
+  private          bool           isInitialized_;
+
+  /// <summary>
+  ///   Activate logger, get the options and the JetStreamContex through dependency injection
+  /// </summary>
+  /// <param name="logger">Enable activation of log in the class</param>
+  /// <param name="options">Nats options </param>
+  /// <param name="js">The JetStreamContext allowing to create and manage streams</param>
+  public PullQueueStorage(ILogger<PullQueueStorage> logger,
+                          Nats                      options,
+                          INatsJSContext            js)
+  {
+    options_ = options;
+    js_      = js;
+    logger_  = logger;
+  }
+
+  /// <inheritdoc />
+  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => Task.FromResult(isInitialized_
+                         ? HealthCheckResult.Healthy()
+                         : HealthCheckResult.Unhealthy("Plugin is not yet initialized."));
+
+  /// <inheritdoc />
+  public Task Init(CancellationToken cancellationToken)
+  {
+    if (!isInitialized_)
+    {
+      isInitialized_ = true;
+    }
+
+    return Task.CompletedTask;
+  }
+
+  /// <inheritdoc />
+  public int MaxPriority
+    => int.MaxValue;
+
+  /// <inheritdoc />
+  /// <remarks>
+  ///   The method performs the following steps:
+  ///   1. Obtains a reference to the JetStream stream "armonik-stream" or create the stream.
+  ///   2. Attempts to get an existing consumer bound to the given <paramref name="partitionId" />.
+  ///   - If the consumer does not exist (<see cref="NatsJSException" />), it creates a new durable consumer
+  ///   with <c>DurableName</c> set to <paramref name="partitionId" />, and with
+  ///   <see cref="ConsumerConfigAckPolicy.Explicit" /> to require manual acknowledgement of messages.
+  ///   3. Pulls up to <paramref name="nbMessages" /> messages from the consumer using <see cref="NatsJSFetchOpts.MaxMsgs" />
+  ///   .
+  ///   4. For each message fetched, wraps it into a <see cref="QueueMessageHandler" /> which manages acknowledgement
+  ///   (Ack, Nack, extend deadlines, etc.) according to configured options (<c>AckWait</c> and <c>AckExtendDeadlineStep</c>
+  ///   ).
+  ///   5. Returns the message handlers as an asynchronous stream (<see cref="IAsyncEnumerable{T}" />), so messages
+  ///   can be processed one by one as they arrive.
+  ///   This ensures that if a consumer for the given partition does not exist, it is created on-demand,
+  ///   and messages are always processed through a uniform handler abstraction.
+  /// </remarks>
+  public async IAsyncEnumerable<IQueueMessageHandler> PullMessagesAsync(string                                     partitionId,
+                                                                        int                                        nbMessages,
+                                                                        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  {
+    INatsJSConsumer? consumer;
+    INatsJSStream?   stream;
+    try
+    {
+      stream = await js_.GetStreamAsync("armonik-stream")
+                        .ConfigureAwait(false);
+    }
+    catch (NatsJSApiException ex) when (ex.Error.Code == 404)
+    {
+      var config = new StreamConfig
+                   {
+                     Name    = "armonik-stream",
+                     Storage = StreamConfigStorage.File,
+                     Subjects = new[]
+                                {
+                                  partitionId,
+                                },
+                     Retention = StreamConfigRetention.Workqueue,
+                   };
+      stream = await js_.CreateStreamAsync(config)
+                        .ConfigureAwait(false);
+    }
+
+    try
+    {
+      consumer = await stream.GetConsumerAsync(partitionId)
+                             .ConfigureAwait(false);
+    }
+    catch (NatsJSApiException ex) when (ex.Error.Code == 404)
+    {
+      consumer = await js_.CreateConsumerAsync("armonik-stream",
+                                               new ConsumerConfig(partitionId)
+                                               {
+                                                 DurableName   = partitionId,
+                                                 AckWait       = TimeSpan.FromSeconds(options_.AckWait),
+                                                 AckPolicy     = ConsumerConfigAckPolicy.Explicit,
+                                                 FilterSubject = partitionId,
+                                               })
+                          .ConfigureAwait(false);
+    }
+
+    await foreach (var natsJSMsg in consumer.FetchAsync<string>(new NatsJSFetchOpts
+                                                                {
+                                                                  MaxMsgs = nbMessages,
+                                                                }))
+    {
+      yield return new QueueMessageHandler(natsJSMsg,
+                                           js_,
+                                           options_.AckWait,
+                                           options_.AckExtendDeadlineStep,
+                                           logger_,
+                                           cancellationToken);
+    }
+  }
+}

--- a/Adaptors/Nats/src/PushQueueStorage.cs
+++ b/Adaptors/Nats/src/PushQueueStorage.cs
@@ -1,0 +1,156 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Utils;
+
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+using NATS.Client.Core;
+using NATS.Client.JetStream;
+using NATS.Client.JetStream.Models;
+
+namespace ArmoniK.Core.Adapters.Nats;
+
+/// <summary>
+///   Insert messages into the queue.
+/// </summary>
+internal class PushQueueStorage : IPushQueueStorage
+{
+  private readonly INatsJSContext js_;
+  private readonly Nats           options_;
+  private          bool           isInitialized_;
+
+  /// <summary>
+  ///   Set Jet Stream and option as member value
+  ///   if the configured value is less than 1, it defaults to 1.
+  /// </summary>
+  /// <param name="js">The DI container to register services into.</param>
+  /// <param name="options">The options </param>
+  public PushQueueStorage(INatsJSContext js,
+                          Nats           options)
+  {
+    js_      = js;
+    options_ = options;
+  }
+
+
+  /// <inheritdoc />
+  public int MaxPriority
+    => int.MaxValue;
+
+  /// <inheritdoc />
+  public Task<HealthCheckResult> Check(HealthCheckTag tag)
+    => Task.FromResult(isInitialized_
+                         ? HealthCheckResult.Healthy()
+                         : HealthCheckResult.Unhealthy("Plugin is not yet initialized."));
+
+  /// <inheritdoc />
+  public Task Init(CancellationToken cancellationToken)
+  {
+    isInitialized_ = true;
+    return Task.CompletedTask;
+  }
+
+  /// <inheritdoc />
+  /// <remarks>
+  ///   Attempts to publish all messages to the given subject.
+  ///   If publishing fails, the method checks whether the stream exists:
+  ///   - If the stream exists, it updates the stream configuration to include the subject.
+  ///   - If the stream does not exist (404), it creates a new stream with the subject.
+  ///   After fixing the stream, the messages are published again.
+  /// </remarks>
+  public async Task PushMessagesAsync(IEnumerable<MessageData> messages,
+                                      string                   partitionId,
+                                      CancellationToken        cancellationToken = default)
+  {
+    try
+    {
+      await Publish(messages,
+                    partitionId,
+                    cancellationToken);
+    }
+    catch (Exception)
+    {
+      try
+      {
+        var existing = await js_.GetStreamAsync("armonik-stream")
+                                .ConfigureAwait(false);
+        if (!existing.Info.Config.Subjects!.Contains(partitionId))
+        {
+          existing.Info.Config.Subjects!.Add(partitionId);
+          await js_.UpdateStreamAsync(existing.Info.Config)
+                   .ConfigureAwait(false);
+        }
+      }
+      catch (NatsJSApiException ex) when (ex.Error.Code == 404)
+      {
+        var config = new StreamConfig
+                     {
+                       Name    = "armonik-stream",
+                       Storage = StreamConfigStorage.File,
+                       Subjects = new[]
+                                  {
+                                    partitionId,
+                                  },
+                       Retention = StreamConfigRetention.Workqueue,
+                     };
+        await js_.CreateStreamAsync(config)
+                 .ConfigureAwait(false);
+      }
+
+      await Publish(messages,
+                    partitionId,
+                    cancellationToken);
+    }
+  }
+
+  /// <summary>
+  ///   Push all messages to partitionId subject in queue.
+  /// </summary>
+  /// <param name="messages">an IEnumerable containing taskId.</param>
+  /// <param name="partitionId">The partition Id use for this tasks.</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method.</param>
+  /// <returns> Task representing the asynchronous execution of the method.</returns>
+  private async Task Publish(IEnumerable<MessageData> messages,
+                             string                   partitionId,
+                             CancellationToken        cancellationToken = default)
+    => await messages.ParallelForEach(new ParallelTaskOptions(options_.DegreeOfParallelism,
+                                                              cancellationToken),
+                                      async message =>
+                                      {
+                                        await js_.PublishAsync(partitionId,
+                                                               Encoding.UTF8.GetBytes(message.TaskId),
+                                                               headers: new NatsHeaders
+                                                                        {
+                                                                          {
+                                                                            "Nats-Msg-Id", Guid.NewGuid()
+                                                                                               .ToString()
+                                                                          },
+                                                                        },
+                                                               cancellationToken: cancellationToken)
+                                                 .ConfigureAwait(false);
+                                      })
+                     .ConfigureAwait(false);
+}

--- a/Adaptors/Nats/src/QueueBuilder.cs
+++ b/Adaptors/Nats/src/QueueBuilder.cs
@@ -1,0 +1,61 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using ArmoniK.Core.Base;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+using NATS.Client.JetStream;
+using NATS.Net;
+
+namespace ArmoniK.Core.Adapters.Nats;
+
+/// <summary>
+///   Build object for Nats Jetstream Adapter through dependancy.
+/// </summary>
+public class QueueBuilder : IDependencyInjectionBuildable
+{
+  /// <inheritdoc />
+  /// <remarks>
+  ///   Registers all NATS-related services into the dependency injection container.
+  ///   - Loads NATS options from configuration (throws if missing).
+  ///   - Registers the NATS options instance as a singleton.
+  ///   - Creates and registers a JetStream context (INatsJSContext) from a NatsClient.
+  ///   - Registers queue storage implementations: PullQueueStorage and PushQueueStorage.
+  /// </remarks>
+  public void Build(IServiceCollection   serviceCollection,
+                    ConfigurationManager configuration,
+                    ILogger              logger)
+  {
+    var natsOptions = configuration.GetSection(Nats.SettingSection)
+                                   .Get<Nats>() ?? throw new InvalidOperationException("Options not found");
+    Console.WriteLine(natsOptions.Url);
+    serviceCollection.AddSingleton(natsOptions);
+    serviceCollection.AddSingleton<INatsJSContext>(sp =>
+                                                   {
+                                                     var nc = new NatsClient(natsOptions.Url);
+                                                     return nc.CreateJetStreamContext();
+                                                   });
+
+    serviceCollection.AddSingleton<IPullQueueStorage, PullQueueStorage>();
+    serviceCollection.AddSingleton<IPushQueueStorage, PushQueueStorage>();
+  }
+}

--- a/Adaptors/Nats/src/QueueMessageHandler.cs
+++ b/Adaptors/Nats/src/QueueMessageHandler.cs
@@ -1,0 +1,156 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2025. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+
+using ArmoniK.Core.Base;
+
+using Microsoft.Extensions.Logging;
+
+using NATS.Client.JetStream;
+
+namespace ArmoniK.Core.Adapters.Nats;
+
+/// <summary>
+///   Handle queue messages lifecycle
+/// </summary>
+internal class QueueMessageHandler : IQueueMessageHandler
+{
+  private readonly Heart             autoExtendAckDeadline_;
+  private readonly INatsJSContext    js_;
+  private readonly ILogger           logger_;
+  private readonly NatsJSMsg<string> message_;
+  private          StackTrace?       stackTrace_;
+
+  /// <summary>
+  ///   Set needed parameter and start the Heart <see cref="Heart" /> .
+  /// </summary>
+  /// <param name="message">The message to handle. Contain taskId</param>
+  /// <param name="js"> </param>
+  /// <param name="AckWait">
+  ///   <see cref="Nats.AckWait" />
+  /// </param>
+  /// <param name="ackExtendDeadlineStep">
+  ///   <see cref="Nats.AckExtendDeadlineStep" />
+  /// </param>
+  /// <param name="logger">Singleton use to aggregate logs</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method.</param>
+  public QueueMessageHandler(NatsJSMsg<string> message,
+                             INatsJSContext    js,
+                             int               AckWait,
+                             int               ackExtendDeadlineStep,
+                             ILogger           logger,
+                             CancellationToken cancellationToken)
+  {
+    js_       = js;
+    message_  = message;
+    MessageId = message.Headers["Nats-Msg-Id"];
+
+    TaskId            = message.Data!;
+    ReceptionDateTime = DateTime.UtcNow;
+    logger_           = logger;
+    stackTrace_       = new StackTrace(true);
+    autoExtendAckDeadline_ = new Heart(ModifyAckDeadline,
+                                       TimeSpan.FromSeconds(ackExtendDeadlineStep),
+                                       CancellationToken);
+    autoExtendAckDeadline_.Start();
+  }
+
+  public CancellationToken  CancellationToken { get; set; }
+  public string             MessageId         { get; }
+  public string             TaskId            { get; }
+  public QueueMessageStatus Status            { get; set; }
+  public DateTime           ReceptionDateTime { get; init; }
+
+  /// <inheritdoc />
+  /// <remarks>
+  ///   Stops the automatic ack-deadline extension, then:
+  ///   - For messages in Waiting, Failed, Running, or Postponed status, calls AckProgressAsync to extend the processing
+  ///   window.
+  ///   - For messages in Cancelled, Processed, or Poisonous status, calls AckAsync to mark the message as fully
+  ///   acknowledged.
+  ///   Finally, suppresses the finalizer to avoid double-disposal.
+  /// </remarks>
+  public async ValueTask DisposeAsync()
+  {
+    stackTrace_ = null;
+
+    await autoExtendAckDeadline_.Stop()
+                                .ConfigureAwait(false);
+
+    switch (Status)
+    {
+      case QueueMessageStatus.Waiting:
+      case QueueMessageStatus.Failed:
+      case QueueMessageStatus.Running:
+      case QueueMessageStatus.Postponed:
+        await message_.NakAsync()
+                      .ConfigureAwait(false);
+        break;
+      case QueueMessageStatus.Cancelled:
+      case QueueMessageStatus.Processed:
+      case QueueMessageStatus.Poisonous:
+        await message_.AckAsync()
+                      .ConfigureAwait(false);
+        break;
+      default:
+        throw new ArgumentOutOfRangeException();
+    }
+
+    GC.SuppressFinalize(this);
+  }
+
+  /// <summary>
+  ///   Extends the acknowledgement deadline for the current message.
+  /// </summary>
+  private async Task ModifyAckDeadline(CancellationToken cancellationToken)
+    => await message_.AckProgressAsync()
+                     .ConfigureAwait(false);
+
+  /// <summary>
+  ///   Finalizer for <see cref="QueueMessageHandler" /> Acts as a safety net to log undisposed handlers and force cleanup,
+  ///   though explicit disposal is strongly recommended.
+  /// </summary>
+  /// <remarks>
+  ///   Ensures that message handlers are properly disposed even if the user forgets to call <c>Dispose</c> or
+  ///   <c>DisposeAsync</c>.
+  ///   If the handler was not disposed:
+  ///   - Logs an error including the message ID, task ID, and the captured creation stack trace.
+  ///   - Forces a synchronous call to <see cref="DisposeAsync" /> to release resources.
+  ///   This acts as a safety net to prevent resource leaks, but relying on finalizers is discouraged.
+  ///   Users should always dispose <see cref="QueueMessageHandler" /> explicitly to avoid non-deterministic cleanup timing.
+  /// </remarks>
+  ~QueueMessageHandler()
+  {
+    if (stackTrace_ is null)
+    {
+      return;
+    }
+
+    logger_.LogError("QueueMessageHandler for Message {MessageId} and Task {TaskId} was not disposed: Created {MessageCreationStackTrace}",
+                     MessageId,
+                     TaskId,
+                     stackTrace_);
+    DisposeAsync()
+      .AsTask()
+      .GetAwaiter()
+      .GetResult();
+  }
+}

--- a/ArmoniK.Core.sln
+++ b/ArmoniK.Core.sln
@@ -97,15 +97,17 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Tests.Connecti
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Adapters.SQS", "Adaptors\SQS\src\ArmoniK.Core.Adapters.SQS.csproj", "{399C779C-CE8D-4757-8098-7F055467D96C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmoniK.Core.Adapters.Embed", "Adaptors\Embed\src\ArmoniK.Core.Adapters.Embed.csproj", "{F95A1BF7-B660-4789-9F2D-1749FC104EEE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Adapters.Embed", "Adaptors\Embed\src\ArmoniK.Core.Adapters.Embed.csproj", "{F95A1BF7-B660-4789-9F2D-1749FC104EEE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ArmoniK.Core.Adapters.Embed.Tests", "Adaptors\Embed\tests\ArmoniK.Core.Adapters.Embed.Tests.csproj", "{2DC798DD-F147-4245-BD63-E0E6E5BB5E9E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Adapters.Embed.Tests", "Adaptors\Embed\tests\ArmoniK.Core.Adapters.Embed.Tests.csproj", "{2DC798DD-F147-4245-BD63-E0E6E5BB5E9E}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Base", "Base", "{44FE7EFD-2EAA-49BA-9621-D9EFCB39D50B}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{B52DF352-C460-4707-851A-22436174CBAA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Queue", "Base\tests\Queue\Queue.csproj", "{214D88B7-D35B-4129-A8F0-54B16AF2D67E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Queue", "Base\tests\Queue\Queue.csproj", "{214D88B7-D35B-4129-A8F0-54B16AF2D67E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ArmoniK.Core.Adapters.Nats", "Adaptors\Nats\src\ArmoniK.Core.Adapters.Nats.csproj", "{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -427,6 +429,14 @@ Global
 		{214D88B7-D35B-4129-A8F0-54B16AF2D67E}.Release|Any CPU.Build.0 = Release|Any CPU
 		{214D88B7-D35B-4129-A8F0-54B16AF2D67E}.Release|x64.ActiveCfg = Release|Any CPU
 		{214D88B7-D35B-4129-A8F0-54B16AF2D67E}.Release|x64.Build.0 = Release|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Debug|x64.Build.0 = Debug|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Release|x64.ActiveCfg = Release|Any CPU
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -481,6 +491,7 @@ Global
 		{2DC798DD-F147-4245-BD63-E0E6E5BB5E9E} = {2D548C40-6260-4A4E-9C56-E8A80C639E13}
 		{B52DF352-C460-4707-851A-22436174CBAA} = {44FE7EFD-2EAA-49BA-9621-D9EFCB39D50B}
 		{214D88B7-D35B-4129-A8F0-54B16AF2D67E} = {B52DF352-C460-4707-851A-22436174CBAA}
+		{790E147B-C2A8-4F60-B8C9-8C9087EB8F93} = {1A9BCE53-79D0-4761-B3A2-6967B610FA94}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1285A466-2AF6-43E6-8DCC-2F93A5D5F02E}

--- a/Base/tests/Queue/QueueStorageTests.cs
+++ b/Base/tests/Queue/QueueStorageTests.cs
@@ -75,6 +75,9 @@ public class QueueStorageTests
       case "ArmoniK.Core.Adapters.PubSub.QueueBuilder":
         adapterAbsolutePath = "../../../../../../Adaptors/PubSub/src/bin/Debug/net8.0/ArmoniK.Core.Adapters.PubSub.dll";
         break;
+      case "ArmoniK.Core.Adapters.Nats.QueueBuilder":
+        adapterAbsolutePath = "../../../../../../Adaptors/Nats/src/bin/Debug/net8.0/ArmoniK.Core.Adapters.Nats.dll";
+        break;
 
       default:
         throw new InvalidOperationException($"Unknown ClassName: {className}");

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ COPY ["Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj", "Adaptors/Mon
 COPY ["Adaptors/QueueCommon/src/ArmoniK.Core.Adapters.QueueCommon.csproj", "Adaptors/QueueCommon/src/"]
 COPY ["Adaptors/RabbitMQ/src/ArmoniK.Core.Adapters.RabbitMQ.csproj", "Adaptors/RabbitMQ/src/"]
 COPY ["Adaptors/PubSub/src/ArmoniK.Core.Adapters.PubSub.csproj", "Adaptors/PubSub/src/"]
+COPY ["Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj", "Adaptors/Nats/src/"]
 COPY ["Adaptors/Redis/src/ArmoniK.Core.Adapters.Redis.csproj", "Adaptors/Redis/src/"]
 COPY ["Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj", "Adaptors/S3/src/"]
 COPY ["Adaptors/SQS/src/ArmoniK.Core.Adapters.SQS.csproj", "Adaptors/SQS/src/"]
@@ -40,6 +41,7 @@ RUN dotnet restore -a "${TARGETARCH}" "Control/Submitter/src/ArmoniK.Core.Contro
 RUN dotnet restore -a "${TARGETARCH}" "Adaptors/Amqp/src/ArmoniK.Core.Adapters.Amqp.csproj"
 RUN dotnet restore -a "${TARGETARCH}" "Adaptors/RabbitMQ/src/ArmoniK.Core.Adapters.RabbitMQ.csproj"
 RUN dotnet restore -a "${TARGETARCH}" "Adaptors/PubSub/src/ArmoniK.Core.Adapters.PubSub.csproj"
+RUN dotnet restore -a "${TARGETARCH}" "Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj"
 RUN dotnet restore -a "${TARGETARCH}" "Adaptors/SQS/src/ArmoniK.Core.Adapters.SQS.csproj"
 RUN dotnet restore -a "${TARGETARCH}" "Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj"
 RUN dotnet restore -a "${TARGETARCH}" "Adaptors/LocalStorage/src/ArmoniK.Core.Adapters.LocalStorage.csproj"
@@ -54,6 +56,7 @@ COPY ["Adaptors/MongoDB/src", "Adaptors/MongoDB/src"]
 COPY ["Adaptors/QueueCommon/src", "Adaptors/QueueCommon/src"]
 COPY ["Adaptors/RabbitMQ/src", "Adaptors/RabbitMQ/src"]
 COPY ["Adaptors/PubSub/src", "Adaptors/PubSub/src"]
+COPY ["Adaptors/Nats/src", "Adaptors/Nats/src"]
 COPY ["Adaptors/Redis/src", "Adaptors/Redis/src"]
 COPY ["Adaptors/S3/src", "Adaptors/S3/src"]
 COPY ["Adaptors/SQS/src", "Adaptors/SQS/src"]
@@ -71,6 +74,9 @@ RUN dotnet publish "ArmoniK.Core.Adapters.SQS.csproj" -a "${TARGETARCH}" --no-re
 
 WORKDIR /src/Adaptors/PubSub/src
 RUN dotnet publish "ArmoniK.Core.Adapters.PubSub.csproj" -a "${TARGETARCH}" --no-restore -o /app/publish/pubsub /p:UseAppHost=false -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion=$VERSION -p:Version=$VERSION
+
+WORKDIR /src/Adaptors/Nats/src
+RUN dotnet publish "ArmoniK.Core.Adapters.Nats.csproj" -a "${TARGETARCH}" --no-restore -o /app/publish/nats /p:UseAppHost=false -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion=$VERSION -p:Version=$VERSION
 
 WORKDIR /src/Adaptors/Amqp/src
 RUN dotnet publish "ArmoniK.Core.Adapters.Amqp.csproj" -a "${TARGETARCH}" --no-restore -o /app/publish/amqp /p:UseAppHost=false -p:RunAnalyzers=false -p:WarningLevel=0 -p:PackageVersion=$VERSION -p:Version=$VERSION
@@ -108,6 +114,8 @@ WORKDIR /adapters/queue/sqs
 COPY --from=build /app/publish/sqs .
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
+WORKDIR /adapters/queue/nats
+COPY --from=build /app/publish/nats .
 WORKDIR /adapters/queue/amqp
 COPY --from=build /app/publish/amqp .
 WORKDIR /adapters/queue/rabbit
@@ -148,6 +156,8 @@ WORKDIR /adapters/queue/sqs
 COPY --from=build /app/publish/sqs .
 WORKDIR /adapters/queue/pubsub
 COPY --from=build /app/publish/pubsub .
+WORKDIR /adapters/queue/nats
+COPY --from=build /app/publish/nats .
 WORKDIR /adapters/queue/amqp
 COPY --from=build /app/publish/amqp .
 WORKDIR /adapters/queue/rabbit

--- a/justfile
+++ b/justfile
@@ -55,6 +55,8 @@ export TF_VAR_queue_storage := if queue == "rabbitmq" {
   '{ name = "activemq", image = "symptoma/activemq:5.16.3" }'
 } else if queue == "pubsub" {
   '{ name = "pubsub", image = "gcr.io/google.com/cloudsdktool/google-cloud-cli:latest" }'
+} else if queue == "nats" {
+  '{ name = "nats", image = "nats:alpine" }'
 } else if queue == "sqs" {
   '{ name = "sqs", image = "localstack/localstack:latest" }'
 } else {
@@ -168,6 +170,7 @@ _usage:
         rabbitmq091 :  for rabbitmq (0.9.1 protocol)
         artemis     :  for artemis  (1.0.0 protocol)
         pubsub      :  for Google PubSub
+        nats        :  for Nats with JetStream
         none        :  for external queue configurations
 
       worker: allowed values below

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -14,7 +14,7 @@ locals {
     "ASPNETCORE_ENVIRONMENT"                                                                 = "${var.aspnet_core_env}"
   }
   worker             = merge(var.compute_plane.worker, { image = var.worker_image })
-  queue              = one(concat(module.queue_activemq, module.queue_rabbitmq, module.queue_artemis, module.queue_pubsub, module.queue_sqs, module.queue_none))
+  queue              = one(concat(module.queue_activemq, module.queue_rabbitmq, module.queue_artemis, module.queue_pubsub, module.queue_sqs, module.queue_nats, module.queue_none))
   database           = module.database
   object             = one(concat(module.object_redis, module.object_minio, module.object_local, module.object_embed))
   partition_env_vars = { for i in local.partitions : "InitServices__Partitioning__Partitions__${i}" => jsonencode(merge(var.partition_data, { PartitionId = "${var.partition_data.PartitionId}${i}" })) }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -98,6 +98,14 @@ module "queue_pubsub" {
   network    = docker_network.armonik.id
 }
 
+module "queue_nats" {
+  source     = "./modules/storage/queue/nats"
+  count      = var.queue_storage.name == "nats" ? 1 : 0
+  queue_envs = var.queue_env_vars
+  image      = var.queue_storage.image
+  network    = docker_network.armonik.id
+}
+
 module "queue_sqs" {
   source     = "./modules/storage/queue/sqs"
   count      = var.queue_storage.name == "sqs" ? 1 : 0

--- a/terraform/modules/storage/queue/nats/inputs.tf
+++ b/terraform/modules/storage/queue/nats/inputs.tf
@@ -1,0 +1,29 @@
+variable "image" {
+  type = string
+}
+
+variable "network" {
+  type = string
+}
+
+variable "queue_envs" {
+  type = object({
+    user         = string,
+    password     = string,
+    host         = string,
+    port         = number,
+    max_priority = number,
+    max_retries  = number,
+    link_credit  = number,
+    partition    = string
+  })
+}
+
+variable "exposed_ports" {
+  type = object({
+    connection = number,
+  })
+  default = {
+    connection = 4222
+  }
+}

--- a/terraform/modules/storage/queue/nats/main.tf
+++ b/terraform/modules/storage/queue/nats/main.tf
@@ -1,0 +1,29 @@
+resource "docker_image" "queue" {
+  name         = var.image
+  keep_locally = true
+}
+
+resource "docker_container" "queue" {
+  name  = "queue"
+  image = docker_image.queue.image_id
+
+  networks_advanced {
+    name = var.network
+  }
+
+  command = ["-js", "--http_port", "8222"]
+  wait    = true
+
+  ports {
+    internal = 4222
+    external = var.exposed_ports.connection
+  }
+
+  healthcheck {
+    test         = concat(["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"])
+    interval     = "10s"
+    timeout      = "3s"
+    start_period = "10s"
+    retries      = "10"
+  }
+}

--- a/terraform/modules/storage/queue/nats/outputs.tf
+++ b/terraform/modules/storage/queue/nats/outputs.tf
@@ -1,0 +1,12 @@
+output "generated_env_vars" {
+  value = ({
+    "Components__QueueAdaptorSettings__ClassName"           = "ArmoniK.Core.Adapters.Nats.QueueBuilder"
+    "Components__QueueAdaptorSettings__AdapterAbsolutePath" = "/adapters/queue/nats/ArmoniK.Core.Adapters.Nats.dll"
+    "Nats__Url"                                             = "${var.queue_envs.host}:4222"
+  })
+}
+output "core_mounts" {
+  description = "Volumes that agents and submitters must mount to access the queue"
+  value = {
+  }
+}

--- a/terraform/modules/storage/queue/nats/versions.tf
+++ b/terraform/modules/storage/queue/nats/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = ">= 3.0.2"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -79,8 +79,8 @@ variable "queue_storage" {
     error_message = "Protocol must be amqp1_0|amqp0_9_1"
   }
   validation {
-    condition     = can(regex("^(activemq|rabbitmq|artemis|pubsub|sqs|none)$", var.queue_storage.name))
-    error_message = "Must be activemq, rabbitmq, artemis, pubsub, sqs or none"
+    condition     = can(regex("^(activemq|rabbitmq|artemis|pubsub|nats|sqs|none)$", var.queue_storage.name))
+    error_message = "Must be activemq, rabbitmq, artemis, pubsub, nats, sqs or none"
   }
   default = {}
 }


### PR DESCRIPTION
**Motivation**
Add NATS as a supported queue system in ArmoniK to leverage JetStream for in-flight message handling. This enables high-throughput, durable message processing while maintaining the same pull/push and queue handler patterns used by other queue systems.

**Description**

* Implemented a NATS adapter with both `PushMessagesAsync` and `PullMessagesAsync` methods.
* Introduced a `QueueMessageHandler` for NATS messages to handle acknowledgement and auto-extend deadlines.
* Added a `Heart` mechanism for monitoring message processing.
* Exposed configuration options: `AckWait` and `AckExtendDeadlineStep` to control ack timing, `DegreeOfParallelism` to limit parrallelism in operation.
* Integrated NATS into the list of available queues in ArmoniK.

**Testing**

* Verified push and pull workflows for NATS messages.
* Confirmed proper handling of durable consumers and message acknowledgement.
* Ensured `QueueMessageHandler` disposes correctly and respects `AckWait` and `AckExtendDeadlineStep`.
* Tested stream creation and update behavior for missing subjects.

**Impact**

* Adds NATS as a new dependency in ArmoniK.
* Minor impact on configuration: users can now select NATS as a queue backend and set ack-related options.
* No breaking changes for existing queue systems.

**Additional Information**

* This implementation follows the same design patterns as other queue adapters in ArmoniK.
* JetStream is required for durable and in-flight message support.
