### PR TITLE
fix: keep server kestrel on after SIGTERM until Pollster grace delay

### DIFF
--- a/Common/src/Injection/ServiceCollectionExt.cs
+++ b/Common/src/Injection/ServiceCollectionExt.cs
@@ -25,6 +25,7 @@ using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.gRPC.Validators;
 using ArmoniK.Core.Common.Injection.Options;
 using ArmoniK.Core.Common.Stream.Worker;
+using ArmoniK.Core.Common.Utils;
 using ArmoniK.Core.Utils;
 
 using Calzolari.Grpc.AspNetCore.Validation;
@@ -33,6 +34,7 @@ using JetBrains.Annotations;
 
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 using ConfigurationExt = ArmoniK.Core.Utils.ConfigurationExt;
@@ -209,4 +211,22 @@ public static class ServiceCollectionExt
                .AddValidator<EventSubscriptionRequestValidator>()
                .AddValidator<SubmitTasksRequestValidator>()
                .AddGrpcValidation();
+
+  /// <summary>
+  ///   Add singleton for <see cref="ExceptionManager" />
+  /// </summary>
+  /// <param name="services">Collection of service descriptors</param>
+  /// <param name="optionsFactory">
+  ///   Function to create <see cref="ExceptionManager.Options" /> from
+  ///   <see cref="ServiceProvider" />
+  /// </param>
+  /// <returns>
+  ///   The updated collection of service descriptors
+  /// </returns>
+  [PublicAPI]
+  public static IServiceCollection AddExceptionManager(this IServiceCollection                           services,
+                                                       Func<IServiceProvider, ExceptionManager.Options>? optionsFactory = null)
+    => services.AddSingleton<ExceptionManager>()
+               .AddSingleton(optionsFactory ?? (_ => new ExceptionManager.Options()))
+               .AddSingleton<IHostLifetime>(sp => sp.GetRequiredService<ExceptionManager>());
 }

--- a/Common/src/Pollster/Pollster.cs
+++ b/Common/src/Pollster/Pollster.cs
@@ -510,8 +510,8 @@ public class Pollster : IInitializable
     }
     finally
     {
-      exceptionManager_.Stop(logger_,
-                             "End of Pollster main loop: Stop the application");
+      exceptionManager_.UnregisterAndStop(logger_,
+                                          "End of Pollster main loop: Stop the application");
       runningTaskQueue_.CloseWriter();
       endLoopReached_ = true;
     }

--- a/Common/src/Pollster/PostProcessor.cs
+++ b/Common/src/Pollster/PostProcessor.cs
@@ -100,7 +100,7 @@ public class PostProcessor : BackgroundService
       }
     }
 
-    exceptionManager_.Stop(logger_,
-                           "End of task post processor; no more tasks will be finalized");
+    exceptionManager_.UnregisterAndStop(logger_,
+                                        "End of task post processor; no more tasks will be finalized");
   }
 }

--- a/Common/src/Pollster/RunningTaskProcessor.cs
+++ b/Common/src/Pollster/RunningTaskProcessor.cs
@@ -122,7 +122,7 @@ public class RunningTaskProcessor : BackgroundService
       }
     }
 
-    exceptionManager_.Stop(logger_,
-                           "End of running task processor; no more tasks will be executed");
+    exceptionManager_.UnregisterAndStop(logger_,
+                                        "End of running task processor; no more tasks will be executed");
   }
 }

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -28,6 +28,7 @@ using ArmoniK.Core.Adapters.Memory;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.gRPC.Services;
+using ArmoniK.Core.Common.Injection;
 using ArmoniK.Core.Common.Injection.Options;
 using ArmoniK.Core.Common.Injection.Options.Database;
 using ArmoniK.Core.Common.Meter;
@@ -205,11 +206,10 @@ public class TestPollsterProvider : IDisposable
            .AddInitializedOption<InitServices>(builder.Configuration,
                                                InitServices.SettingSection)
            .AddSingleton<InitDatabase>()
