### PR TITLE
fix: merge of TaskOptions and TaskOptions validator

### DIFF
--- a/Base/src/DataStructures/TaskOptions.cs
+++ b/Base/src/DataStructures/TaskOptions.cs
@@ -110,13 +110,15 @@ public record TaskOptions(IDictionary<string, string> Options,
     }
 
     return new TaskOptions(options,
-                           taskOption.MaxDuration == TimeSpan.Zero
+                           taskOption.MaxDuration != TimeSpan.Zero
                              ? taskOption.MaxDuration
                              : defaultOption.MaxDuration,
-                           taskOption.MaxRetries == 0
+                           taskOption.MaxRetries != 0
                              ? taskOption.MaxRetries
                              : defaultOption.MaxRetries,
-                           taskOption.Priority,
+                           taskOption.Priority != 0
+                             ? taskOption.Priority
+                             : defaultOption.Priority,
                            taskOption.PartitionId != string.Empty
                              ? taskOption.PartitionId
                              : defaultOption.PartitionId,

--- a/Base/src/DataStructures/TaskOptions.cs
+++ b/Base/src/DataStructures/TaskOptions.cs
@@ -116,7 +116,9 @@ public record TaskOptions(IDictionary<string, string> Options,
                            taskOption.MaxRetries != 0
                              ? taskOption.MaxRetries
                              : defaultOption.MaxRetries,
-                           taskOption.Priority,
+                           taskOption.Priority != 0
+                             ? taskOption.Priority
+                             : defaultOption.Priority,
                            taskOption.PartitionId != string.Empty
                              ? taskOption.PartitionId
                              : defaultOption.PartitionId,

--- a/Common/src/gRPC/Validators/CreateSessionRequestValidator.cs
+++ b/Common/src/gRPC/Validators/CreateSessionRequestValidator.cs
@@ -31,7 +31,7 @@ public class CreateSessionRequestValidator : AbstractValidator<CreateSessionRequ
   /// </summary>
   public CreateSessionRequestValidator()
     => RuleFor(request => request.DefaultTaskOption)
-       .SetValidator(new TaskOptionsValidator())
+       .SetValidator(new TaskOptionsValidator(true))
        .NotNull()
        .WithName(nameof(CreateSessionRequest.DefaultTaskOption));
 }

--- a/Common/src/gRPC/Validators/CreateSessionRequestValidator.cs
+++ b/Common/src/gRPC/Validators/CreateSessionRequestValidator.cs
@@ -31,7 +31,7 @@ public class CreateSessionRequestValidator : AbstractValidator<CreateSessionRequ
   /// </summary>
   public CreateSessionRequestValidator()
     => RuleFor(request => request.DefaultTaskOption)
-       .SetValidator(new TaskOptionsValidator(true))
+       .SetValidator(new TaskOptionsValidator(false))
        .NotNull()
        .WithName(nameof(CreateSessionRequest.DefaultTaskOption));
 }

--- a/Common/src/gRPC/Validators/SessionsService/CreateSessionRequestValidator.cs
+++ b/Common/src/gRPC/Validators/SessionsService/CreateSessionRequestValidator.cs
@@ -31,7 +31,7 @@ public class CreateSessionRequestValidator : AbstractValidator<CreateSessionRequ
   /// </summary>
   public CreateSessionRequestValidator()
     => RuleFor(request => request.DefaultTaskOption)
-       .SetValidator(new TaskOptionsValidator())
+       .SetValidator(new TaskOptionsValidator(true))
        .NotNull()
        .WithName(nameof(CreateSessionRequest.DefaultTaskOption));
 }

--- a/Common/src/gRPC/Validators/SessionsService/CreateSessionRequestValidator.cs
+++ b/Common/src/gRPC/Validators/SessionsService/CreateSessionRequestValidator.cs
@@ -31,7 +31,7 @@ public class CreateSessionRequestValidator : AbstractValidator<CreateSessionRequ
   /// </summary>
   public CreateSessionRequestValidator()
     => RuleFor(request => request.DefaultTaskOption)
