### PR TITLE
fix(mongodb): remove redundant index creation on id_ in partition collection

### DIFF
--- a/Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs
+++ b/Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs
@@ -15,6 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -84,11 +85,7 @@ public class PartitionDataModelMapping : IMongoDataModelMapping<PartitionData>
 
   /// <inheritdoc />
   public ICollection<CreateIndexModel<PartitionData>> InitializeIndexes(Options.MongoDB options)
-    => new[]
-       {
-         IndexHelper.CreateHashedOrAscendingIndex<PartitionData>(model => model.PartitionId,
-                                                                 options.UseHashed),
-       };
+    => Array.Empty<CreateIndexModel<PartitionData>>();
 
   /// <inheritdoc />
   public Task ShardCollectionAsync(IClientSessionHandle sessionHandle,


### PR DESCRIPTION
# Motivation

The partition collection in MongoDB had an explicit index being created on the `PartitionId` field (mapped to `id_` in the document model). Since `PartitionId` serves as the document identifier and is already indexed via the default `_id` index, creating an additional hashed or ascending index on this field is redundant and unnecessary.

# Description

Removed the explicit index initialization for `PartitionId` in `PartitionDataModelMapping.InitializeIndexes`. The method now returns an empty collection instead of creating a hashed/ascending index on `id_`.

- `Adaptors/MongoDB/src/Table/DataModel/PartitionDataModelMapping.cs`: replaced the index array containing a `PartitionId` index with `Array.Empty<CreateIndexModel<PartitionData>>()`.

# Testing

The existing test suite covers the partition data model. No new tests were added as this is a straightforward removal of a redundant index definition.

# Impact

- Slightly reduced MongoDB initialization time as one fewer index is created on the partition collection.
- No behavioral change: queries on `PartitionId` continue to work via the existing `_id` index.
- No configuration or API changes.

# Additional Information

This aligns with the broader refactoring to avoid errors and redundancy during MongoDB index and collection initialization (see related commits in this branch).