### PR TITLE
refactor(mongodb): avoid errors during index and collection initialization

### DIFF
--- a/Adaptors/MongoDB/src/Common/IMongoDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Common/IMongoDataModelMapping.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Common.Injection.Options.Database;
@@ -38,15 +39,11 @@ public interface IMongoDataModelMapping<T>
   ///   Setup indexes for the collection
   ///   Can be called multiple times
   /// </summary>
-  /// <param name="sessionHandle">MongoDB Client session</param>
-  /// <param name="collection">MongoDDB Collection in which to insert data</param>
   /// <param name="options">Options for MongoDB</param>
   /// <returns>
   ///   Task representing the asynchronous execution of the method
   /// </returns>
-  Task InitializeIndexesAsync(IClientSessionHandle sessionHandle,
-                              IMongoCollection<T>  collection,
-                              Options.MongoDB      options);
+  ICollection<CreateIndexModel<T>> InitializeIndexes(Options.MongoDB options);
 
   /// <summary>
   ///   Setup sharding for the collection

--- a/Adaptors/MongoDB/src/Common/MongoCollectionProvider.cs
+++ b/Adaptors/MongoDB/src/Common/MongoCollectionProvider.cs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -131,17 +132,19 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
         lastException = null;
         try
         {
+          if (await mongoDatabase.ListCollectionNamesAsync(cancellationToken: cancellationToken)
+                                 .ToAsyncEnumerable(cancellationToken)
+                                 .AnyAsync(name => name == model.CollectionName,
+                                           cancellationToken)
+                                 .ConfigureAwait(false))
+          {
+            break;
+          }
+
           await mongoDatabase.CreateCollectionAsync(model.CollectionName,
                                                     null,
                                                     cancellationToken)
                              .ConfigureAwait(false);
-          break;
-        }
-        catch (MongoCommandException ex) when (ex.CodeName == "NamespaceExists")
-        {
-          logger.LogDebug(ex,
-                          "Use already existing instance of Collection {CollectionName}",
-                          model.CollectionName);
           break;
         }
         catch (Exception ex)
@@ -163,14 +166,14 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
       }
     }
 
-    var output = mongoDatabase.GetCollection<TData>(model.CollectionName);
+    var collection = mongoDatabase.GetCollection<TData>(model.CollectionName);
     await sessionProvider.Init(cancellationToken)
                          .ConfigureAwait(false);
     var session = sessionProvider.Get();
 
     if (!initDatabase.Init)
     {
-      return output;
+      return collection;
     }
 
     for (var indexRetry = 1; indexRetry < options.MaxRetries; indexRetry++)
@@ -178,17 +181,30 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
       lastException = null;
       try
       {
-        await model.InitializeIndexesAsync(session,
-                                           output,
-                                           options)
-                   .ConfigureAwait(false);
-        break;
-      }
-      catch (MongoCommandException ex) when (ex.CodeName == "IndexOptionsConflict")
-      {
-        logger.LogWarning(ex,
-                          "Index options conflict for {CollectionName} collection",
-                          model.CollectionName);
+        var indexModels = model.InitializeIndexes(options);
+
+        if (!indexModels.Any())
+        {
+          break;
+        }
+
+        var existingIndexes = await collection.Indexes.ListAsync(cancellationToken)
+                                              .ToAsyncEnumerable(cancellationToken)
+                                              .Select(document => document["name"].AsString)
+                                              .ToHashSetAsync(cancellationToken: cancellationToken)
+                                              .ConfigureAwait(false);
+
+        indexModels = indexModels.Where(indexModel => !existingIndexes.Contains(indexModel.Options.Name))
+                                 .ToList();
+
+        if (!indexModels.Any())
+        {
+          break;
+        }
+
+        await collection.Indexes.CreateManyAsync(indexModels,
+                                                 cancellationToken)
+                        .ConfigureAwait(false);
         break;
       }
       catch (Exception ex)
