### PR TITLE
refactor: show logs in error when worker channel failed to create

### DIFF
--- a/Common/src/Stream/Worker/WorkerStreamHandler.cs
+++ b/Common/src/Stream/Worker/WorkerStreamHandler.cs
@@ -92,8 +92,8 @@ public class WorkerStreamHandler : IWorkerStreamHandler
       }
       catch (Exception ex)
       {
-        logger_.LogDebug(ex,
-                         "Channel was not created, retry in {seconds}",
+        logger_.LogError(ex,
+                         "Failed to create worker channel, retry in {seconds}",
                          optionsInitWorker_.WorkerCheckDelay * retry);
         await Task.Delay(optionsInitWorker_.WorkerCheckDelay * retry,
                          cancellationToken)


### PR DESCRIPTION
# Motivation

Improve debuggability

# Description

Move channel creation error from Debug to Error logging level.
