### PR TITLE
fix: tasks and results creation should be atomic

### DIFF
--- a/Adaptors/Memory/src/ResultTable.cs
+++ b/Adaptors/Memory/src/ResultTable.cs
@@ -74,6 +74,19 @@ public class ResultTable : IResultTable
   }
 
   /// <inheritdoc />
+  public Task DeleteResults(ICollection<string> results,
+                            CancellationToken   cancellationToken = default)
+  {
+    foreach (var id in results)
+    {
+      results_.TryRemove(id,
+                         out _);
+    }
+
+    return Task.CompletedTask;
+  }
+
+  /// <inheritdoc />
   public IAsyncEnumerable<T> GetResults<T>(Expression<Func<Result, bool>> filter,
                                            Expression<Func<Result, T>>    convertor,
                                            CancellationToken              cancellationToken = default)

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -151,6 +151,19 @@ public class TaskTable : ITaskTable
   }
 
   /// <inheritdoc />
+  public Task DeleteTasksAsync(ICollection<string> taskIds,
+                               CancellationToken   cancellationToken = default)
+  {
+    foreach (var id in taskIds)
+    {
+      taskId2TaskData_.TryRemove(id,
+                                 out _);
+    }
+
+    return Task.CompletedTask;
+  }
+
+  /// <inheritdoc />
   public Task<(IEnumerable<T> tasks, long totalCount)> ListTasksAsync<T>(Expression<Func<TaskData, bool>>    filter,
                                                                          Expression<Func<TaskData, object?>> orderField,
                                                                          Expression<Func<TaskData, T>>       selector,

--- a/Adaptors/MongoDB/src/ResultTable.cs
+++ b/Adaptors/MongoDB/src/ResultTable.cs
@@ -261,6 +261,18 @@ public class ResultTable : BaseTable<Result, ResultDataModelMapping>, IResultTab
   }
 
   /// <inheritdoc />
+  public async Task DeleteResults(ICollection<string> results,
+                                  CancellationToken   cancellationToken = default)
+  {
+    using var activity         = StartActivity();
+    var       resultCollection = GetCollection();
+
+    await resultCollection.DeleteManyAsync(model => results.Contains(model.ResultId),
+                                           cancellationToken)
+                          .ConfigureAwait(false);
+  }
+
+  /// <inheritdoc />
   public IAsyncEnumerable<T> GetResults<T>(Expression<Func<Result, bool>> filter,
                                            Expression<Func<Result, T>>    convertor,
                                            CancellationToken              cancellationToken = default)

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -211,6 +211,18 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
   }
 
   /// <inheritdoc />
+  public async Task DeleteTasksAsync(ICollection<string> taskIds,
+                                     CancellationToken   cancellationToken = default)
+  {
+    using var activity       = StartActivity();
+    var       taskCollection = GetCollection();
+
+    await taskCollection.DeleteManyAsync(data => taskIds.Contains(data.TaskId),
+                                         cancellationToken)
+                        .ConfigureAwait(false);
+  }
+
+  /// <inheritdoc />
   public async Task<(IEnumerable<T> tasks, long totalCount)> ListTasksAsync<T>(Expression<Func<TaskData, bool>>    filter,
                                                                                Expression<Func<TaskData, object?>> orderField,
                                                                                Expression<Func<TaskData, T>>       selector,

--- a/Common/src/Storage/IResultTable.cs
+++ b/Common/src/Storage/IResultTable.cs
@@ -103,6 +103,17 @@ public interface IResultTable : IInitializable
                      CancellationToken cancellationToken = default);
 
   /// <summary>
+  ///   Delete all the results from a collection
+  /// </summary>
+  /// <param name="results">ids of the results to be deleted</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Task representing the asynchronous execution of the method
+  /// </returns>
+  Task DeleteResults(ICollection<string> results,
+                     CancellationToken   cancellationToken = default);
+
+  /// <summary>
   ///   Get the results from a filter and convert it in the given type
   /// </summary>
   /// <param name="filter">Filter to select results</param>

--- a/Common/src/Storage/ITaskTable.cs
+++ b/Common/src/Storage/ITaskTable.cs
@@ -115,7 +115,7 @@ public interface ITaskTable : IInitializable
                                CancellationToken cancellationToken = default);
 
   /// <summary>