@@ -200,6 +216,12 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
         await Task.Delay(1000 * indexRetry,
                          cancellationToken)
                   .ConfigureAwait(false);
+      }
+
+      if (lastException is not null)
+      {
+        throw new TimeoutException($"Index creation {model.CollectionName}: Max retries reached",
+                                   lastException);
       }
     }
 
@@ -226,6 +248,12 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
                     .ConfigureAwait(false);
         }
       }
+
+      if (lastException is not null)
+      {
+        throw new TimeoutException($"Shard collection {model.CollectionName}: Max retries reached",
+                                   lastException);
+      }
     }
 
     for (var indexRetry = 1; indexRetry < options.MaxRetries; indexRetry++)
@@ -234,7 +262,7 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
       try
       {
         await model.InitializeCollectionAsync(session,
-                                              output,
+                                              collection,
                                               initDatabase)
                    .ConfigureAwait(false);
         break;
@@ -257,7 +285,10 @@ public class MongoCollectionProvider<TData, TModelMapping> : IInitializable, IAs
                                  lastException);
     }
 
-    return output;
+    logger.LogInformation("Collection {CollectionName} initialized",
+                          model.CollectionName);
+
+    return collection;
   }
 
   /// <summary>

--- a/Adaptors/MongoDB/src/ICursorExt.cs
+++ b/Adaptors/MongoDB/src/ICursorExt.cs
@@ -1,0 +1,43 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+
+using MongoDB.Driver;
+
+namespace ArmoniK.Core.Adapters.MongoDB;
+
+internal static class ICursorExt
+{
+  internal static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this                     Task<IAsyncCursor<T>> cursorTask,
+                                                                 [EnumeratorCancellation] CancellationToken     cancellationToken)
+  {
+    var cursor = await cursorTask.ConfigureAwait(false);
+    while (await cursor.MoveNextAsync(cancellationToken)
+                       .ConfigureAwait(false))
+    {
+      foreach (var item in cursor.Current)
+      {
+        cancellationToken.ThrowIfCancellationRequested();
+        yield return item;
+      }
+    }
+  }
+}

--- a/Adaptors/MongoDB/src/Table/DataModel/Auth/AuthDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/Auth/AuthDataModelMapping.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -61,27 +62,6 @@ public class AuthDataModelMapping : IMongoDataModelMapping<AuthData>
     => nameof(AuthData);
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle       sessionHandle,
-                                           IMongoCollection<AuthData> collection,
-                                           Options.MongoDB            options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateCombinedIndex<AuthData>(model => model.Fingerprint,
-                                                                  model => model.Cn,
-                                                                  true),
-                        IndexHelper.CreateHashedOrAscendingIndex<AuthData>(model => model.Fingerprint,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<AuthData>(model => model.UserId,
-                                                                           options.UseHashed),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
-
-  /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,
                                    Options.MongoDB      options)
     => Task.CompletedTask;
@@ -104,4 +84,17 @@ public class AuthDataModelMapping : IMongoDataModelMapping<AuthData>
                       .ConfigureAwait(false);
     }
   }
+
+  /// <inheritdoc />
+  public ICollection<CreateIndexModel<AuthData>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateCombinedIndex<AuthData>(model => model.Fingerprint,
+                                                   model => model.Cn,
+                                                   true),
+         IndexHelper.CreateHashedOrAscendingIndex<AuthData>(model => model.Fingerprint,
+                                                            options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<AuthData>(model => model.UserId,
+                                                            options.UseHashed),
+       };
 }

--- a/Adaptors/MongoDB/src/Table/DataModel/Auth/RoleDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/Auth/RoleDataModelMapping.cs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -59,20 +60,12 @@ public class RoleDataModelMapping : IMongoDataModelMapping<RoleData>
     => nameof(RoleData);
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle       sessionHandle,
-                                           IMongoCollection<RoleData> collection,
-                                           Options.MongoDB            options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateAscendingIndex<RoleData>(model => model.RoleName,
-                                                                   true),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
+  public ICollection<CreateIndexModel<RoleData>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateAscendingIndex<RoleData>(model => model.RoleName,
+                                                    true),
+       };
 
   /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,

