### PR TITLE
fix: retry on the proper exception in S3 adapter

### DIFF
--- a/Adaptors/S3/src/ObjectStorage.cs
+++ b/Adaptors/S3/src/ObjectStorage.cs
@@ -20,6 +20,8 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Threading;
@@ -247,9 +249,10 @@ public class ObjectStorage : IObjectStorage
       {
         logger_.LogError("The key {Key} was not found",
                          key);
-        throw new ObjectDataNotFoundException("Key not found");
+        throw new ObjectDataNotFoundException("Key not found",
+                                              ex);
       }
-      catch (AmazonS3Exception ex)
+      catch (Exception ex) when (ex is AmazonS3Exception or HttpRequestException or SocketException or IOException)
       {
         if (retryCount + 1 >= options_.MaxRetry)
         {


### PR DESCRIPTION
# Motivation

Actually retry when there is a connection issue during object download in S3 adapter.

# Description

Retry where implemented on AmazonS3Exception which is not thrown in every case. HttpResquestException are also emitted. This PR also enable retries when this exception occurs.

# Testing

- No particular test were added because we see this exception appear in logs on production.

# Impact

- Make ArmoniK more resilient.

