### PR TITLE
test(partition): add tests for PodConfiguration null values

### DIFF
--- a/Common/tests/StaticInitTests.cs
+++ b/Common/tests/StaticInitTests.cs
@@ -316,4 +316,22 @@ internal class StaticInitTests
     Assert.That(cert.Fingerprint,
                 Is.Null);
   }
+
+  [Test]
+  public void NullPodConfigurationShouldSucceed()
+  {
+    var cert =
+      Partition.FromJson("{\"ParentPartitionIds\":[],\"PartitionId\":\"TestPartition0\",\"PodConfiguration\":null,\"PodMax\":100,\"PodReserved\":50,\"PreemptionPercentage\":20,\"Priority\":1}");
+    Assert.That(cert.PodConfiguration,
+                Is.Null);
+  }
+
+  [Test]
+  public void NoPodConfigurationShouldSucceed()
+  {
+    var cert =
+      Partition.FromJson("{\"ParentPartitionIds\":[],\"PartitionId\":\"TestPartition0\",\"PodMax\":100,\"PodReserved\":50,\"PreemptionPercentage\":20,\"Priority\":1}");
+    Assert.That(cert.PodConfiguration,
+                Is.Empty);
+  }
 }


### PR DESCRIPTION
# Motivation

Ensure that `Partition.FromJson` correctly handles edge cases where `PodConfiguration` is explicitly `null` or entirely absent from the JSON payload.

# Description

Added two unit tests to `Common/tests/StaticInitTests.cs`:

- `NullPodConfigurationShouldSucceed`: verifies that deserializing a partition JSON with `"PodConfiguration": null` results in a `null` `PodConfiguration` property.
- `NoPodConfigurationShouldSucceed`: verifies that deserializing a partition JSON with no `PodConfiguration` field results in an empty `PodConfiguration` property.

# Testing

Two new tests added in `StaticInitTests.cs` covering the null and missing `PodConfiguration` scenarios. No production code was modified.

# Impact

No impact on production behaviour, configuration, or dependencies. Tests only.

# Additional Information

These tests complement the existing `StaticInitTests` suite and improve confidence in the robustness of partition JSON deserialization.