### PR TITLE
feat: Use SessionId as GroupId on SQS

### DIFF
--- a/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
+++ b/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
@@ -1,0 +1,45 @@
+﻿// This file is part of the ArmoniK project
+//
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using Amazon.SQS.Model;
+
+using ArmoniK.Core.Base.DataStructures;
+
+namespace ArmoniK.Core.Adapters.SQS.Extensions;
+
+internal static class MessageDataExtensions
+{
+  public static SendMessageBatchRequestEntry ToBatchRequestEntry(this MessageData messageData,
+                                                                 SQS sqsOptions)
+  {
+    var sendMessageBatchRequestEntry = new SendMessageBatchRequestEntry
+    {
+      Id          = Guid.NewGuid().ToString(),
+      MessageBody = System.Text.Json.JsonSerializer.Serialize(messageData),
+    };
+
+    if (sqsOptions.UseSessionMessageGroupId)
+    {
+      sendMessageBatchRequestEntry.MessageGroupId = messageData.SessionId;
+    }
+
+    return sendMessageBatchRequestEntry;
+  }
+
+}

--- a/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
+++ b/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
@@ -1,21 +1,22 @@
 ﻿// This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Text.Json;
 
 using Amazon.SQS.Model;
 
@@ -26,13 +27,14 @@ namespace ArmoniK.Core.Adapters.SQS.Extensions;
 internal static class MessageDataExtensions
 {
   public static SendMessageBatchRequestEntry ToBatchRequestEntry(this MessageData messageData,
-                                                                 SQS sqsOptions)
+                                                                 SQS              sqsOptions)
   {
     var sendMessageBatchRequestEntry = new SendMessageBatchRequestEntry
-    {
-      Id          = Guid.NewGuid().ToString(),
-      MessageBody = System.Text.Json.JsonSerializer.Serialize(messageData),
-    };
+                                       {
+                                         Id = Guid.NewGuid()
+                                                  .ToString(),
+                                         MessageBody = JsonSerializer.Serialize(messageData),
+                                       };
 
     if (sqsOptions.UseSessionMessageGroupId)
     {
@@ -41,5 +43,4 @@ internal static class MessageDataExtensions
 
     return sendMessageBatchRequestEntry;
   }
-
 }

--- a/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
+++ b/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
@@ -1,22 +1,21 @@
 ﻿// This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Text.Json;
 
 using Amazon.SQS.Model;
 
@@ -33,7 +32,7 @@ internal static class MessageDataExtensions
                                        {
                                          Id = Guid.NewGuid()
                                                   .ToString(),
-                                         MessageBody = JsonSerializer.Serialize(messageData),
+                                         MessageBody = messageData.TaskId,
                                        };
 
     if (sqsOptions.UseSessionMessageGroupId)

--- a/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
+++ b/Adaptors/SQS/src/Extensions/MessageDataExtensions.cs
@@ -1,17 +1,17 @@
 ﻿// This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/SQS/src/Options/SQS.cs
+++ b/Adaptors/SQS/src/Options/SQS.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -88,4 +88,9 @@ internal class SQS
   ///   Maximum number of retry attempts for failed operations.
   /// </summary>
   public int MaxRetries { get; set; } = 5;
+
+  /// <summary>
+  /// Use the message group Id SQS property to ensure that messages are sent within groupId.
+  /// </summary>
+  public bool UseSessionMessageGroupId { get; set; } = false;
 }

--- a/Adaptors/SQS/src/Options/SQS.cs
+++ b/Adaptors/SQS/src/Options/SQS.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -90,7 +90,7 @@ internal class SQS
   public int MaxRetries { get; set; } = 5;
 
   /// <summary>
-  /// Use the message group Id SQS property to ensure that messages are sent within groupId.
+  ///   Use the message group Id SQS property to ensure that messages are sent within groupId.
   /// </summary>
   public bool UseSessionMessageGroupId { get; set; } = false;
 }

--- a/Adaptors/SQS/src/PushQueueStorage.cs
+++ b/Adaptors/SQS/src/PushQueueStorage.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -90,6 +90,7 @@ internal class PushQueueStorage : IPushQueueStorage
                                                                                    Id = Guid.NewGuid()
                                                                                             .ToString(),
                                                                                    MessageBody = data.TaskId,
+                                                                                   MessageGroupId = data.SessionId,
                                                                                  })
                                                                  .ToList();
                                      var retry = 0;

--- a/Adaptors/SQS/src/PushQueueStorage.cs
+++ b/Adaptors/SQS/src/PushQueueStorage.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -86,8 +86,7 @@ internal class PushQueueStorage : IPushQueueStorage
                                    async entries =>
                                    {
                                      var (queueUrl, chunk) = entries;
-                                     var remainingEntries =
-                                       chunk.Select(data => data.ToBatchRequestEntry(options_))
+                                     var remainingEntries = chunk.Select(data => data.ToBatchRequestEntry(options_))
                                                                  .ToList();
                                      var retry = 0;
                                      while (remainingEntries.Any())

--- a/Adaptors/SQS/src/PushQueueStorage.cs
+++ b/Adaptors/SQS/src/PushQueueStorage.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using Amazon.SQS;
 using Amazon.SQS.Model;
 
+using ArmoniK.Core.Adapters.SQS.Extensions;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
@@ -85,13 +86,8 @@ internal class PushQueueStorage : IPushQueueStorage
                                    async entries =>
                                    {
                                      var (queueUrl, chunk) = entries;
-                                     var remainingEntries = chunk.Select(data => new SendMessageBatchRequestEntry
-                                                                                 {
-                                                                                   Id = Guid.NewGuid()
-                                                                                            .ToString(),
-                                                                                   MessageBody = data.TaskId,
-                                                                                   MessageGroupId = data.SessionId,
-                                                                                 })
+                                     var remainingEntries =
+                                       chunk.Select(data => data.ToBatchRequestEntry(options_))
                                                                  .ToList();
                                      var retry = 0;
                                      while (remainingEntries.Any())


### PR DESCRIPTION
# Motivation

Using the SQS ability to perform fair session to avoid the "Noisy Neighbour" issue.

# Description

Adding the possiblity to send messages through SQS using MessageGroupId when the featureflag UseSessionMessageGroupId is set to 'true'

# Impact

Impact can only be seen if we are in SQS AWS queue usage and when the flag SQS__UseSessionMessageGroupId  is used.

# Additional Information

To Activate this feature on AWS need to set SQS__UseSessionMessageGroupId: true