-  ///   Remove a task from the data base given its id
+  ///   Remove a task from the database given its id
   /// </summary>
   /// <param name="id">Id of the tasks to be deleted</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
@@ -123,10 +123,15 @@ public interface ITaskTable : IInitializable
   ///   Task representing the asynchronous execution of the method
   /// </returns>
   Task DeleteTaskAsync(string            id,
-                       CancellationToken cancellationToken = default);
+                       CancellationToken cancellationToken = default)
+    => DeleteTasksAsync(new List<string>
+                        {
+                          id,
+                        },
+                        cancellationToken);
 
   /// <summary>
-  ///   Remove tasks from the data base given their session id
+  ///   Remove tasks from the database given their session id
   /// </summary>
   /// <param name="sessionId">Id of the session from which tasks should be deleted</param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
@@ -135,6 +140,20 @@ public interface ITaskTable : IInitializable
   /// </returns>
   Task DeleteTasksAsync(string            sessionId,
                         CancellationToken cancellationToken = default);
+
+  /// <summary>
+  ///   Remove tasks from the database given their ids
+  /// </summary>
+  /// <param name="taskIds">Ids of the tasks to be deleted</param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>
+  ///   Task representing the asynchronous execution of the method
+  /// </returns>
+  /// <remarks>
+  ///   Does not throw if the task does not exist.
+  /// </remarks>
+  Task DeleteTasksAsync(ICollection<string> taskIds,
+                        CancellationToken   cancellationToken = default);
 
   /// <summary>
   ///   List all tasks matching the given filter and ordering

--- a/Common/tests/GrpcTasksServiceTests.cs
+++ b/Common/tests/GrpcTasksServiceTests.cs
@@ -15,14 +15,18 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
 using System.Threading.Tasks;
 
-using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
+using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -38,7 +42,11 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 
+using Moq;
+
 using NUnit.Framework;
+
+using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
 
 namespace ArmoniK.Core.Common.Tests;
 
@@ -341,5 +349,203 @@ public class GrpcTasksServiceTests
                 Throws.InstanceOf<RpcException>()
                       .With.Property(nameof(RpcException.StatusCode))
                       .EqualTo(StatusCode.FailedPrecondition));
