### PR TITLE
feat: Added pipeline for microbenchmarks

### DIFF
--- a/.github/workflows/run-microbenchmarks.yml
+++ b/.github/workflows/run-microbenchmarks.yml
@@ -1,0 +1,22 @@
+name: Run microbenchmarks on release
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to benchmark'
+        required: true
+        default: 'latest'
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Repository B workflow
+        run: |
+          curl -X POST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/aneoconsulting/ArmoniK.Microbench/dispatches \
+            -d '{"event_type":"trigger-microbenchmarks","client_payload":{"release_tag":"${{ github.event.release.tag_name || github.event.inputs.release_tag }}"}}'

--- a/Microbenchmarks/parameters.tfvars
+++ b/Microbenchmarks/parameters.tfvars
@@ -1,0 +1,50 @@
+# Core configuration (assuming these already exist in your setup)
+region  = "us-east-1" 
+profile = "default"
+prefix  = "armonik-microbench-workflows"
+
+# Additional tags for this deployment
+additional_common_tags = {
+  "github-run-id" = "12345"
+  "environment"   = "workflows"
+}
+
+# Benchmark runner configuration
+benchmark_runner = {
+  instance_type = "c7a.8xlarge"
+}
+
+# Enable only the benchmarks you want to run
+# Comment out or remove the ones you don't want
+
+# Storage benchmarks
+localstorage_benchmark = {
+  
+}
+
+# redis_benchmark = {
+#   instance_type = "cache.m5.xlarge"
+# }
+
+# efs_benchmark = {}
+
+# s3_benchmark = {}
+
+# # Queue benchmarks
+# sqs_benchmark = {}
+
+# rabbitmq_amq_benchmark = {
+#   instance_type     = "mq.m5.4xlarge"
+#   username_override = "mybenchuser"
+#   password_override = "mybenchpass"
+# }
+
+# rabbitmq_ec2_benchmark = {
+#   instance_type = "m5.4xlarge"
+# }
+
+# activemq_benchmark = {
+#   instance_type     = "mq.m5.4xlarge"
+#   username_override = "activemquser"
+#   password_override = "activemqpass"
+# }


### PR DESCRIPTION
# Motivation

Needed a way to run microbenchmarks automatically whenever new releases for ArmoniK.Core come out 

# Description

- Added a Github pipeline for microbenchmarks

# Testing

Ran the pipeline in another repo.

# Impact

Financial mainly, microbenchmarks take a lot of time. Microbenchmarks with AmazonMQ/Elasticache are expensive.

# Additional Information

I haven't enabled the different microbenchmarks in parameters.tfvars. I'd like an initial review on this. 

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
