### PR TITLE
docs: Integrate document extraction tool to readthedocs

### DIFF
--- a/.docs/content/envars/index.rst
+++ b/.docs/content/envars/index.rst
@@ -1,0 +1,9 @@
+Environment variables
+==========================
+
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   *

--- a/.docs/index.rst
+++ b/.docs/index.rst
@@ -20,5 +20,6 @@ ArmoniK.Core documentation
    content/services/tasks_service.md
    content/services/results_service.md
    content/services/sessions_service.md
+   content/envars/index.rst
    content/csharp/index.rst
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,16 +15,17 @@ build:
   jobs:
     pre_build:
       - PATH="$PATH":"$HOME/.dotnet/tools" tools/generate-csharp-doc.sh
+      - PATH="$PATH":"$HOME/.dotnet/tools" tools/generate-envvars-doc.sh
 
 # Move anchors out of the titles
 # Build documentation in the ".docs/" directory with Sphinx
 sphinx:
    configuration: .docs/conf.py
 
-# Optionally, but recommended,
+     # Optionally, but recommended,
 # declare the Python requirements required to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 python:
    install:
    - requirements: .docs/requirements.txt
-        
+

--- a/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
+++ b/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
@@ -31,6 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2" />
     <PackageReference Include="MongoDB.Driver" Version="2.25.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.4.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.400.36" />

--- a/Adaptors/MongoDB/src/Options/MongoDB.cs
+++ b/Adaptors/MongoDB/src/Options/MongoDB.cs
@@ -17,6 +17,8 @@
 
 using System;
 
+using ArmoniK.Utils.DocAttribute;
+
 using JetBrains.Annotations;
 
 // ReSharper disable InconsistentNaming
@@ -27,6 +29,7 @@ namespace ArmoniK.Core.Adapters.MongoDB.Options;
 ///   Represents the configuration settings for connecting to a MongoDB database.
 /// </summary>
 [PublicAPI]