+  }
+
+  [Test]
+  public async Task CrashDuringSubmissionShouldNotCreateTasks()
+  {
+    var queue = new Mock<IPushQueueStorage>();
+    queue.Setup(storage => storage.MaxPriority)
+         .Returns(10);
+    queue.Setup(storage => storage.PushMessagesAsync(It.IsAny<ICollection<MessageData>>(),
+                                                     It.IsAny<string>(),
+                                                     It.IsAny<CancellationToken>()))
+         .Throws<OperationCanceledException>();
+
+    var helper = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
+                                                                  .AddSingleton(queue.Object)
+                                                                  .AddSingleton<IPartitionTable, SimplePartitionTable>()
+                                                                  .AddSingleton<Injection.Options.Submitter>()
+                                                                  .AddSingleton<MeterHolder>()
+                                                                  .AddSingleton<AgentIdentifier>()
+                                                                  .AddScoped(typeof(FunctionExecutionMetrics<>))
+                                                                  .AddHttpClient()
+                                                                  .AddGrpc(),
+                                          builder => builder.UseRouting()
+                                                            .UseAuthorization(),
+                                          builder =>
+                                          {
+                                            builder.MapGrpcService<GrpcTasksService>();
+                                            builder.MapGrpcService<GrpcSessionsService>();
+                                            builder.MapGrpcService<GrpcResultsService>();
+                                          },
+                                          true,
+                                          true);
+
+    await helper.App.StartAsync()
+                .ConfigureAwait(false);
+
+    var server = helper.App.GetTestServer();
+
+    var channel = GrpcChannel.ForAddress("http://localhost:9999",
+                                         new GrpcChannelOptions
+                                         {
+                                           HttpHandler = server.CreateHandler(),
+                                         });
+
+    var sessionId = new Sessions.SessionsClient(channel).CreateSession(new CreateSessionRequest
+                                                                       {
+                                                                         DefaultTaskOption = new TaskOptions
+                                                                                             {
+                                                                                               MaxRetries = 1,
+                                                                                               Priority   = 2,
+                                                                                               MaxDuration = new Duration
+                                                                                                             {
+                                                                                                               Seconds = 500,
+                                                                                                               Nanos   = 0,
+                                                                                                             },
+                                                                                             },
+                                                                       })
+                                                        .SessionId;
+
+    var resultClient = new Results.ResultsClient(channel);
+    var resultId = resultClient.CreateResultsMetaData(new CreateResultsMetaDataRequest
+                                                      {
+                                                        SessionId = sessionId,
+                                                        Results =
+                                                        {
+                                                          new CreateResultsMetaDataRequest.Types.ResultCreate
+                                                          {
+                                                            Name = "result_id",
+                                                          },
+                                                        },
+                                                      })
+                               .Results.Single()
+                               .ResultId;
+    var payloadId = resultClient.CreateResults(new CreateResultsRequest
+                                               {
+                                                 SessionId = sessionId,
+                                                 Results =
+                                                 {
+                                                   new CreateResultsRequest.Types.ResultCreate
+                                                   {
+                                                     Name = "payload",
+                                                   },
+                                                 },
+                                               })
+                                .Results.Single()
+                                .ResultId;
+
+    var client = new Tasks.TasksClient(channel);
+    Assert.That(delegate
+                {
+                  client.SubmitTasks(new SubmitTasksRequest
+                                     {
+                                       SessionId = sessionId,
+                                       TaskCreations =
+                                       {
+                                         new SubmitTasksRequest.Types.TaskCreation
+                                         {
+                                           PayloadId = payloadId,
+                                           ExpectedOutputKeys =
+                                           {
+                                             resultId,
+                                           },
+                                         },
+                                       },
+                                     });
+                },
+                Throws.InstanceOf<RpcException>()
+                      .With.Property(nameof(RpcException.StatusCode))
+                      .EqualTo(StatusCode.Unknown));
+
+    Assert.That(await helper.GetRequiredService<ITaskTable>()
+                            .FindTasksAsync(data => true,
+                                            data => data.TaskId)
+                            .CountAsync()
+                            .ConfigureAwait(false),
+                Is.EqualTo(0));
+  }
+
+  [Test]
+  public async Task CrashDuringSubmissionGetResultsShouldNotCreateTasks()
+  {
+    var mock = new Mock<IResultTable>();
+    mock.Setup(table => table.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
+                                         It.IsAny<Expression<Func<Result, Result>>>(),
+                                         It.IsAny<CancellationToken>()))
+        .Throws<OperationCanceledException>();
+
+    var helper = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
+                                                                  .AddSingleton<IPushQueueStorage, SimplePushQueueStorage>()
+                                                                  .AddSingleton<IPartitionTable, SimplePartitionTable>()
+                                                                  .AddSingleton(mock.Object)
+                                                                  .AddSingleton<Injection.Options.Submitter>()
+                                                                  .AddSingleton<MeterHolder>()
+                                                                  .AddSingleton<AgentIdentifier>()
+                                                                  .AddScoped(typeof(FunctionExecutionMetrics<>))
+                                                                  .AddHttpClient()
+                                                                  .AddGrpc(),
+                                          builder => builder.UseRouting()
+                                                            .UseAuthorization(),
+                                          builder =>
+                                          {
+                                            builder.MapGrpcService<GrpcTasksService>();
+                                            builder.MapGrpcService<GrpcSessionsService>();
+                                          },
+                                          true,
+                                          true);
+
+    await helper.App.StartAsync()
+                .ConfigureAwait(false);
+
+    var server = helper.App.GetTestServer();
+
+    var channel = GrpcChannel.ForAddress("http://localhost:9999",
+                                         new GrpcChannelOptions
+                                         {
+                                           HttpHandler = server.CreateHandler(),
+                                         });
+
+    var sessionId = new Sessions.SessionsClient(channel).CreateSession(new CreateSessionRequest
+                                                                       {
+                                                                         DefaultTaskOption = new TaskOptions
+                                                                                             {
+                                                                                               MaxRetries = 1,
+                                                                                               Priority   = 2,
+                                                                                               MaxDuration = new Duration
+                                                                                                             {
+                                                                                                               Seconds = 500,
+                                                                                                               Nanos   = 0,
+                                                                                                             },
+                                                                                             },
+                                                                       })
+                                                        .SessionId;
+
+    var client = new Tasks.TasksClient(channel);
+    Assert.That(delegate
+                {
+                  client.SubmitTasks(new SubmitTasksRequest
+                                     {
+                                       SessionId = sessionId,
+                                       TaskCreations =
+                                       {
+                                         new SubmitTasksRequest.Types.TaskCreation
+                                         {
+                                           PayloadId = "payload",
+                                         },
+                                       },
+                                     });
+                },
+                Throws.InstanceOf<RpcException>()
+                      .With.Property(nameof(RpcException.StatusCode))
+                      .EqualTo(StatusCode.Unknown));
+
+    Assert.That(await helper.GetRequiredService<ITaskTable>()
+                            .FindTasksAsync(data => true,
+                                            data => data.TaskId)
+                            .CountAsync()
+                            .ConfigureAwait(false),
+                Is.EqualTo(0));
   }
 }

