### PR TITLE
chore: change rabbitmq for windows to nats for windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -698,7 +698,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Deploy Core
-        run: just -v tag=$env:VERSION object=local worker=htcmock ingress=false prometheus=false grafana=false seq=false queue=rabbitmq091 deploy
+        run: just -v tag=$env:VERSION object=local worker=htcmock ingress=false prometheus=false grafana=false seq=false queue=nats deploy
         shell: powershell
 
       - name: Pull image

--- a/justfile
+++ b/justfile
@@ -55,8 +55,12 @@ export TF_VAR_queue_storage := if queue == "rabbitmq" {
   '{ name = "activemq", image = "symptoma/activemq:5.16.3" }'
 } else if queue == "pubsub" {
   '{ name = "pubsub", image = "gcr.io/google.com/cloudsdktool/google-cloud-cli:latest" }'
-} else if queue == "nats" {
+} else if queue == "nats" { 
+  if os_family() == "windows" {
+    '{ name = "nats", image = "nats:nanoserver-ltsc2022"}'
+  } else {
   '{ name = "nats", image = "nats:alpine" }'
+  }
 } else if queue == "sqs" {
   '{ name = "sqs", image = "localstack/localstack:latest" }'
 } else {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -105,6 +105,7 @@ module "queue_nats" {
   queue_envs = var.queue_env_vars
   image      = var.queue_storage.image
   network    = docker_network.armonik.id
+  windows    = var.windows
 }
 
 module "queue_sqs" {

--- a/terraform/modules/storage/queue/nats/inputs.tf
+++ b/terraform/modules/storage/queue/nats/inputs.tf
@@ -27,3 +27,7 @@ variable "exposed_ports" {
     connection = 4222
   }
 }
+
+variable "windows" {
+  type = bool
+}

--- a/terraform/modules/storage/queue/nats/main.tf
+++ b/terraform/modules/storage/queue/nats/main.tf
@@ -12,18 +12,21 @@ resource "docker_container" "queue" {
   }
 
   command = ["-js", "--http_port", "8222"]
-  wait    = true
+  wait    = !var.windows ? true : false
 
   ports {
     internal = 4222
     external = var.exposed_ports.connection
   }
 
-  healthcheck {
-    test         = concat(["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"])
-    interval     = "10s"
-    timeout      = "3s"
-    start_period = "10s"
-    retries      = "10"
+  dynamic "healthcheck" {
+    for_each = var.windows ? [] : [1]
+    content {
+      test         = concat(["CMD", "wget", "http://localhost:8222/healthz"])
+      interval     = "10s"
+      timeout      = "3s"
+      start_period = "10s"
+      retries      = "10"
+    }
   }
 }

--- a/terraform/modules/storage/queue/nats/main.tf
+++ b/terraform/modules/storage/queue/nats/main.tf
@@ -22,7 +22,7 @@ resource "docker_container" "queue" {
   dynamic "healthcheck" {
     for_each = var.windows ? [] : [1]
     content {
-      test         = concat(["CMD", "wget", "http://localhost:8222/healthz"])
+      test         = concat(["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"])
       interval     = "10s"
       timeout      = "3s"
       start_period = "10s"

--- a/terraform/modules/storage/queue/nats/main.tf
+++ b/terraform/modules/storage/queue/nats/main.tf
@@ -12,7 +12,7 @@ resource "docker_container" "queue" {
   }
 
   command = ["-js", "--http_port", "8222"]
-  wait    = !var.windows ? true : false
+  wait    = !var.windows
 
   ports {
     internal = 4222


### PR DESCRIPTION
# Motivation

L’image Windows utilisée pour RabbitMQ n’était pas officielle et pouvait poser des problèmes de maintenance et de sécurité. À l’inverse, NATS dispose d’une image officielle Windows, ce qui justifie son ajout.

# Description

* Suppression de l’image Windows non officielle pour RabbitMQ.
* Ajout de l’image Windows officielle pour NATS.
  Ces changements visent à standardiser l’utilisation d’images officielles et maintenues.

# Testing

* Vérification du bon démarrage des conteneurs avec la nouvelle configuration.
* Tests de connectivité et de fonctionnement des files de messages sous Linux et Windows.

# Impact

*Rabbitmq ne supporte plus windows.
*Nats supporte windows.
* Pas d’impact attendu sur la configuration ou les performances globales d’ArmoniK.

# Additional Information

Le changement de queue va modifier les performances lier sur Windows.

# Checklist

* [x] Mon code adhère aux guidelines du projet.
* [x] Auto-review effectuée.
* [ ] Documentation mise à jour pour refléter le changement d’images.
* [x] Tests effectués localement.
* [x] Vérification des tests CI/CD.
* [x] Impact en performance et dépendances évalué.