--- a/Adaptors/MongoDB/src/Table/DataModel/Auth/UserDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/Auth/UserDataModelMapping.cs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -59,19 +60,12 @@ public class UserDataModelMapping : IMongoDataModelMapping<UserData>
     => nameof(UserData);
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle       sessionHandle,
-                                           IMongoCollection<UserData> collection,
-                                           Options.MongoDB            options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateAscendingIndex<UserData>(model => model.Username,
-                                                                   true),
-                      };
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
+  public ICollection<CreateIndexModel<UserData>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateAscendingIndex<UserData>(model => model.Username,
+                                                    true),
+       };
 
   /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,

--- a/Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -82,20 +83,12 @@ public class PartitionDataModelMapping : IMongoDataModelMapping<PartitionData>
 
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle            sessionHandle,
-                                           IMongoCollection<PartitionData> collection,
-                                           Options.MongoDB                 options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateHashedOrAscendingIndex<PartitionData>(model => model.PartitionId,
-                                                                                options.UseHashed),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
+  public ICollection<CreateIndexModel<PartitionData>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateHashedOrAscendingIndex<PartitionData>(model => model.PartitionId,
+                                                                 options.UseHashed),
+       };
 
   /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,

--- a/Adaptors/MongoDB/src/Table/DataModel/ResultDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/ResultDataModelMapping.cs
@@ -92,29 +92,21 @@ public class ResultDataModelMapping : IMongoDataModelMapping<Result>
     => nameof(Result);
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle     sessionHandle,
-                                           IMongoCollection<Result> collection,
-                                           Options.MongoDB          options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.SessionId,
-                                                                         options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.CreatedBy,
-                                                                         options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.CompletedBy,
-                                                                         options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.OwnerTaskId,
-                                                                         options.UseHashed),
-                        IndexHelper.CreateAscendingIndex<Result>(model => model.CreationDate,
-                                                                 expireAfter: options.DataRetention),
-                        IndexHelper.CreateAscendingIndex<Result>(model => model.CompletionDate),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
+  public ICollection<CreateIndexModel<Result>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.SessionId,
+                                                          options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.CreatedBy,
+                                                          options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.CompletedBy,
+                                                          options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<Result>(model => model.OwnerTaskId,
+                                                          options.UseHashed),
+         IndexHelper.CreateAscendingIndex<Result>(model => model.CreationDate,
+                                                  expireAfter: options.DataRetention),
+         IndexHelper.CreateAscendingIndex<Result>(model => model.CompletionDate),
+       };
 
   /// <inheritdoc />
   public async Task ShardCollectionAsync(IClientSessionHandle sessionHandle,

--- a/Adaptors/MongoDB/src/Table/DataModel/SessionDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/SessionDataModelMapping.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Adapters.MongoDB.Common;
@@ -123,25 +124,17 @@ public class SessionDataModelMapping : IMongoDataModelMapping<SessionData>
     => nameof(SessionData);
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle          sessionHandle,
-                                           IMongoCollection<SessionData> collection,
-                                           Options.MongoDB               options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateAscendingIndex<SessionData>(model => model.CreationDate,
-                                                                      expireAfter: options.DataRetention),
-                        IndexHelper.CreateAscendingIndex<SessionData>(model => model.CancellationDate),
-                        IndexHelper.CreateHashedOrAscendingIndex<SessionData>(model => model.Status,
-                                                                              options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<SessionData>(model => model.Options.PartitionId,
-                                                                              options.UseHashed),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
+  public ICollection<CreateIndexModel<SessionData>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateAscendingIndex<SessionData>(model => model.CreationDate,
+                                                       expireAfter: options.DataRetention),
+         IndexHelper.CreateAscendingIndex<SessionData>(model => model.CancellationDate),
+         IndexHelper.CreateHashedOrAscendingIndex<SessionData>(model => model.Status,
+                                                               options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<SessionData>(model => model.Options.PartitionId,
+                                                               options.UseHashed),
+       };
 
   /// <inheritdoc />
   public async Task ShardCollectionAsync(IClientSessionHandle sessionHandle,

--- a/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/TaskDataModelMapping.cs
@@ -187,39 +187,31 @@ public class TaskDataModelMapping : IMongoDataModelMapping<TaskData>
 
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle       sessionHandle,
-                                           IMongoCollection<TaskData> collection,
-                                           Options.MongoDB            options)
-  {
-    var indexModels = new[]
-                      {
-                        IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.Status,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.Options.PartitionId,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.SessionId,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.OwnerPodId,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.InitialTaskId,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.CreatedBy,
-                                                                           options.UseHashed),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationDate,
-                                                                   expireAfter: options.DataRetention),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.SubmittedDate),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.StartDate),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.EndDate),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationToEndDuration),
-                        IndexHelper.CreateAscendingIndex<TaskData>(model => model.ProcessingToEndDuration),
-                        IndexHelper.CreateCombinedIndex<TaskData>(model => model.Options.PartitionId,
-                                                                  model => model.Status),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
-  }
+  public ICollection<CreateIndexModel<TaskData>> InitializeIndexes(Options.MongoDB options)
+    => new[]
+       {
+         IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.Status,
+                                                            options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.Options.PartitionId,
+                                                            options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.SessionId,
+                                                            options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.OwnerPodId,
+                                                            options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.InitialTaskId,
+                                                            options.UseHashed),
+         IndexHelper.CreateHashedOrAscendingIndex<TaskData>(model => model.CreatedBy,
+                                                            options.UseHashed),
+         IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationDate,
+                                                    expireAfter: options.DataRetention),
+         IndexHelper.CreateAscendingIndex<TaskData>(model => model.SubmittedDate),
+         IndexHelper.CreateAscendingIndex<TaskData>(model => model.StartDate),
+         IndexHelper.CreateAscendingIndex<TaskData>(model => model.EndDate),
+         IndexHelper.CreateAscendingIndex<TaskData>(model => model.CreationToEndDuration),
+         IndexHelper.CreateAscendingIndex<TaskData>(model => model.ProcessingToEndDuration),
+         IndexHelper.CreateCombinedIndex<TaskData>(model => model.Options.PartitionId,
+                                                   model => model.Status),
+       };
 
   /// <inheritdoc />
   public async Task ShardCollectionAsync(IClientSessionHandle sessionHandle,

--- a/ProfilingTools/src/OpenTelemetryExporter/OpenTelemetryDataModelMapping.cs
+++ b/ProfilingTools/src/OpenTelemetryExporter/OpenTelemetryDataModelMapping.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Adapters.MongoDB.Common;
@@ -81,9 +82,7 @@ public class OpenTelemetryDataModelMapping : IMongoDataModelMapping<OpenTelemetr
 
 
   /// <inheritdoc />
-  public async Task InitializeIndexesAsync(IClientSessionHandle                sessionHandle,
-                                           IMongoCollection<OpenTelemetryData> collection,
-                                           Adapters.MongoDB.Options.MongoDB    options)
+  public ICollection<CreateIndexModel<OpenTelemetryData>> InitializeIndexes(Adapters.MongoDB.Options.MongoDB options)
   {
     var sourceNameIndex  = Builders<OpenTelemetryData>.IndexKeys.Hashed(model => model.SourceName);
     var displayNameIndex = Builders<OpenTelemetryData>.IndexKeys.Hashed(model => model.DisplayName);
@@ -92,23 +91,19 @@ public class OpenTelemetryDataModelMapping : IMongoDataModelMapping<OpenTelemetr
     var combinedIndex = Builders<OpenTelemetryData>.IndexKeys.Combine(sourceNameIndex,
                                                                       displayNameIndex);
 
-    var indexModels = new CreateIndexModel<OpenTelemetryData>[]
-                      {
-                        new(combinedIndex,
-                            new CreateIndexOptions
-                            {
-                              Name = nameof(combinedIndex),
-                            }),
-                        new(activityIdIndex,
-                            new CreateIndexOptions
-                            {
-                              Name = nameof(activityIdIndex),
-                            }),
-                      };
-
-    await collection.Indexes.CreateManyAsync(sessionHandle,
-                                             indexModels)
-                    .ConfigureAwait(false);
+    return new CreateIndexModel<OpenTelemetryData>[]
+           {
+             new(combinedIndex,
+                 new CreateIndexOptions
+                 {
+                   Name = nameof(combinedIndex),
+                 }),
+             new(activityIdIndex,
+                 new CreateIndexOptions
+                 {
+                   Name = nameof(activityIdIndex),
+                 }),
+           };
   }
 
   public Task ShardCollectionAsync(IClientSessionHandle             sessionHandle,


### PR DESCRIPTION
# Motivation

When MongoDB collections or indexes already exist, the previous implementation relied on catching `MongoCommandException` (e.g. `NamespaceExists`, `IndexOptionsConflict`) to handle idempotent initialization. This approach masks genuine errors and makes it harder to reason about initialization failures. The goal is to proactively check for existing resources and skip creation when they are already present, letting real errors surface properly.

# Description

Refactored the MongoDB collection and index initialization logic to avoid error-driven control flow:

- **`IMongoDataModelMapping<T>.InitializeIndexesAsync`**: Changed the method signature from `async Task` (which internally created indexes) to a synchronous `ICollection<CreateIndexModel<T>>` that simply returns the desired index models. The actual index creation is now centralized in `MongoCollectionProvider`.

- **`MongoCollectionProvider`**: 
  - Before creating a collection, checks whether it already exists via `ListCollectionNamesAsync` and skips creation if so (instead of catching `NamespaceExists`).
  - Before creating indexes, lists existing indexes via `collection.Indexes.ListAsync`, then filters out any index models whose name already appears in the existing set (instead of catching `IndexOptionsConflict`).
  - Added `TimeoutException` throwing when max retries are exceeded for index and shard initialization, so callers get a clear error instead of silent failure.
  - Added an info log after successful collection initialization.

- **`ICursorExt`**: New internal helper that converts a `Task<IAsyncCursor<T>>` into an `IAsyncEnumerable<T>` for convenient async streaming with LINQ operators.

- All `DataModelMapping` implementations (`AuthDataModelMapping`, `RoleDataModelMapping`, `UserDataModelMapping`, `PartitionDataModelMapping`, `ResultDataModelMapping`, `SessionDataModelMapping`, `TaskDataModelMapping`, `OpenTelemetryDataModelMapping`) updated to match the new interface — they now return index model collections synchronously instead of performing async index creation themselves.

# Testing

The refactoring preserves the same index definitions across all data model mappings. Existing integration tests covering MongoDB initialization cover the behavior. No new test cases were added as the logic change is structural (proactive check vs. reactive error handling) with equivalent observable outcomes.

# Impact

- **Behavior**: Initialization is now idempotent without relying on exception handling for control flow. Real errors (e.g., network issues, auth failures) will no longer be masked by `MongoCommandException` catches.
- **Error reporting**: Max-retry exhaustion now raises a `TimeoutException` with a descriptive message and the underlying cause, making failures easier to diagnose.
- **Performance**: Minor improvement — skipping index creation when indexes already exist avoids unnecessary round-trips to MongoDB.
- **No breaking changes**: The public API surface of ArmoniK.Core is unchanged; only the internal MongoDB adapter internals are refactored.