--- a/Common/tests/Helpers/SimpleResultTable.cs
+++ b/Common/tests/Helpers/SimpleResultTable.cs
@@ -55,6 +55,10 @@ public class SimpleResultTable : IResultTable
                             CancellationToken cancellationToken = default)
     => Task.CompletedTask;
 
+  public Task DeleteResults(ICollection<string> results,
+                            CancellationToken   cancellationToken = default)
+    => Task.CompletedTask;
+
   public IAsyncEnumerable<T> GetResults<T>(Expression<Func<Result, bool>> filter,
                                            Expression<Func<Result, T>>    convertor,
                                            CancellationToken              cancellationToken = default)

--- a/Common/tests/Helpers/SimpleTaskTable.cs
+++ b/Common/tests/Helpers/SimpleTaskTable.cs
@@ -121,6 +121,10 @@ public class SimpleTaskTable : ITaskTable
                                CancellationToken cancellationToken = default)
     => Task.CompletedTask;
 
+  public Task DeleteTasksAsync(ICollection<string> taskIds,
+                               CancellationToken   cancellationToken = default)
+    => Task.CompletedTask;
+
   public Task<(IEnumerable<T> tasks, long totalCount)> ListTasksAsync<T>(Expression<Func<TaskData, bool>>    filter,
                                                                          Expression<Func<TaskData, object?>> orderField,
                                                                          Expression<Func<TaskData, T>>       selector,

--- a/Common/tests/Pollster/DataPrefetcherTest.cs
+++ b/Common/tests/Pollster/DataPrefetcherTest.cs
@@ -100,6 +100,10 @@ public class DataPrefetcherTest
                               CancellationToken cancellationToken = default)
       => throw new NotImplementedException();
 
+    public Task DeleteResults(ICollection<string> results,
+                              CancellationToken   cancellationToken = default)
+      => throw new NotImplementedException();
+
     public IAsyncEnumerable<T> GetResults<T>(Expression<Func<Result, bool>> filter,
                                              Expression<Func<Result, T>>    convertor,
                                              CancellationToken              cancellationToken = default)

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -1170,6 +1170,10 @@ public class TaskHandlerTest
                                  CancellationToken cancellationToken = default)
       => throw new NotImplementedException();
 
