### PR TITLE
docs: Add Nats to doc and upgrade queue documentation

### DIFF
--- a/.docs/content/1.concepts/4.adaptors.md
+++ b/.docs/content/1.concepts/4.adaptors.md
@@ -38,9 +38,13 @@ It allows using any AMQP server such as ActiveMQ, ActiveMQ Artemis, RabbitMQ or 
 - `ArmoniK.Core.Adapters.RabbitMQ` provides a dedicated adaptor for RabbitMQ.
 It uses RabbitMQ native client that supports priorities better than the AMQ protocol in our AMQP adaptor.
 
+- `ArmoniK.Core.Adapters.Nats` provides an Nats Jets Stream connector for ArmoniK. It allows using a Nats server.
+
 Other adaptors for queue may also be available:
 
-- AmazonSQS
+- `ArmoniK.Core.Adapters.SQS` AmazonSQS (supports priority)
+
+- `ArmoniK.Core.Adapters.PubSub` GCP Pub/Sub
 
 ## Object Storage Adaptors
 

--- a/Adaptors/README.md
+++ b/Adaptors/README.md
@@ -20,6 +20,9 @@ ArmoniK provides multiple queue adapter implementations:
 - **Google Cloud Pub/Sub** - `ArmoniK.Core.Adapters.PubSub`
   - Google Cloud messaging service integration
 
+- **Nats Jet Stream** - `ArmoniK.Core.Adapters.Nats`
+  - Messaging service integration
+
 - **Memory** - `ArmoniK.Core.Adapters.Memory`
   - In-memory queue for testing and development
 
@@ -61,7 +64,7 @@ Configuration example:
 ## Deployment Examples
 
 ### On-premises
-- **Queue**: RabbitMQ or AMQP
+- **Queue**: RabbitMQ or AMQP or Nats
 - **Object Storage**: Minio
 - **Database**: MongoDB
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ Therefore, features in development or testing that cannot fit within a branch an
 | RabbitMQ | Queue          | RabbitMQ client using AMQP protocol 0.9.2     | GA      | Linux          | 
 | AMQP     | Queue          | AMQP client using AMQP protocol 1.0.0         | GA      | Linux          | 
 | PubSub   | Queue          | Google PubSub client                          | GA      | -              | 
-| SQS      | Queue          | AWS SQS client                                | Preview | -              | 
+| SQS      | Queue          | AWS SQS client                                | GA      | -              | 
+| Nats     | Queue          | Nats Jet Stream client                        | Preview | -              | 
 | Redis    | Object Storage | Redis client used to store binary data        | GA      | Windows, Linux | 
 | Local    | Object Storage | File system used to store binary data         | GA      | -              | 
 | S3       | Object Storage | AWS S3 client used to store binary data       | GA      | -              | 


### PR DESCRIPTION
# Motivation
ArmoniK recently introduced support for NATS as a messaging backend, but the documentation did not reflect this addition. Furthermore, information about the missing queue handling mechanism was incomplete. Clear and updated documentation is essential for both contributors and users to understand available backends and queue options.

# Description

* Adding NATS as a supported queue backend in the official docs.

* Completing the missing documentation for the queue configuration and behavior, including how missing queues are managed.

* Ensuring consistency across documentation sections where supported queues are listed or explained.

# Impact

* **Documentation:** Improves user understanding by covering missing queue cases explicitly.