-       .SetValidator(new TaskOptionsValidator(true))
+       .SetValidator(new TaskOptionsValidator(false))
        .NotNull()
        .WithName(nameof(CreateSessionRequest.DefaultTaskOption));
 }

--- a/Common/src/gRPC/Validators/TaskOptionsValidator.cs
+++ b/Common/src/gRPC/Validators/TaskOptionsValidator.cs
@@ -29,19 +29,30 @@ public class TaskOptionsValidator : AbstractValidator<TaskOptions>
   /// <summary>
   ///   Initializes a validator for <see cref="TaskOptions" />
   /// </summary>
-  public TaskOptionsValidator()
+  public TaskOptionsValidator(bool isSession = false)
   {
+    var minRetries = isSession
+                       ? 1
+                       : 0;
+    var minPriority = isSession
+                        ? 1
+                        : 0;
     RuleFor(o => o.MaxRetries)
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(minRetries)
+      .WithMessage($"MaxRetries should be greater or equal than {minRetries}")
       .WithName(nameof(TaskOptions.MaxRetries));
     RuleFor(o => o.Priority)
-      .GreaterThanOrEqualTo(1)
+      .GreaterThanOrEqualTo(minPriority)
       .LessThanOrEqualTo(99)
-      .WithMessage("Priority should be included between 1 and 99")
+      .WithMessage($"Priority should be included between {minPriority} and 99")
       .WithName(nameof(TaskOptions.Priority));
-    RuleFor(o => o.MaxDuration)
-      .NotNull()
-      .NotEmpty()
-      .WithName(nameof(TaskOptions.MaxDuration));
+    if (isSession)
+    {
+      RuleFor(o => o.MaxDuration)
+        .NotNull()
+        .NotEmpty()
+        .WithMessage("MaxDuration is required")
+        .WithName(nameof(TaskOptions.MaxDuration));
+    }
   }
 }

--- a/Common/src/gRPC/Validators/TaskOptionsValidator.cs
+++ b/Common/src/gRPC/Validators/TaskOptionsValidator.cs
@@ -29,14 +29,15 @@ public class TaskOptionsValidator : AbstractValidator<TaskOptions>
   /// <summary>
   ///   Initializes a validator for <see cref="TaskOptions" />
   /// </summary>
-  public TaskOptionsValidator(bool isSession = false)
+  /// <param name="allowDefaults">Whether default values are allowed</param>
+  public TaskOptionsValidator(bool allowDefaults = true)
   {
-    var minRetries = isSession
-                       ? 1
-                       : 0;
-    var minPriority = isSession
-                        ? 1
-                        : 0;
+    var minRetries = allowDefaults
+                       ? 0
+                       : 1;
+    var minPriority = allowDefaults
+                        ? 0
+                        : 1;
     RuleFor(o => o.MaxRetries)
       .GreaterThanOrEqualTo(minRetries)
       .WithMessage($"MaxRetries should be greater or equal than {minRetries}")
@@ -46,7 +47,7 @@ public class TaskOptionsValidator : AbstractValidator<TaskOptions>
       .LessThanOrEqualTo(99)
       .WithMessage($"Priority should be included between {minPriority} and 99")
       .WithName(nameof(TaskOptions.Priority));
-    if (isSession)
+    if (!allowDefaults)
     {
       RuleFor(o => o.MaxDuration)
         .NotNull()

--- a/Common/tests/TaskOptionsTests.cs
+++ b/Common/tests/TaskOptionsTests.cs
@@ -122,6 +122,8 @@ public class TaskOptionsTests
                                   Is.EqualTo(completeOptions_.MaxDuration));
                       Assert.That(merged.MaxRetries,
                                   Is.EqualTo(completeOptions_.MaxRetries));
+                      Assert.That(merged.Priority,
+                                  Is.EqualTo(completeOptions_.Priority));
                       Assert.That(merged.PartitionId,
                                   Is.EqualTo(completeOptions_.PartitionId));
                       Assert.That(merged.ApplicationName,

--- a/Common/tests/Validators/CreateSmallTaskRequestValidatorTest.cs
+++ b/Common/tests/Validators/CreateSmallTaskRequestValidatorTest.cs
@@ -91,30 +91,30 @@ public class CreateSmallTaskRequestValidatorTest
   }
 
   [Test]
-  public void UndefinedMaxDurationShouldFail()
+  public void UndefinedMaxDurationShouldBeValid()
   {
     validCreateSmallTaskRequest_!.TaskOptions.MaxDuration = null;
     Assert.That(validator_.Validate(validCreateSmallTaskRequest_)
                           .IsValid,
-                Is.False);
+                Is.True);
   }
 
   [Test]