-           .AddSingleton(sp => new ExceptionManager.Options(sp.GetRequiredService<Injection.Options.Pollster>()
-                                                              .GraceDelay,
-                                                            sp.GetRequiredService<Injection.Options.Pollster>()
-                                                              .MaxErrorAllowed))
-           .AddSingleton<ExceptionManager>()
+           .AddExceptionManager(sp => new ExceptionManager.Options(sp.GetRequiredService<Injection.Options.Pollster>()
+                                                                     .GraceDelay,
+                                                                   sp.GetRequiredService<Injection.Options.Pollster>()
+                                                                     .MaxErrorAllowed))
            .AddSingleton<MeterHolder>()
            .AddSingleton<AgentIdentifier>()
            .AddScoped(typeof(FunctionExecutionMetrics<>))

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -26,6 +26,7 @@ using ArmoniK.Core.Adapters.Memory;
 using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.gRPC.Services;
+using ArmoniK.Core.Common.Injection;
 using ArmoniK.Core.Common.Injection.Options;
 using ArmoniK.Core.Common.Injection.Options.Database;
 using ArmoniK.Core.Common.Meter;
@@ -179,8 +180,7 @@ public class TestTaskHandlerProvider : IDisposable
            .AddSingleton<IObjectStorage, ObjectStorage>()
            .AddSingleton<MeterHolder>()
            .AddSingleton<AgentIdentifier>()
-           .AddSingleton<ExceptionManager.Options>()
-           .AddSingleton<ExceptionManager>()
+           .AddExceptionManager()
            .AddScoped(typeof(FunctionExecutionMetrics<>))
            .AddSingleton<HealthCheckRecord>()
            .AddSingleton(provider => new TaskHandler(provider.GetRequiredService<ISessionTable>(),

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -116,10 +116,9 @@ public static class Program
                                                  InitServices.SettingSection)
              .AddSingleton<InitDatabase>()
              .AddSingleton(pollsterOptions)
-             .AddSingleton(new ExceptionManager.Options(pollsterOptions.GraceDelay,
-                                                        pollsterOptions.MaxErrorAllowed))
-             .AddSingleton<ExceptionManager>()
              .AddSingleton<HealthCheckRecord>()
+             .AddExceptionManager(_ => new ExceptionManager.Options(pollsterOptions.GraceDelay,
+                                                                    pollsterOptions.MaxErrorAllowed))
              .AddSingleton<IHealthCheckPublisher, HealthCheckRecord.Publisher>()
              .AddSingleton<IAgentHandler, AgentHandler>()
              .AddSingleton<DataPrefetcher>()

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -105,10 +105,9 @@ public static class Program
              .AddInitializedOption<InitServices>(builder.Configuration,
                                                  InitServices.SettingSection)
              .AddSingleton<InitDatabase>()
-             .AddSingleton(sp => new ExceptionManager.Options(TimeSpan.Zero,
-                                                              sp.GetRequiredService<Common.Injection.Options.Submitter>()
-                                                                .MaxErrorAllowed))
-             .AddSingleton<ExceptionManager>()
+             .AddExceptionManager(sp => new ExceptionManager.Options(TimeSpan.Zero,
+                                                                     sp.GetRequiredService<Common.Injection.Options.Submitter>()
+                                                                       .MaxErrorAllowed))
              .AddGrpcReflection()
              .AddSingleton<MeterHolder>()
              .AddSingleton<AgentIdentifier>()


### PR DESCRIPTION
# Motivation

During agent shut down, a SIGTERM is sent to it, triggering graceful shutdown. At this point, kestrel server is disabled and do not respond to `/taskprocessing`, `/cancelled`, `/liveness` etc endpoints. This is an issue because `/taskprocessing` is used in message deduplication.
When the SIGTERM occurs, the agent still processes a task until the GraceDelay. During this time, the message representing the task can be redistributed and the other agent will try to check if the task is still being processed by the former agent by calling its `/taskprocessing`. The former agent will not respond while still processing the task. This can cause tasks being executed twice.

# Description

The ExceptionManager was made to implement `IHostLifetime` and `IApplicationLifetime` to properly delay actual shut down of the kestrel server after the `Pollster__GraceDelay` expires.

# Testing

- Unit tests were added and pipeline are executing tests successfully.
- The following procedure was used to validate `/taskprocessing` was responding is
  - deploy with increased Pollster__GraceDely
  - send tasks with long duration
  - `docker stop -t 100 armonik.compute.pollingagent0`, it will take some time since the agent does not stop until the task finished or the grace delay expires.
  - in another terminal, `curl localhost:9980/taskprocessing`. Now it should answer whereas before this PR, it was not the case.

# Impact

- Avoid false negative when trying to contact an agent to determine which tasks it processes.
