### PR TITLE
fix(metrics): escape dashes to underscores in Prometheus metric names

### DIFF
--- a/Control/Metrics/src/ArmoniKMeter.cs
+++ b/Control/Metrics/src/ArmoniKMeter.cs
@@ -193,6 +193,8 @@ public class ArmoniKMeter
       }
     }
 
+    sb.Replace("-",
+               "_");
     return sb.ToString();
   }
 

--- a/Control/Metrics/tests/ArmoniKMeterTest.cs
+++ b/Control/Metrics/tests/ArmoniKMeterTest.cs
@@ -447,6 +447,26 @@ public class ArmoniKMeterTest
   }
 
   [Test]
+  public async Task GetMetricsWithDashInPartitionNameShouldEscapeDashToUnderscore()
+  {
+    SetupPartitions("my-partition");
+    SetupTaskCounts(("my-partition", TaskStatus.Submitted, 4));
+    var meter = CreateMeter();
+
+    var output = await meter.GetMetricsAsync(CancellationToken.None)
+                            .ConfigureAwait(false);
+
+    // Dashes in partition names must be replaced by underscores in metric names
+    Assert.That(output,
+                Does.Not.Contain("-"));
+    var metrics = ParseMetrics(output);
+    Assert.That(metrics["armonik_my_partition_tasks_submitted"],
+                Is.EqualTo(4));
+    Assert.That(metrics["armonik_my_partition_tasks_queued"],
+                Is.EqualTo(4));
+  }
+
+  [Test]
   public async Task GetMetricsAfterCacheExpiryWindowShouldQueryDbAgain()
   {
     SetupPartitions("p1");


### PR DESCRIPTION
# Motivation

Prometheus metric names must match `[a-zA-Z_:][a-zA-Z0-9_:]*` — dashes are not valid characters. When a partition ID contains a dash (e.g. `my-partition`), the generated metric name `armonik_my-partition_tasks_queued` is invalid Prometheus format and can be rejected or silently mishandled by Prometheus scrapers and dashboards.

# Description

- Added `sb.Replace("-", "_")` at the end of `BuildMetricsAsync` in `ArmoniKMeter.cs` to replace all dashes with underscores in the final Prometheus text output.
- Added a unit test `GetMetricsWithDashInPartitionNameShouldEscapeDashToUnderscore` in `ArmoniKMeterTest.cs` that verifies:
  - No dash characters appear anywhere in the output when a partition name contains a dash.
  - The escaped metric names (`armonik_my_partition_tasks_submitted`, `armonik_my_partition_tasks_queued`) are present with the correct values.

# Testing

Added `GetMetricsWithDashInPartitionNameShouldEscapeDashToUnderscore` in `Control/Metrics/tests/ArmoniKMeterTest.cs`. It sets up a partition named `my-partition`, runs `GetMetricsAsync`, and asserts that the output contains no dashes and that the underscore-escaped metric names carry the expected counts.

# Impact

Partition IDs containing dashes will have those dashes replaced by underscores in the exported Prometheus metric names. This is a correctness fix with no behavioural impact for partitions whose names are already valid Prometheus identifiers.

# Additional Information

No new dependencies. No configuration changes required.