-  public void UndefinedMaxRetriesShouldFail()
+  public void UndefinedMaxRetriesShouldBeValid()
   {
     validCreateSmallTaskRequest_!.TaskOptions.MaxRetries = default;
     Assert.That(validator_.Validate(validCreateSmallTaskRequest_)
                           .IsValid,
-                Is.False);
+                Is.True);
   }
 
   [Test]
-  public void ZeroMaxRetryShouldFail()
+  public void ZeroMaxRetryShouldBeValid()
   {
     validCreateSmallTaskRequest_!.TaskOptions.MaxRetries = 0;
     Assert.That(validator_.Validate(validCreateSmallTaskRequest_)
                           .IsValid,
-                Is.False);
+                Is.True);
   }
 
   [Test]
@@ -137,21 +137,21 @@ public class CreateSmallTaskRequestValidatorTest
   }
 
   [Test]
-  public void UndefinedPriorityShouldFail()
+  public void UndefinedPriorityShouldBeValid()
   {
     validCreateSmallTaskRequest_!.TaskOptions.Priority = default;
     Assert.That(validator_.Validate(validCreateSmallTaskRequest_)
                           .IsValid,
-                Is.False);
+                Is.True);
   }
 
   [Test]
-  public void ZeroPriorityShouldFail()
+  public void ZeroPriorityShouldBeValid()
   {
     validCreateSmallTaskRequest_!.TaskOptions.Priority = 0;
     Assert.That(validator_.Validate(validCreateSmallTaskRequest_)
                           .IsValid,
-                Is.False);
+                Is.True);
   }
 
   [Test]

--- a/Common/tests/Validators/TaskOptionsValidatorTest.cs
+++ b/Common/tests/Validators/TaskOptionsValidatorTest.cs
@@ -39,96 +39,151 @@ public class TaskOptionsValidatorTest
                              Priority    = 2,
                            };
 
-  private readonly TaskOptionsValidator validator_ = new();
+  private readonly TaskOptionsValidator sessionValidator_ = new(true);
+  private readonly TaskOptionsValidator taskValidator_    = new();
   private          TaskOptions?         validTaskOptions_;
 
   [Test]
-  public void TaskOptionsShouldBeValid()
-    => Assert.IsTrue(validator_.Validate(validTaskOptions_!)
-                               .IsValid);
+  public void SessionTaskOptionsShouldBeValid()
+    => Assert.IsTrue(sessionValidator_.Validate(validTaskOptions_!)
+                                      .IsValid);
 
   [Test]
-  public void UndefinedMaxDurationShouldFail()
+  public void TaskTaskOptionsShouldBeValid()
+    => Assert.IsTrue(taskValidator_.Validate(validTaskOptions_!)
+                                   .IsValid);
+
+  [Test]
+  public void UndefinedSessionMaxDurationShouldFail()
   {
     validTaskOptions_!.MaxDuration = null;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(validTaskOptions_)
+                                    .IsValid);
   }
 
   [Test]
-  public void UndefinedMaxRetriesShouldFail()
+  public void UndefinedTaskMaxDurationShouldBeValid()
   {
-    validTaskOptions_!.MaxRetries = default;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    validTaskOptions_!.MaxDuration = null;
+    Assert.IsTrue(taskValidator_.Validate(validTaskOptions_)
+                                .IsValid);
   }
 
   [Test]
-  public void ZeroMaxRetryShouldFail()
+  public void ZeroSessionMaxRetryShouldFail()
   {
     validTaskOptions_!.MaxRetries = 0;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(validTaskOptions_)
+                                    .IsValid);
   }
 
   [Test]
