### PR TITLE
fix(pollster): make cache directory creation conditional and best-effort

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -194,7 +194,22 @@ public sealed class TaskHandler : IAsyncDisposable
     folder_ = Path.Combine(pollsterOptions.SharedCacheFolder,
                            token_);
     Directory.CreateDirectory(folder_);
-    Directory.CreateDirectory(cache_);
+
+    if (cacheEvictionThreshold_ > 0)
+    {
+      try
+      {
+        Directory.CreateDirectory(cache_);
+      }
+      catch (Exception ex)
+      {
+        // cache should be best effort, if it fails we continue without cache
+        logger_.LogWarning(ex,
+                           "Cache folder {Cache} was not created",
+                           cache_);
+      }
+    }
+
     delayBeforeAcquisition_  = pollsterOptions.TimeoutBeforeNextAcquisition + TimeSpan.FromSeconds(2);
     messageDuplicationDelay_ = pollsterOptions.MessageDuplicationDelay;
     processingCrashedDelay_  = pollsterOptions.ProcessingCrashedDelay;


### PR DESCRIPTION
# Motivation

When the cache eviction threshold is set to 0 (cache disabled), there is no need to create the cache directory. Additionally, cache directory creation could fail in some environments, causing task acquisition to crash unnecessarily when the cache is not critical to task execution.

# Description

- Skip cache directory creation entirely when `cacheEvictionThreshold_` is 0 (i.e. cache is disabled).
- When the threshold is > 0, wrap the directory creation in a try/catch: on failure, a warning is logged (including the cache path and exception) and task handling continues without the cache.

# Testing

No automated tests added; the change is a defensive guard around a directory creation call. Manual testing confirms that task handling proceeds normally when cache directory creation fails or is skipped.

# Impact

- No behavioural change when cache is enabled and directory creation succeeds.
- When cache is disabled (`cacheEvictionThreshold_ = 0`), avoids creating an unused directory.
- Prevents task acquisition crashes caused by transient or permission-related failures on cache directory creation.
- Failures are now surfaced as warnings in the logs rather than being silently ignored.
