### PR TITLE
chore: update deployment of rabbitmq to rabbitmq4

### DIFF
--- a/terraform/modules/storage/queue/rabbitmq/locals.tf
+++ b/terraform/modules/storage/queue/rabbitmq/locals.tf
@@ -1,3 +1,0 @@
-locals {
-  plug = var.protocol == "amqp1_0" ? ",rabbitmq_amqp1_0" : ""
-}

--- a/terraform/modules/storage/queue/rabbitmq/main.tf
+++ b/terraform/modules/storage/queue/rabbitmq/main.tf
@@ -34,7 +34,7 @@ resource "docker_container" "queue" {
 
   upload {
     file    = "/etc/rabbitmq/enabled_plugins"
-    content = "[rabbitmq_management ,rabbitmq_management_agent ${local.plug}]."
+    content = "[rabbitmq_management ,rabbitmq_management_agent]."
   }
 
   dynamic "upload" {


### PR DESCRIPTION
# Motivation

Starting from RabbitMQ 4, the plugin argument is no longer required.

# Description

Removed the unused `plug` local variable.

# Additional Information

For versions prior to RabbitMQ 4, the plugin argument may still be required. From RabbitMQ 4 onward, the deployment  behaves the same as AMQP.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