-  public void NegativeMaxRetryShouldFail()
+  public void ZeroTaskMaxRetryShouldBeValid()
+  {
+    validTaskOptions_!.MaxRetries = 0;
+    Assert.IsTrue(taskValidator_.Validate(validTaskOptions_)
+                                .IsValid);
+  }
+
+  [Test]
+  public void NegativeSessionMaxRetryShouldFail()
   {
     validTaskOptions_!.MaxRetries = -6;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(validTaskOptions_)
+                                    .IsValid);
   }
 
   [Test]
-  public void UndefinedPriorityShouldFail()
+  public void NegativeTaskMaxRetryShouldFail()
   {
-    validTaskOptions_!.Priority = default;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    validTaskOptions_!.MaxRetries = -6;
+    Assert.IsFalse(taskValidator_.Validate(validTaskOptions_)
+                                 .IsValid);
   }
 
   [Test]
-  public void ZeroPriorityShouldFail()
+  public void ZeroSessionPriorityShouldFail()
   {
     validTaskOptions_!.Priority = 0;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(validTaskOptions_)
+                                    .IsValid);
   }
 
   [Test]
-  public void NegativePriorityShouldFail()
+  public void ZeroTaskPriorityShouldBeValid()
+  {
+    validTaskOptions_!.Priority = 0;
+    Assert.IsTrue(taskValidator_.Validate(validTaskOptions_)
+                                .IsValid);
+  }
+
+  [Test]
+  public void NegativeSessionPriorityShouldFail()
   {
     validTaskOptions_!.Priority = -6;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(validTaskOptions_)
+                                    .IsValid);
   }
 
   [Test]
-  public void TooBigPriorityShouldFail()
+  public void NegativeTaskPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = -6;
+    Assert.IsFalse(taskValidator_.Validate(validTaskOptions_)
+                                 .IsValid);
+  }
+
+  [Test]
+  public void TooBigSessionPriorityShouldFail()
   {
     validTaskOptions_!.Priority = 100;
-    Assert.IsFalse(validator_.Validate(validTaskOptions_)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(validTaskOptions_)
+                                    .IsValid);
   }
 
   [Test]
-  public void EmptyPartitionShouldSucceed()
+  public void TooBigTaskPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = 100;
+    Assert.IsFalse(taskValidator_.Validate(validTaskOptions_)
+                                 .IsValid);
+  }
+
+  [Test]
+  public void EmptySessionPartitionShouldSucceed()
   {
     validTaskOptions_!.PartitionId = string.Empty;
-    Assert.IsTrue(validator_.Validate(validTaskOptions_)
-                            .IsValid);
+    Assert.IsTrue(sessionValidator_.Validate(validTaskOptions_)
+                                   .IsValid);
   }
 
   [Test]
-  public void OnlyMaxRetryAndPriorityDefinedShouldFail()
+  public void EmptyTaskPartitionShouldSucceed()
+  {
+    validTaskOptions_!.PartitionId = string.Empty;
+    Assert.IsTrue(taskValidator_.Validate(validTaskOptions_)
+                                .IsValid);
+  }
+
+  [Test]
+  public void OnlySessionMaxRetryAndPriorityDefinedShouldFail()
   {
     var to = new TaskOptions
              {
                MaxRetries = 1,
-               Priority   = 100,
+               Priority   = 99,
              };
 
-    Assert.IsFalse(validator_.Validate(to)
-                             .IsValid);
+    Assert.IsFalse(sessionValidator_.Validate(to)
+                                    .IsValid);
+  }
+
+  [Test]
+  public void DefaultTaskTaskOptionsShouldBeValid()
+  {
+    var to = new TaskOptions();
+
+    Assert.IsTrue(taskValidator_.Validate(to)
+                                .IsValid);
   }
 }

--- a/Common/tests/Validators/TaskOptionsValidatorTest.cs
+++ b/Common/tests/Validators/TaskOptionsValidatorTest.cs
@@ -39,107 +39,169 @@ public class TaskOptionsValidatorTest
                              Priority    = 2,
                            };
 
