### PR TITLE
fix: Order sqs messages

### DIFF
--- a/Adaptors/SQS/src/PullQueueStorage.cs
+++ b/Adaptors/SQS/src/PullQueueStorage.cs
@@ -17,7 +17,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
@@ -68,7 +67,9 @@ internal class PullQueueStorage : IPullQueueStorage
 
     var queueInfos = new List<(string queueUrl, string queueName, int priority)>();
 
-    for (var i = int.Max(options_.MaxPriority,1); i >=1 ; i--)
+    var maxPriority = int.Max(options_.MaxPriority,
+                              1);
+    for (var i = maxPriority; i >= 1; i--)
     {
       var priority = i + 1;
       logger_.LogDebug("Getting queue for priority #{SqsPriority} with options {@SqsOptions}",

--- a/Adaptors/SQS/src/PullQueueStorage.cs
+++ b/Adaptors/SQS/src/PullQueueStorage.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -68,8 +68,7 @@ internal class PullQueueStorage : IPullQueueStorage
 
     var queueInfos = new List<(string queueUrl, string queueName, int priority)>();
 
-    for (var i = 0; i < int.Max(options_.MaxPriority,
-                                1); i++)
+    for (var i = int.Max(options_.MaxPriority,1); i >=1 ; i--)
     {
       var priority = i + 1;
       logger_.LogDebug("Getting queue for priority #{SqsPriority} with options {@SqsOptions}",
@@ -91,7 +90,7 @@ internal class PullQueueStorage : IPullQueueStorage
       queueInfos.Add((queueUrl, queueName, priority));
     }
 
-    foreach (var (queueUrl, queueName, priority) in queueInfos.OrderByDescending(x => x.priority))
+    foreach (var (queueUrl, queueName, priority) in queueInfos)
     {
       logger_.LogDebug("Try pulling {NbMessages} from {QueueUrl} (priority {Priority}) with options {@SqsOptions}",
                        nbMessages,

--- a/Adaptors/SQS/src/PullQueueStorage.cs
+++ b/Adaptors/SQS/src/PullQueueStorage.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/src/ArmoniK.Core.Common.csproj
+++ b/Common/src/ArmoniK.Core.Common.csproj
@@ -51,5 +51,8 @@
     <ProjectReference Include="..\..\Utils\src\ArmoniK.Core.Utils.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="ArmoniK.Core.Common.Tests" />
+  </ItemGroup>
 
 </Project>

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -540,7 +540,7 @@ public static class TaskLifeCycleHelper
 
   internal static IEnumerable<IGrouping<(string PartitionId, int PriorityId), MessageData>> GroupMessageByPartitionAndOrderItByPriority(IEnumerable<MessageData> dataMessages)
   {
-    return dataMessages.GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority));
+    return dataMessages.OrderByDescending(dm => dm.Options.Priority).GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority));
   }
 
   /// <summary>

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
@@ -516,9 +516,10 @@ public static class TaskLifeCycleHelper
       return;
     }
 
-    if (sessionData.Status != SessionStatus.Paused)
+    if (sessionData.Status is not SessionStatus.Paused)
     {
-      foreach (var group in messages.GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority)))
+      var groupedMessageByPartitionAndOrderedByPriority = GroupMessageByPartitionAndOrderItByPriority(messages);
+      foreach (var group in groupedMessageByPartitionAndOrderedByPriority)
       {
         await pushQueueStorage.PushMessagesAsync(group,
                                                  group.Key.PartitionId,
@@ -535,6 +536,11 @@ public static class TaskLifeCycleHelper
                                          sessionData.Status == SessionStatus.Paused,
                                          cancellationToken)
                    .ConfigureAwait(false);
+  }
+
+  internal static IEnumerable<IGrouping<(string PartitionId, int PriorityId), MessageData>> GroupMessageByPartitionAndOrderItByPriority(IEnumerable<MessageData> dataMessages)
+  {
+    return dataMessages.GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority));
   }
 
   /// <summary>

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -538,10 +538,10 @@ public static class TaskLifeCycleHelper
                    .ConfigureAwait(false);
   }
 
-  internal static IEnumerable<IGrouping<(string PartitionId, int PriorityId), MessageData>> GroupMessageByPartitionAndOrderItByPriority(IEnumerable<MessageData> dataMessages)
-  {
-    return dataMessages.OrderByDescending(dm => dm.Options.Priority).GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority));
-  }
+  internal static IEnumerable<IGrouping<(string PartitionId, int PriorityId), MessageData>> GroupMessageByPartitionAndOrderItByPriority(
+    IEnumerable<MessageData> dataMessages)
+    => dataMessages.OrderByDescending(dm => dm.Options.Priority)
+                   .GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority));
 
   /// <summary>
   ///   Resume session and its paused tasks

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -569,6 +569,7 @@ public static class TaskLifeCycleHelper
                                                                                     data.SessionId,
                                                                                     data.Options),
                                                             cancellationToken)
+                                            .OrderByDescending(msg => msg.Options.Priority)
                                             .GroupBy(msg => (msg.Options.PartitionId, msg.Options.Priority))
                                             .WithCancellation(cancellationToken)
                                             .ConfigureAwait(false))

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -1559,7 +1559,6 @@ public class TaskLifeCycleHelperTest
                                                        currentOption);
                      currentDataMessagesForSession.Add(messageData);
                      dataMessagesCollection.Add(messageData);
-
                    }
 
                    foreach (var messageData in currentDataMessagesForSession.OrderByDescending(p => p.Options.Priority))
@@ -1570,6 +1569,7 @@ public class TaskLifeCycleHelperTest
                        dataMessagesSessionIdByPriority.Add(priority,
                                                            new HashSet<MessageData>());
                      }
+
                      dataMessagesSessionIdByPriority[priority]
                        .Add(messageData);
                    }
@@ -1582,15 +1582,16 @@ public class TaskLifeCycleHelperTest
                 Is.Not.Empty);
     foreach (var messageGrouped in messagesGroupedByPartitionAndOrderedByPriority)
     {
-      var messageGroupPartition    = messageGrouped.Key.PartitionId;
-      var messageGroupPriority = messageGrouped.Key.PriorityId;
+      var messageGroupPartition = messageGrouped.Key.PartitionId;
+      var messageGroupPriority  = messageGrouped.Key.PriorityId;
 
       var dataMessagesForPartition = dataMessagesByPrioritiesByPartition[messageGroupPartition];
 
       var firstElementOfDictionary = dataMessagesForPartition.FirstOrDefault();
 
       var expectedPriority = firstElementOfDictionary.Key;
-      Assert.That(messageGroupPriority, Is.EqualTo(expectedPriority));
+      Assert.That(messageGroupPriority,
+                  Is.EqualTo(expectedPriority));
 
       var messageDataWithinPartitionAndPriority = dataMessagesForPartition[messageGroupPriority];
 

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 


### PR DESCRIPTION
# Motivation

When message are pushed they are grouped by partition and priority. However they are sent on different priority level where the level is quite important.

# Description

Add some logic within the TaskLifeCycleHelper when pushing messages. 

# Testing

This can be tested by sending different priorities within the same partition. And on SQS Adapter we ensure that the queue are created and used from priority 10 into priority 1

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
