### PR TITLE
fix: retry message deadline extension in SQS adapter

### DIFF
--- a/Adaptors/SQS/src/PullQueueStorage.cs
+++ b/Adaptors/SQS/src/PullQueueStorage.cs
@@ -168,8 +168,7 @@ internal class PullQueueStorage : IPullQueueStorage
         yield return new QueueMessageHandler(message,
                                              client_,
                                              queueUrl,
-                                             options_.AckDeadlinePeriod,
-                                             options_.WaitTimeSeconds,
+                                             options_,
                                              logger_);
       }
 

--- a/Adaptors/SQS/src/SQS.cs
+++ b/Adaptors/SQS/src/SQS.cs
@@ -80,4 +80,9 @@ internal class SQS
   ///   </a>
   /// </remarks>
   public Dictionary<string, string> Attributes { get; set; } = new();
+
+  /// <summary>
+  ///   Maximum number of retry attempts for failed operations.
+  /// </summary>
+  public int MaxRetries { get; set; } = 5;
 }


### PR DESCRIPTION
# Motivation

Improve the likelihood to extend on flight message deadline when there is an issue. This reduce the probability of a message representing a task in Processing being redistributed while still being processed elsewhere by an agent that was not able to extend the deadline for some reason.

# Description

Add a loop to retry message deadline extension.

# Testing

- Pipelines are passing.
- More extensive testing will be made later on where a few more fixes will be implemented.

# Impact

- Improve ArmoniK stability during connection issues with SQS. For instance, DNS issues that impede acces to AWS services.