-  private readonly TaskOptionsValidator validator_ = new();
+  private readonly TaskOptionsValidator sessionValidator_ = new(true);
+  private readonly TaskOptionsValidator taskValidator_    = new();
   private          TaskOptions?         validTaskOptions_;
 
   [Test]
-  public void TaskOptionsShouldBeValid()
-    => Assert.That(validator_.Validate(validTaskOptions_!)
-                             .IsValid,
+  public void SessionTaskOptionsShouldBeValid()
+    => Assert.That(sessionValidator_.Validate(validTaskOptions_!)
+                                    .IsValid,
                    Is.True);
 
   [Test]
-  public void UndefinedMaxDurationShouldFail()
+  public void TaskTaskOptionsShouldBeValid()
+    => Assert.That(taskValidator_.Validate(validTaskOptions_!)
+                                 .IsValid,
+                   Is.True);
+
+  [Test]
+  public void UndefinedSessionMaxDurationShouldFail()
   {
     validTaskOptions_!.MaxDuration = null;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
                 Is.False);
   }
 
   [Test]
-  public void UndefinedMaxRetriesShouldFail()
+  public void UndefinedTaskMaxDurationShouldBeValid()
   {
-    validTaskOptions_!.MaxRetries = default;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void ZeroMaxRetryShouldFail()
-  {
-    validTaskOptions_!.MaxRetries = 0;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void NegativeMaxRetryShouldFail()
-  {
-    validTaskOptions_!.MaxRetries = -6;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void UndefinedPriorityShouldFail()
-  {
-    validTaskOptions_!.Priority = default;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void ZeroPriorityShouldFail()
-  {
-    validTaskOptions_!.Priority = 0;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void NegativePriorityShouldFail()
-  {
-    validTaskOptions_!.Priority = -6;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void TooBigPriorityShouldFail()
-  {
-    validTaskOptions_!.Priority = 100;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
-                Is.False);
-  }
-
-  [Test]
-  public void EmptyPartitionShouldSucceed()
-  {
-    validTaskOptions_!.PartitionId = string.Empty;
-    Assert.That(validator_.Validate(validTaskOptions_)
-                          .IsValid,
+    validTaskOptions_!.MaxDuration = null;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
                 Is.True);
   }
 
   [Test]
-  public void OnlyMaxRetryAndPriorityDefinedShouldFail()
+  public void ZeroSessionMaxRetryShouldFail()
+  {
+    validTaskOptions_!.MaxRetries = 0;
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void ZeroTaskMaxRetryShouldBeValid()
+  {
+    validTaskOptions_!.MaxRetries = 0;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
+                Is.True);
+  }
+
+  [Test]
+  public void NegativeSessionMaxRetryShouldFail()
+  {
+    validTaskOptions_!.MaxRetries = -6;
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void NegativeTaskMaxRetryShouldFail()
+  {
+    validTaskOptions_!.MaxRetries = -6;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void ZeroSessionPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = 0;
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void ZeroTaskPriorityShouldBeValid()
+  {
+    validTaskOptions_!.Priority = 0;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
+                Is.True);
+  }
+
+  [Test]
+  public void NegativeSessionPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = -6;
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void NegativeTaskPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = -6;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void TooBigSessionPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = 100;
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void TooBigTaskPriorityShouldFail()
+  {
+    validTaskOptions_!.Priority = 100;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
+                Is.False);
+  }
+
+  [Test]
+  public void EmptySessionPartitionShouldSucceed()
+  {
+    validTaskOptions_!.PartitionId = string.Empty;
+    Assert.That(sessionValidator_.Validate(validTaskOptions_)
+                                 .IsValid,
+                Is.True);
+  }
+
+  [Test]
+  public void EmptyTaskPartitionShouldSucceed()
+  {
+    validTaskOptions_!.PartitionId = string.Empty;
+    Assert.That(taskValidator_.Validate(validTaskOptions_)
+                              .IsValid,
+                Is.True);
+  }
+
+  [Test]
+  public void OnlySessionMaxRetryAndPriorityDefinedShouldFail()
   {
     var to = new TaskOptions
              {
                MaxRetries = 1,
-               Priority   = 100,
+               Priority   = 99,
              };
 
-    Assert.That(validator_.Validate(to)
-                          .IsValid,
+    Assert.That(sessionValidator_.Validate(to)
+                                 .IsValid,
                 Is.False);
+  }
+
+  [Test]
+  public void DefaultTaskTaskOptionsShouldBeValid()
+  {
+    var to = new TaskOptions();
+
+    Assert.That(taskValidator_.Validate(to)
+                              .IsValid,
+                Is.True);
   }
 }

--- a/Common/tests/Validators/TaskOptionsValidatorTest.cs
+++ b/Common/tests/Validators/TaskOptionsValidatorTest.cs
@@ -39,7 +39,7 @@ public class TaskOptionsValidatorTest
                              Priority    = 2,
                            };
 
-  private readonly TaskOptionsValidator sessionValidator_ = new(true);
+  private readonly TaskOptionsValidator sessionValidator_ = new(false);
   private readonly TaskOptionsValidator taskValidator_    = new();
   private          TaskOptions?         validTaskOptions_;
 


### PR DESCRIPTION
# Motivation

Some merging rules in TaskOptions were inverted and session's default TaskOptions validator should differ from task's TaskOptions validator.

A session's default TaskOptions is the fallback for every task of that session, so it must be complete. A task's TaskOptions, on the other hand, is only an overlay: `TaskLifeCycleHelper.ValidateSession` merges it with the session defaults, so leaving `MaxDuration`, `MaxRetries` or `Priority` unset there is legitimate and must not be rejected.

# Description

- `TaskOptions.Merge`: `Priority` now falls back to the session default when unset (`0`) instead of being taken verbatim from the task options. The `MaxDuration` and `MaxRetries` inversions from the original version of this PR have meanwhile been fixed on `main` by #1270 (`fix(data): MaxDuration and MaxRetries ignores set values`), so only the `Priority` part remains here.
- `TaskOptionsValidator` takes an `allowDefaults` parameter (defaulting to `true`, the task case):
  - `allowDefaults: false` (session case) keeps the previous rules — `MaxRetries >= 1`, `1 <= Priority <= 99`, `MaxDuration` required;
  - `allowDefaults: true` (task case) accepts `MaxRetries >= 0`, `0 <= Priority <= 99` and an unset `MaxDuration`, while still rejecting negative and out-of-range values.
- Both `CreateSessionRequestValidator` (legacy submitter and `SessionsService`) pass `allowDefaults: false`; the task-level validators (`CreateSmallTaskRequestValidator`, `CreateLargeTaskRequestValidator`) and the DI-registered `TaskOptionsValidator` keep the permissive default.

This branch has been rebased on `main`.

# Testing

- `TaskOptionsValidatorTest` now covers both flavours of the validator: valid options, unset/zero/negative/out-of-range `MaxRetries` and `Priority`, unset `MaxDuration`, empty `PartitionId`, and a fully default `TaskOptions` (valid for tasks, invalid for a session).
- `CreateSmallTaskRequestValidatorTest`: the five cases asserting that unset or zero `MaxDuration`, `MaxRetries` and `Priority` are rejected now assert the opposite, matching the new task-level semantics.
- `TaskOptionsTests.MergeShouldFallBackToDefaultForUnsetValues` gained the missing `Priority` assertion, which is the behaviour changed by this PR.
- Verified locally: solution builds with no error, `Validators` + `TaskOptionsTests` 159/159 pass, `SubmitterTests` 21/21 pass.

# Impact

Behaviour change on request validation:

- Creating a session with an incomplete `DefaultTaskOption` is still rejected, as before.
- Submitting tasks with a partially filled `TaskOptions` is now accepted; the missing fields are resolved from the session defaults by the existing merge. Previously such a submission was rejected with an `InvalidArgument` status, which made the session defaults useless for `MaxDuration`, `MaxRetries` and `Priority`.
- A task submitted without an explicit `Priority` now inherits the session priority instead of being queued at priority `0`.

No configuration change, no new dependency, no performance impact.

# Additional Information

`allowDefaults` is inverted with respect to the `isSession` parameter used in the first commit of this branch; the last commit propagates that inversion to the call sites and the test fixture, which had been left on the old value.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
