### PR TITLE
fix: remove MongoDB connection string from logs

### DIFF
--- a/Adaptors/MongoDB/src/ServiceCollectionExt.cs
+++ b/Adaptors/MongoDB/src/ServiceCollectionExt.cs
@@ -188,8 +188,7 @@ public static class ServiceCollectionExt
     var mongoOptions = provider.GetRequiredService<Options.MongoDB>();
     using var _ = logger.BeginNamedScope("MongoDB configuration",
                                          ("host", mongoOptions.Host),
-                                         ("port", mongoOptions.Port),
-                                         ("connectionString", mongoOptions.ConnectionString));
+                                         ("port", mongoOptions.Port));
 
     var settings = GetMongoSettings(mongoOptions,
                                     logger);


### PR DESCRIPTION
# Motivation

The MongoDB connection string was being logged as part of the named scope when configuring MongoDB. Connection strings typically contain sensitive information such as credentials (username and password), host addresses, and other configuration details that should not appear in logs.

# Description

Removed `connectionString` from the named scope properties logged during MongoDB configuration in `Adaptors/MongoDB/src/ServiceCollectionExt.cs`. The `host` and `port` properties are retained as they are not sensitive and remain useful for debugging.

# Testing

No additional tests are required for this change, as it is a straightforward removal of a log property. The existing tests continue to pass.

# Impact

- **Security**: Connection strings will no longer appear in application logs, reducing the risk of credential exposure.
- **Observability**: The `host` and `port` properties are still logged, preserving useful diagnostic information without exposing sensitive data.
- No configuration changes or new dependencies are introduced.

# Additional Information

This is a security hygiene fix. Logging connection strings is a common source of credential leakage, especially in environments where logs are aggregated and accessible to multiple teams.
