### PR TITLE
docs(concepts): add partitions, initialization, and cache concept guides

### DIFF
--- a/.docs/content/1.concepts/10.initialization.md
+++ b/.docs/content/1.concepts/10.initialization.md
@@ -1,0 +1,85 @@
+
+# Initialization
+
+## What is initialization?
+
+Before ArmoniK can serve requests, its backing stores must be set up: database collections must
+exist and be indexed, queue infrastructure must be ready, and initial data such as
+[partitions](./9.partitions.md) and [authentication](./3.authentication.md) entries must be
+present. This setup phase is called **initialization**.
+
+Initialization is performed by the **control plane** at startup. Four flags in the `InitServices`
+configuration section control which parts are initialized and whether the control plane exits once
+initialization is complete.
+
+## Initialization flags
+
+| Flag                | Default | Description                                                                                                       |
+|---------------------|---------|-------------------------------------------------------------------------------------------------------------------|
+| `InitDatabase`      | `true`  | Creates database collections and indexes, then inserts the configured partitions and authentication data.         |
+| `InitObjectStorage` | `true`  | Initializes the object storage backend (buckets, paths, or equivalent).                                           |
+| `InitQueue`         | `true`  | Initializes the queue infrastructure (queues, channels, or equivalent).                                           |
+| `StopAfterInit`     | `false` | When `true`, the control plane exits as soon as initialization completes instead of continuing to serve requests. |
+
+Each flag can be set independently via environment variables:
+
+```bash
+InitServices__InitDatabase=true
+InitServices__InitObjectStorage=true
+InitServices__InitQueue=true
+InitServices__StopAfterInit=false
+```
+
+## What gets initialized
+
+### Database
+
+When `InitDatabase` is enabled, the control plane:
+
+1. Creates the necessary collections if they do not already exist.
+2. Creates indexes on those collections.
+3. Upserts the initial data provided in the configuration: **partitions** and **authentication**
+   entries (users, roles, and certificates).
+
+Refer to [Partitions](./9.partitions.md#partition-administration) and
+[Authentication](./3.authentication.md#user-administration) for details on how to supply this
+data via environment variables.
+
+### Object storage and queue
+
+When `InitObjectStorage` or `InitQueue` are enabled, the control plane prepares the respective
+backends according to the adaptor in use. The exact operations depend on the adaptor (e.g.
+creating S3 buckets, AMQP queues, etc.).
+
+## Recommended deployment pattern
+
+The recommended approach is to separate initialization from normal operation by running the
+control plane once in **init-then-quit** mode before starting it (and the agents) for regular
+use.
+
+### Step 1 — Initialize
+
+Run the control plane with all init flags enabled and `StopAfterInit=true`. It will set up all
+backing stores, insert initial data, and exit.
+
+```bash
+InitServices__InitDatabase=true
+InitServices__InitObjectStorage=true
+InitServices__InitQueue=true
+InitServices__StopAfterInit=true
+```
+
+### Step 2 — Run normally
+
+Start the control plane and agents with initialization disabled. They connect to the already
+initialized backing stores and begin serving requests immediately.
+
+```bash
+InitServices__InitDatabase=false
+InitServices__InitObjectStorage=false
+InitServices__InitQueue=false
+InitServices__StopAfterInit=false
+```
+
+> **NOTE :** Disabling initialization in normal operation reduces startup time and avoids any
+> risk of accidentally modifying backing store structure or data during a restart.

--- a/.docs/content/1.concepts/11.cache.md
+++ b/.docs/content/1.concepts/11.cache.md
@@ -1,0 +1,118 @@
+
+# Agent cache
+
+## Overview
+
+Each ArmoniK agent maintains a local, file-based cache that avoids redundant fetches from the
+object storage. When a task depends on a result that was recently consumed by another task on the
+same node, the agent reads the data directly from disk instead of going back to the remote object
+storage.
+
+The cache is entirely internal to the agent process. Workers do not have direct access to it.
+
+## Two-level folder design
+
+The agent uses two distinct filesystem paths for data management.
+
+| Path (option)        | Purpose                                                 | Accessible by worker |
+|----------------------|---------------------------------------------------------|----------------------|
+| `InternalCacheFolder`| Persistent cache shared across tasks and agent processes| No                   |
+| `SharedCacheFolder`  | Per-task temporary staging folder exposed to the worker | Yes                  |
+
+### Internal cache (`InternalCacheFolder`)
+
+`InternalCacheFolder` is the actual cache. It is a flat directory where each file is named after
+the `ResultId` of the result it contains. Files accumulate across task executions and are only
+removed when eviction is triggered (see [Cache eviction](#cache-eviction)).
+
+Because this folder is just a regular directory on the node, multiple agent processes running on
+the same physical or virtual node can point to the **same path**. This makes the cache effectively
+shared at the node level: if agent A already fetched a result, agent B on the same node will
+find it in the cache without a round trip to the object storage.
+
+### Per-task folder (`SharedCacheFolder`)
+
+For each task it processes, the agent creates a unique temporary sub-directory under
+`SharedCacheFolder` (named after a randomly generated token). This folder holds:
+
+- The task payload.
+- All data dependencies that the task needs.
+- Any output results produced by the worker.
+
+The worker is given a path to this folder and reads its inputs and writes its outputs there.
+The agent then reads the outputs back to upload them to the object storage and optionally copy
+them into the internal cache.
+
+The folder is deleted during agent cleanup after the task completes.
+
+## Cache lifecycle
+
+### Pre-processing
+
+Before executing a task, the agent resolves the `ResultId` of each dependency (payload and data
+dependencies) and tries to serve them from the internal cache:
+
+1. For each dependency, the agent looks for a file named `<ResultId>` in `InternalCacheFolder`.
+2. If found, the file is copied into the per-task folder so the worker can access it.
+3. If not found, the data is fetched from the object storage into the per-task folder.
+4. Newly fetched files are then copied into the internal cache (via a temporary file to ensure
+   atomicity) so that future tasks on the same node can reuse them.
+
+### Post-processing
+
+After the worker reports a successful output, the agent copies every result file produced by the
+worker from the per-task folder into `InternalCacheFolder`. Downstream tasks that depend on those
+results will therefore find them in the cache without hitting the object storage.
+
+## Why workers cannot access the cache
+
+Workers only see the per-task folder. This is intentional:
+
+- **Isolation**: a worker should only access the data it is authorised to see for its current
+  task.
+- **Simplicity**: the cache files are keyed by `ResultId`, which is an internal ArmoniK
+  identifier. Exposing the raw cache to workers would require them to understand ArmoniK
+  internals.
+- **Safety**: the cache is shared across tasks and potentially across agents. Allowing a worker
+  to write to it directly could corrupt entries used by other tasks.
+
+## Cache eviction
+
+Eviction is driven by disk usage and happens at the end of every task (during agent disposal).
+
+1. The agent reads the disk usage of the filesystem that hosts `InternalCacheFolder`.
+2. If `(usedSpace / totalSize) > CacheEvictionThreshold`, eviction is triggered.
+3. Files are sorted by their last-access or last-write time (whichever is more recent).
+4. Files are deleted from the oldest to the most recently accessed until the usage falls below
+   the threshold.
+
+Caching is disabled when `CacheEvictionThreshold` is set to `0` (the default).
+
+## Configuration
+
+The cache is configured through the following environment variables:
+
+```bash
+Pollster__SharedCacheFolder=/cache/shared
+Pollster__InternalCacheFolder=/cache/internal
+Pollster__CacheEvictionThreshold=0.8
+```
+
+For a full description of each variable, see the
+[Pollster variables documentation](https://armonikcore.readthedocs.io/en/latest/content/envars/ArmoniK.Core.EnvVars.html#options-for-pollster).
+
+### Sharing the cache across agents on the same node
+
+To enable node-level cache sharing, mount the same directory on all agent containers and point
+`InternalCacheFolder` at it. The cache is purely additive (no coordination protocol is needed):
+if two agents write the same `ResultId` simultaneously the first write wins, and either copy is
+equally valid.
+
+```bash
+# Agent A and Agent B on the same node both use:
+Pollster__InternalCacheFolder=/mnt/node-cache/armonik
+```
+
+> **NOTE:** `SharedCacheFolder` should **not** be shared between agents. Each agent must have
+> its own `SharedCacheFolder` because per-task sub-directories are created and deleted there
+> independently.

--- a/.docs/content/1.concepts/9.partitions.md
+++ b/.docs/content/1.concepts/9.partitions.md
@@ -1,0 +1,162 @@
+
+# Partitions
+
+## What is a partition?
+
+A **partition** is a logical namespace in ArmoniK that groups a set of agent/worker couples and controls
+how tasks are routed to them. Every task is assigned to exactly one partition, and a
+**session** declares upfront which partitions its tasks are allowed to use.
+
+Partitions serve two complementary purposes:
+
+- **Resource management**: each partition defines how many agent/worker couples are reserved for it and
+  how many it may use at most, enabling multi-tenant deployments where different workloads have
+  guaranteed capacity.
+- **Task routing**: tasks are dispatched to the partition-specific message queue, so only
+  workers subscribed to that partition will pick them up.
+
+## Partition properties
+
+### Identity
+
+Each partition is identified by a unique **`PartitionId`** string, which is what clients use when
+creating sessions and submitting tasks. A list of **`ParentPartitionIds`** records the chain of
+ancestor partitions from the direct parent up to the root; this is used to express partition
+hierarchies (e.g. a specialised partition that belongs to a broader resource pool). Fields other 
+than **`PartitionId`** are not used. They are only there as an indication. They do not have default
+values.
+
+### Capacity and scheduling
+
+Three numeric properties govern how the scheduler allocates pods to a partition:
+
+- **`PodReserved`** is the number of agent/worker couples kept permanently available for this
+  partition. It acts as a soft floor, ensuring that at least this much capacity is always
+  dedicated to the partition regardless of other workloads running concurrently.
+- **`PodMax`** is the hard upper bound on the number of agent/worker couples the partition may
+  use at once. The scheduler ignores partitions whose `PodMax` is 0, so setting it to 0 is a
+  convenient way to disable a partition without removing it.
+- **`PreemptionPercentage`** (0–100) controls how much of the partition's capacity can be
+  reclaimed when higher-priority work needs resources. A value of 0 means the partition is
+  never preempted; 100 means it can be fully preempted.
+- **`Priority`** determines the partition's relative importance when the scheduler must choose
+  between competing partitions. Higher values take precedence.
+
+### Pod configuration
+
+**`PodConfiguration`** is an optional free-form dictionary of key-value pairs that is forwarded
+to every agent/worker couple running in the partition. Use it to express hardware requirements,
+environment settings, or any other deployment-specific parameters that workers in this partition
+need (for example, the type of GPU accelerator to request).
+
+## Session and task binding
+
+When a **session** is created, the client provides a list of allowed `PartitionIds`. All tasks
+submitted within that session must reference one of those partitions. A default partition is also
+set at the session level and used when the task does not specify one explicitly.
+
+At task submission time, ArmoniK validates that the task's `PartitionId` belongs to the session's
+allowed list. If the partition is not allowed, the task is rejected.
+
+Once validated, the task is pushed to the partition's dedicated message queue. Agents
+subscribed to that partition dequeue and send the tasks work their associated worker for execution.
+
+## Task routing flowchart
+
+```mermaid
+flowchart TB
+    Client([Client])
+    Session{Session\nwith allowed partitions}
+    Validate{PartitionId in\nsession's allowed list?}
+    Rejected(Task rejected)
+    Queue[(Partition queue\npriority-ordered)]
+    Worker([Agent / Worker])
+    Result([Result])
+
+    Client --> Session
+    Session --> |Submit task with PartitionId| Validate
+    Validate --> |No| Rejected
+    Validate --> |Yes| Queue
+    Queue --> |Task message| Worker
+    Worker --> |Executes the task, configured with PodConfiguration| Result
+```
+
+## Partition administration
+
+### Overview
+
+Partitions are initialised at startup from the `Partitioning` section of the `InitServices`
+configuration.
+Each partition is provided as a JSON string that is deserialised and inserted into the database.
+
+> **NOTE :** Partition definitions are loaded during initialisation. To modify a partition
+> after deployment, update the configuration and re-run initialisation as described in
+> [Editing a partition](#editing-a-partition).
+
+### JSON format
+
+A partition JSON object has the following structure:
+
+```json
+{
+  "PartitionId": "default",
+  "ParentPartitionIds": [],
+  "PodReserved": 1,
+  "PodMax": 10,
+  "PreemptionPercentage": 50,
+  "Priority": 2,
+  "PodConfiguration": {
+    "key": "value"
+  }
+}
+```
+
+`PodConfiguration` may be omitted or left empty when no specific pod settings are required.
+
+### Configuring partitions via environment variables
+
+Partitions are provided as indexed environment variables under
+`InitServices__Partitioning__Partitions`. Each variable holds a serialised JSON string for one
+partition.
+
+```bash
+InitServices__Partitioning__Partitions__0=<json string for the first partition>
+InitServices__Partitioning__Partitions__1=<json string for the second partition>
+```
+
+#### Example: a default partition and a GPU partition
+
+The following example defines two partitions: `default` for general-purpose workloads and `gpu`
+for compute-intensive tasks that require a dedicated, higher-priority pool of pods.
+
+```bash
+InitServices__Partitioning__Partitions__0='{"PartitionId":"default","ParentPartitionIds":[],"PodReserved":1,"PodMax":10,"PreemptionPercentage":50,"Priority":2,"PodConfiguration":{}}'
+InitServices__Partitioning__Partitions__1='{"PartitionId":"gpu","ParentPartitionIds":[],"PodReserved":2,"PodMax":20,"PreemptionPercentage":20,"Priority":5,"PodConfiguration":{"accelerator":"nvidia-tesla-v100"}}'
+```
+
+### Editing a partition
+
+To update a partition's properties, edit the corresponding `InitServices__Partitioning__Partitions__N`
+environment variable with the updated JSON and redeploy with initialisation enabled
+(`InitServices__InitDatabase=true`). ArmoniK will overwrite the stored partition with the new values.
+
+### Deleting a partition
+
+To remove a partition, delete its MongoDB document. Refer to the
+[MongoDB `findOneAndDelete` documentation](https://www.mongodb.com/docs/manual/reference/method/db.collection.findOneAndDelete/)
+for the procedure.
+
+> **NOTE :** Deleting a partition while sessions or tasks reference it will cause those tasks to
+> be rejected at submission time.
+
+## Querying partitions via the API
+
+ArmoniK exposes two gRPC endpoints for partitions:
+
+| Endpoint         | Permission required         | Description                                                             |
+|------------------|-----------------------------|-------------------------------------------------------------------------|
+| `GetPartition`   | `Partitions:GetPartition`   | Returns the full metadata of a single partition identified by its ID.   |
+| `ListPartitions` | `Partitions:ListPartitions` | Returns a paginated, optionally filtered and sorted list of partitions. |
+
+Both endpoints return `PartitionRaw` objects containing all fields described in the
+[Partition properties](#partition-properties) section.

--- a/Common/src/Injection/Options/Pollster.cs
+++ b/Common/src/Injection/Options/Pollster.cs
@@ -62,12 +62,14 @@ public class Pollster
   public int NbAcquisitionRetry { get; set; } = 3;
 
   /// <summary>
-  ///   Shared folder between Agent and Worker
+  ///   Root directory for per-task staging folders.
+  ///   Sub-directories are created here for each task and deleted after it completes
   /// </summary>
   public string SharedCacheFolder { get; set; } = "/cache/shared";
 
   /// <summary>
-  ///   Internal cache for data
+  ///   Persistent cache directory. Files are keyed by ResultId.
+  ///   Can be shared across multiple agent processes on the same node.
   /// </summary>
   public string InternalCacheFolder { get; set; } = "/cache/internal";
 
@@ -93,8 +95,8 @@ public class Pollster
   public bool FailReadinessIfNoTasks { get; set; }
 
   /// <summary>
-  ///   Gets or sets the threshold as a storage size fraction at which cache eviction is triggered.
-  ///   Disabled when set to 0 (default).
+  ///   Fraction of disk space used (0–1) above which LRU eviction is triggered.
+  ///   Set to `0` to disable caching entirely.
   /// </summary>
   /// <remarks>
   ///   When the cache usage reaches or exceeds this threshold, eviction policies may be applied to

--- a/Common/src/Storage/PartitionData.cs
+++ b/Common/src/Storage/PartitionData.cs
@@ -24,11 +24,11 @@ namespace ArmoniK.Core.Common.Storage;
 /// </summary>
 /// <param name="PartitionId">Unique name of the partition</param>
 /// <param name="ParentPartitionIds">List of parents up to the first partition</param>
-/// <param name="PodReserved">Number of reserved pods</param>
-/// <param name="PodMax">Max number of pods</param>
-/// <param name="PreemptionPercentage">Percentage of pods that can be preempted</param>
-/// <param name="Priority">Priority of the partition</param>
-/// <param name="PodConfiguration">Configuration for compute plane instances in this Partition</param>
+/// <param name="PodReserved">Number of pods permanently reserved for this partition</param>
+/// <param name="PodMax">Maximum number of pods that may be allocated to this partition</param>
+/// <param name="PreemptionPercentage">Percentage of this partition's pods that higher-priority work may preempt</param>
+/// <param name="Priority">Scheduling priority of the partition relative to others</param>
+/// <param name="PodConfiguration">Arbitrary key-value pairs passed as configuration to partition deployment tool</param>
 public record PartitionData(string            PartitionId,
                             IList<string>     ParentPartitionIds,
                             int               PodReserved,


### PR DESCRIPTION
# Motivation

ArmoniK lacked user-facing conceptual documentation for three foundational topics — partitions, initialization, and the agent cache. Without this reference material, operators and developers have to read the source code to understand how to configure and reason about these subsystems.

# Description

Adds three new concept guides under `.docs/content/1.concepts/`:

- **`9.partitions.md`**: explains what a partition is, its properties (identity, capacity, scheduling, pod configuration), how sessions and tasks are bound to partitions, a Mermaid task-routing flowchart, and partition administration (create, edit, delete via environment variables).
- **`10.initialization.md`**: explains the initialization phase, the four `InitServices` flags (`InitDatabase`, `InitObjectStorage`, `InitQueue`, `StopAfterInit`), what each flag does, and the recommended init-then-run deployment pattern.
- **`11.cache.md`**: documents the agent's file-based, two-level cache (`InternalCacheFolder` and `SharedCacheFolder`), the cache lifecycle during pre-processing and post-processing, why workers cannot access the internal cache directly, LRU eviction behaviour, all configuration options, and how to share the cache across multiple agents on the same node.

Also improves the XML doc comments on `PartitionData.cs` parameters to be more precise and consistent with the new partition guide.

# Testing

Documentation-only change (plus XML doc comment clarifications in `PartitionData.cs`). No behavioural changes; no new tests required.

# Impact

- No runtime behaviour changes.
- Adds three Markdown files to the docs tree that will be rendered by the documentation site.
- `PartitionData.cs` XML comments are clarified but the public API is unchanged.

# Additional Information

The cache document explicitly calls out that `SharedCacheFolder` must **not** be shared between agents (only `InternalCacheFolder` is safe to share), to prevent accidental misconfiguration.
