### PR TITLE
fix: delete subtasks from task that crashed while processing

### DIFF
--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -1019,13 +1019,12 @@ public static class TaskLifeCycleHelper
                                           .ToListAsync(cancellationToken)
                                           .ConfigureAwait(false);
 
-    await ResultLifeCycleHelper.AbortTasksAndResults(taskTable,
-                                                     resultTable,
-                                                     subtasks.ViewSelect(td => td.TaskId),
-                                                     resultsToAbort,
-                                                     errorMessage,
-                                                     TaskStatus.Cancelled,
-                                                     cancellationToken)
+    await ResultLifeCycleHelper.PurgeTasksAndAbortResults(taskTable,
+                                                          resultTable,
+                                                          subtasks.ViewSelect(td => td.TaskId),
+                                                          resultsToAbort,
+                                                          errorMessage,
+                                                          cancellationToken)
                                .ConfigureAwait(false);
 
     // Retry or abort the current task
@@ -1035,7 +1034,7 @@ public static class TaskLifeCycleHelper
                                         pushQueueStorage,
                                         taskData,
                                         sessionData,
-                                        subtasks.ViewSelect(td => td.TaskId),
+                                        [],
                                         errorMessage,
                                         logger,
                                         cancellationToken)

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -1486,20 +1486,22 @@ public class TaskLifeCycleHelperTest
 
                       Assert.That(taskB,
                                   crashState >= CrashState.TasksCreated || !subtask
-                                    ? Has.ItemAt(0)
-                                         .Property("Status")
-                                         .EqualTo(committed || !subtask
-                                                    ? TaskStatus.Pending
-                                                    : TaskStatus.Cancelled)
+                                    ? committed || !subtask
+                                        ? Has.ItemAt(0)
+                                             .Property("Status")
+                                             .EqualTo(TaskStatus.Pending)
+                                        : Is.Empty // subtasks are deleted when not committed
                                     : Is.Empty);
 
                       Assert.That(outputB,
                                   crashState >= CrashState.ResultsCreated || !subtask
-                                    ? Has.ItemAt(0)
-                                         .Property("Status")
-                                         .EqualTo(committed || !subtask
-                                                    ? ResultStatus.Created
-                                                    : ResultStatus.Aborted)
+                                    ? committed || !subtask
+                                        ? Has.ItemAt(0)
+                                             .Property("Status")
+                                             .EqualTo(ResultStatus.Created)
+                                        : Has.ItemAt(0) // results are aborted when not committed
+                                             .Property("Status")
+                                             .EqualTo(ResultStatus.Aborted)
                                     : Is.Empty);
 
                       Assert.That(outputRoot.Status,


### PR DESCRIPTION
# Motivation

When a pod crashes while processing a task near completion, other pods might try to handle this crash when they get the task message from the queue. When two pods try to acquire this task at the same time and handle this task simultaneously, they might end up cancelling a task while the other is still checking created subtasks status. Since Armonik heuristics consider that a task must have all subtasks on status creating while its parent task is no completed, in a concurrency case where a task is cancelled during the check of this heuristic, the parent task is considered completed by the other pods and has its status updated on mongo, making it blocked. This causes non-reexecution of this and blocks the workflow for all dependent tasks.

# Description

This PR fixes the race condition by introducing a new PurgeTasksAndAbortResults method that deletes subtasks instead of just cancelling them when a task crashes during processing.

# Testing

Updated unit tasks and global stress tests at CACIB

# Impact

Subtasks from crashed tasks are now deleted instead of marked as cancelled, preventing the race condition that could block the workflow.

# Additional Information

The recursion kept over tasks dependent indrectly might be removed after discussion, it might not be necessary. Results can also be deleted. The intent of this commit is to fix the bug that was locking sessions, keeping the behaviour close as possible.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