+    public Task DeleteTasksAsync(ICollection<string> taskIds,
+                                 CancellationToken   cancellationToken = default)
+      => throw new NotImplementedException();
+
     public Task<(IEnumerable<T> tasks, long totalCount)> ListTasksAsync<T>(Expression<Func<TaskData, bool>>    filter,
                                                                            Expression<Func<TaskData, object?>> orderField,
                                                                            Expression<Func<TaskData, T>>       selector,

--- a/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
+++ b/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
@@ -25,6 +25,7 @@ using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Submitter;
+using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Services;
@@ -72,10 +73,11 @@ public class GrpcSubmitterServiceTests
   {
   }
 
-  private readonly Mock<IResultTable>  mockResultTable_  = new();
-  private readonly Mock<ISessionTable> mockSessionTable_ = new();
-  private readonly Mock<ITaskTable>    mockTaskTable_    = new();
-  private readonly Mock<ISubmitter>    mockSubmitter_    = new();
+  private readonly Mock<IResultTable>   mockResultTable_   = new();
+  private readonly Mock<ISessionTable>  mockSessionTable_  = new();
+  private readonly Mock<ITaskTable>     mockTaskTable_     = new();
+  private readonly Mock<ISubmitter>     mockSubmitter_     = new();
+  private readonly Mock<IObjectStorage> mockObjectStorage_ = new();
 
   private readonly TaskOptions taskOptions_ = new()
                                               {
@@ -104,6 +106,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -136,6 +139,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -175,6 +179,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -214,6 +219,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -253,6 +259,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -292,6 +299,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -331,6 +339,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -370,6 +379,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -406,6 +416,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -443,6 +454,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var output = await service.TryGetTaskOutput(new TaskOutputRequest
@@ -473,6 +485,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var output = await service.TryGetTaskOutput(new TaskOutputRequest
@@ -499,6 +512,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -533,6 +547,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -557,6 +572,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -584,6 +600,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -618,6 +635,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -652,6 +670,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -688,6 +707,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var response = await service.CancelTasks(new TaskFilter
@@ -720,6 +740,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -759,6 +780,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -801,6 +823,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -832,6 +855,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -870,6 +894,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -929,6 +954,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -975,6 +1001,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1028,6 +1055,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1094,6 +1122,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var list = new List<CreateLargeTaskRequest>
@@ -1135,6 +1164,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var helper = new TestHelperAsyncStreamReader<CreateLargeTaskRequest>(new List<CreateLargeTaskRequest>());
@@ -1172,6 +1202,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var list = new List<CreateLargeTaskRequest>
@@ -1220,6 +1251,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var list = new List<CreateLargeTaskRequest>
@@ -1275,6 +1307,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1315,6 +1348,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1358,6 +1392,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1405,6 +1440,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1433,6 +1469,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1468,6 +1505,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1503,6 +1541,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1538,6 +1577,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     mockSubmitter.Verify();
@@ -1579,6 +1619,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var response = await service.GetTaskStatus(new GetTaskStatusRequest
@@ -1611,6 +1652,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -1649,6 +1691,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -1685,6 +1728,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -1726,6 +1770,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var response = await service.ListTasks(new TaskFilter
@@ -1761,6 +1806,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -1802,6 +1848,7 @@ public class GrpcSubmitterServiceTests
                                            mock.Object,
                                            mockSessionTable_.Object,
                                            mockResultTable_.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -1844,6 +1891,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mock.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     try
@@ -1888,6 +1936,7 @@ public class GrpcSubmitterServiceTests
                                            mockTaskTable_.Object,
                                            mockSessionTable_.Object,
                                            mock.Object,
+                                           mockObjectStorage_.Object,
                                            NullLogger<GrpcSubmitterService>.Instance);
 
     var response = await service.GetResultStatus(new GetResultStatusRequest

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -881,6 +881,10 @@ internal class IntegrationGrpcSubmitterServiceTest
                                  CancellationToken cancellationToken = default)
       => throw new T();
 
+    public Task DeleteTasksAsync(ICollection<string> taskIds,
+                                 CancellationToken   cancellationToken = default)
+      => throw new T();
+
     public Task<(IEnumerable<TData> tasks, long totalCount)> ListTasksAsync<TData>(Expression<Func<TaskData, bool>>    filter,
                                                                                    Expression<Func<TaskData, object?>> orderField,
                                                                                    Expression<Func<TaskData, TData>>   selector,


### PR DESCRIPTION
# Motivation

We observed cases of tasks that were not properly submitted due to interruptions or errors during submission. This PR aims to make submission related RPCs atomic so that, when there is an issue, no tasks or results are left in an inconsistent state.

# Description

A try/catch block was added around critical parts of the code where the tasks/resutls are deleted from the database/object storage upon exception.

# Testing

Unit tests were implemented to check that tasks and results are properly deleted.

# Impact

- Tasks that are in Pending state due to errors during submission should be deleted and not appear in monitoring anymore.
- Issues during result creation should not leave partial results created

# Additional Information

- Rollback after task submission by another task is not properly implemented because owner id in the result is changed without keeping the old value. It requires a change in the data scheme to keep the old value and put it back on if needed. This case should be treated  at some point as it is needed to properly rollback sub tasks when task is reacquired after crash during postprocessing.
- This correction is not completely foolproof as it assumes the service to be able to execute the catch clause. It may not be executed in case of sudden crash of the service. Moreover, connection loss to the data plane may not allow to run the code within the catch properly. More complete solutions depends on #850 
