### PR TITLE
chore: Add tini in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 as base-linux
+ARG TARGETARCH
+ADD --chmod=755 https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-${TARGETARCH} /tini
 RUN groupadd --gid 5000 armonikuser && useradd --home-dir /home/armonikuser --create-home --uid 5000 --gid 5000 --shell /bin/sh --skel /dev/null armonikuser
 RUN mkdir /cache /local_storage /comm && chown armonikuser: /cache /local_storage /comm
 USER armonikuser
-ENTRYPOINT [ "dotnet" ]
+ENTRYPOINT [ "/tini", "-s", "-vv", "--", "dotnet" ]
 
 FROM mcr.microsoft.com/dotnet/aspnet:8.0-nanoserver-ltsc2022 AS base-windows
 ENTRYPOINT ["C:\\Program Files\\dotnet\\dotnet.exe"]


### PR DESCRIPTION
# Motivation

We suspect that some signals are lost when downscaling in Kubernetes.

# Description

Add tini as init of the containers to log signals and check why the process has stopped.

# Testing

Tini has been tested outside of ArmoniK deployment to ensure the logs fit our needs:

```
$ tini -s -vv -- sleep infinity
[INFO  tini (43884)] Spawned child process 'sleep' with pid '43885'
[DEBUG tini (43884)] Passing signal: 'Terminated'
[DEBUG tini (43884)] Received SIGCHLD
[DEBUG tini (43884)] Reaped child with pid: '43885'
[INFO  tini (43884)] Main child exited with signal (with signal 'Terminated')
```

ArmoniK deployment works as expected.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