+[ExtractDocumentation("Options for MongoDB")]
 public class MongoDB
 {
   /// <summary>

--- a/Adaptors/PubSub/src/ArmoniK.Core.Adapters.PubSub.csproj
+++ b/Adaptors/PubSub/src/ArmoniK.Core.Adapters.PubSub.csproj
@@ -14,6 +14,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Grpc.Core.Api" Version="2.62.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/Adaptors/PubSub/src/PubSub.cs
+++ b/Adaptors/PubSub/src/PubSub.cs
@@ -17,8 +17,11 @@
 
 using System;
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Adapters.PubSub;
 
+[ExtractDocumentation("Options for PubSub")]
 internal class PubSub
 {
   public const string SettingSection = nameof(PubSub);

--- a/Adaptors/QueueCommon/src/Amqp.cs
+++ b/Adaptors/QueueCommon/src/Amqp.cs
@@ -15,11 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Adapters.QueueCommon;
 
 /// <summary>
 ///   Represents the configuration settings for the AMQP (Advanced Message Queuing Protocol) connection.
 /// </summary>
+[ExtractDocumentation("Options for AMQP")]
 public class Amqp
 {
   /// <summary>

--- a/Adaptors/QueueCommon/src/ArmoniK.Core.Adapters.QueueCommon.csproj
+++ b/Adaptors/QueueCommon/src/ArmoniK.Core.Adapters.QueueCommon.csproj
@@ -30,6 +30,9 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <ProjectReference Include="..\..\..\Base\src\ArmoniK.Core.Base.csproj">
       <Private>false</Private>
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/Adaptors/Redis/src/ArmoniK.Core.Adapters.Redis.csproj
+++ b/Adaptors/Redis/src/ArmoniK.Core.Adapters.Redis.csproj
@@ -26,6 +26,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="StackExchange.Redis" Version="2.8.58" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0">
       <ExcludeAssets>runtime</ExcludeAssets>

--- a/Adaptors/Redis/src/Options/Redis.cs
+++ b/Adaptors/Redis/src/Options/Redis.cs
@@ -17,11 +17,14 @@
 
 using System;
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Adapters.Redis.Options;
 
 /// <summary>
 ///   Represents the configuration settings for connecting to a Redis instance.
 /// </summary>
+[ExtractDocumentation("Options for Redis")]
 public class Redis
 {
   /// <summary>

--- a/Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj
+++ b/Adaptors/S3/src/ArmoniK.Core.Adapters.S3.csproj
@@ -14,6 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="AWSSDK.S3" Version="3.7.405" />
     <!-- AWSSDK.SecurityToken is required to handle the default authentication -->
     <PackageReference Include="AWSSDK.SecurityToken" Version="3.7.400.36" />

--- a/Adaptors/S3/src/Options/S3.cs
+++ b/Adaptors/S3/src/Options/S3.cs
@@ -15,11 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Adapters.S3.Options;
 
 /// <summary>
 ///   Represents the configuration settings for connecting to AWS S3 object storage service.
 /// </summary>
+[ExtractDocumentation("Options for S3")]
 public class S3
 {
   /// <summary>

--- a/Adaptors/SQS/src/ArmoniK.Core.Adapters.SQS.csproj
+++ b/Adaptors/SQS/src/ArmoniK.Core.Adapters.SQS.csproj
@@ -9,6 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0">
       <ExcludeAssets>runtime</ExcludeAssets>
     </PackageReference>

--- a/Adaptors/SQS/src/SQS.cs
+++ b/Adaptors/SQS/src/SQS.cs
@@ -17,8 +17,11 @@
 
 using System.Collections.Generic;
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Adapters.SQS;
 
+[ExtractDocumentation("Options for SQS")]
 internal class SQS
 {
   /// <summary>

--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -32,6 +32,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.6.2" />
     <PackageReference Include="Calzolari.Grpc.AspNetCore.Validation" Version="8.2.0" />
     <PackageReference Include="Destructurama.Attributed" Version="5.1.0" />
     <PackageReference Include="Grpc.HealthCheck" Version="2.62.0" />

--- a/Common/src/Injection/Options/AdapterSettings.cs
+++ b/Common/src/Injection/Options/AdapterSettings.cs
@@ -15,11 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Common.Injection.Options;
 
 /// <summary>
 ///   Represents configuration settings for an adapter.
 /// </summary>
+[ExtractDocumentation("Options for AdapterSettings")]
 public class AdapterSettings
 {
   /// <summary>

--- a/Common/src/Injection/Options/Components.cs
+++ b/Common/src/Injection/Options/Components.cs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 using JetBrains.Annotations;
 
 namespace ArmoniK.Core.Common.Injection.Options;
@@ -22,6 +24,7 @@ namespace ArmoniK.Core.Common.Injection.Options;
 /// <summary>
 ///   Configuration used to choose which adapter for storage is used
 /// </summary>
+[ExtractDocumentation("Options for Components")]
 [PublicAPI]
 public class Components
 {

--- a/Common/src/Injection/Options/InitServices.cs
+++ b/Common/src/Injection/Options/InitServices.cs
@@ -16,12 +16,14 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using ArmoniK.Core.Common.Injection.Options.Database;
+using ArmoniK.Utils.DocAttribute;
 
 namespace ArmoniK.Core.Common.Injection.Options;
 
 /// <summary>
 ///   Configuration for ArmoniK services
 /// </summary>
+[ExtractDocumentation("Options for InitServices")]
 public class InitServices
 {
   /// <summary>

--- a/Common/src/Injection/Options/InitWorker.cs
+++ b/Common/src/Injection/Options/InitWorker.cs
@@ -17,11 +17,14 @@
 
 using System;
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Common.Injection.Options;
 
 /// <summary>
 ///   Configuration for <see cref="Stream.Worker.WorkerStreamHandler" />
 /// </summary>
+[ExtractDocumentation("Options for InitWorker")]
 public class InitWorker
 {
   /// <summary>

--- a/Common/src/Injection/Options/Pollster.cs
+++ b/Common/src/Injection/Options/Pollster.cs
@@ -17,11 +17,14 @@
 
 using System;
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Common.Injection.Options;
 
 /// <summary>
 ///   Configuration for <see cref="Common.Pollster.Pollster" />
 /// </summary>
+[ExtractDocumentation("Options for Pollster")]
 public class Pollster
 {
   /// <summary>

--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -15,11 +15,14 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 namespace ArmoniK.Core.Common.Injection.Options;
 
 /// <summary>
 ///   Configuration for <see cref="gRPC.Services.Submitter" />.
 /// </summary>
+[ExtractDocumentation("Options for Submitter")]
 public class Submitter
 {
   /// <summary>

--- a/Control/Metrics/src/Options/MetricsExporter.cs
+++ b/Control/Metrics/src/Options/MetricsExporter.cs
@@ -15,17 +15,20 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+// ReSharper disable InconsistentNaming
+
 using System;
 
-using JetBrains.Annotations;
+using ArmoniK.Utils.DocAttribute;
 
-// ReSharper disable InconsistentNaming
+using JetBrains.Annotations;
 
 namespace ArmoniK.Core.Control.Metrics.Options;
 
 /// <summary>
 ///   Represents the configuration settings for the metrics exporter.
 /// </summary>
+[ExtractDocumentation("Options for MetricsExporter")]
 [PublicAPI]
 public class MetricsExporter
 {

--- a/Control/PartitionMetrics/src/Options/MetricsExporter.cs
+++ b/Control/PartitionMetrics/src/Options/MetricsExporter.cs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 using JetBrains.Annotations;
 
 namespace ArmoniK.Core.Control.PartitionMetrics.Options;
@@ -22,6 +24,7 @@ namespace ArmoniK.Core.Control.PartitionMetrics.Options;
 /// <summary>
 ///   Options to set up the connection to the metrics exporter
 /// </summary>
+[ExtractDocumentation("Options for PartitionMetricsExporter")]
 [PublicAPI]
 public class MetricsExporter
 {

--- a/tools/generate-envvars-doc.sh
+++ b/tools/generate-envvars-doc.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+SOLUTION_FILE=$(realpath "ArmoniK.Core.sln")
+OUTPUT_DIR=.docs/content/envars/
+
+dotnet tool install -g ArmoniK.Utils.DocExtractor --version 0.6.2
+
+cd $OUTPUT_DIR
+armonik.utils.docextractor -s $SOLUTION_FILE


### PR DESCRIPTION
# Motivation

Integrate the document extraction tool from https://github.com/aneoconsulting/ArmoniK.Utils/pull/74, in this repository

# Description

Use the decorator introduced in https://github.com/aneoconsulting/ArmoniK.Utils/pull/74 to mark all the classes exposing
options to the user. Then use the extraction tool to produce a markdow file with those variables that is included in the generated documentation.

# Testing


# Impact

Automation of the documentation for user exposed variables.

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
