### PR TITLE
docs: add more content on task statuses and options

### DIFF
--- a/.docs/content/1.concepts/2.tasks.md
+++ b/.docs/content/1.concepts/2.tasks.md
@@ -86,8 +86,36 @@ timeline
 ## TaskOptions
 
 TaskOptions define configurable behaviors and limits for individual tasks. They are supplied when creating or resubmitting a task and control how the runtime schedules, retries, and isolates task execution. Default task options are defined when a session is created and are applied to all tasks in that session. These defaults can be overridden by the task options provided when creating an individual task; task-level options take precedence for that task only.
-The complete list of Task Options can be consulted [here](https://armonikcore.readthedocs.io/en/latest/content/csharp/ArmoniK.Core.Base.DataStructures.TaskOptions.html#parameters). 
+This is a list of TaskOptions with their descriptions :
 
-### TaskOptions: Priority
+#### TaskOptions: Options
+The Options parameter allows for the transmission of custom-defined options from the client to the task. This flexibility enables various configurations tailored to the specific requirements of the task, accommodating specialized processing needs or adjusting runtime behaviors.
+
+#### TaskOptions: MaxDuration
+The MaxDuration parameter specifies the maximum duration allowed for the task to execute. This ensures that tasks do not run indefinitely and provides a mechanism to gracefully handle cases where tasks exceed their expected execution times. If the task runs longer than this duration, it may be forcibly terminated or marked as failed.
+
+#### TaskOptions: MaxRetries
+The MaxRetries parameter sets the number of retries allowed for the task in the event of failure. This feature helps ensure task reliability by allowing for automatic re-execution under certain conditions, thus reducing the impact of transient errors or failures.
+
+#### TaskOptions:  Priority
 
 As previously exposed, a task is in Pending state while its dependencies are unavailable. Once dependencies are ready the task is inserted into a high-performance queue to be acquired by a scheduling agent. The Priority is a numeric hint that affects the ordering the agent uses when picking (acquiring) tasks from that queue: higher-priority tasks are acquired before lower-priority ones.
+
+#### TaskOptions: PartitionId
+
+The PartitionId parameter indicates the partition in which the task is executed. 
+
+#### TaskOptions: ApplicationName
+The ApplicationName parameter transmits the name of the application as defined by the client. This metadata can be useful for tracking and reporting purposes, helping to identify which application initiated a given task.
+
+#### TaskOptions: ApplicationVersion
+The ApplicationVersion parameter indicates the version of the application that is associated with the task. This information can be vital for ensuring compatibility and debugging issues related to specific versions of the application.
+
+#### TaskOptions: ApplicationNamespace
+The ApplicationNamespace parameter represents the namespace of the application that is transmitted alongside the task. Utilizing namespaces aids in organizing code efficiently and can help avoid naming conflicts in larger systems.
+
+#### TaskOptions: ApplicationService
+The ApplicationService parameter denotes the service of the application from which the task originates. This field allows for differentiation between various services within a single application, providing clarity on where a task is spawned.
+
+#### TaskOptions: EngineType
+The EngineType parameter specifies the type of engine that is associated with the task, as defined by the client.

--- a/.docs/content/1.concepts/2.tasks.md
+++ b/.docs/content/1.concepts/2.tasks.md
@@ -106,16 +106,16 @@ As previously exposed, a task is in Pending state while its dependencies are una
 The PartitionId parameter indicates the partition in which the task is executed. 
 
 #### TaskOptions: ApplicationName
-The ApplicationName parameter transmits the name of the application as defined by the client. This metadata can be useful for tracking and reporting purposes, helping to identify which application initiated a given task.
+The ApplicationName parameter transmits the name of the application as defined by the client.
 
 #### TaskOptions: ApplicationVersion
-The ApplicationVersion parameter indicates the version of the application that is associated with the task. This information can be vital for ensuring compatibility and debugging issues related to specific versions of the application.
+The ApplicationVersion parameter indicates the version of the application that is associated with the task.
 
 #### TaskOptions: ApplicationNamespace
-The ApplicationNamespace parameter represents the namespace of the application that is transmitted alongside the task. Utilizing namespaces aids in organizing code efficiently and can help avoid naming conflicts in larger systems.
+The ApplicationNamespace parameter represents the namespace of the application that is transmitted alongside the task.
 
 #### TaskOptions: ApplicationService
-The ApplicationService parameter denotes the service of the application from which the task originates. This field allows for differentiation between various services within a single application, providing clarity on where a task is spawned.
+The ApplicationService parameter denotes the service of the application from which the task originates.
 
 #### TaskOptions: EngineType
 The EngineType parameter specifies the type of engine that is associated with the task, as defined by the client.

--- a/.docs/content/1.concepts/2.tasks.md
+++ b/.docs/content/1.concepts/2.tasks.md
@@ -29,6 +29,7 @@ graph TD
 - Task resubmission
   - copy of task metadata with new id
 
+
 ## Status state diagram
 
 ```mermaid
@@ -58,3 +59,35 @@ stateDiagram-v2
     Retried --> [*]
     Error --> [*]
 ```
+
+## Tasks timestamps and statuses
+
+```mermaid
+%%{init: {
+    "themeVariables": {
+        "fontSize": "30px"
+        }
+}}%%
+timeline
+    created_at: Created
+              : Pending
+    submitted_at: Submitted
+    received_at
+    acquired_at: Dispatched
+    fetched_at
+    started_at: Processing
+    processed_at
+    ended_at: Completed
+            : Error
+            : Timeout
+            : Retried
+```
+
+## TaskOptions
+
+TaskOptions define configurable behaviors and limits for individual tasks. They are supplied when creating or resubmitting a task and control how the runtime schedules, retries, and isolates task execution. Default task options are defined when a session is created and are applied to all tasks in that session. These defaults can be overridden by the task options provided when creating an individual task; task-level options take precedence for that task only.
+The complete list of Task Options can be consulted [here](https://armonikcore.readthedocs.io/en/latest/content/csharp/ArmoniK.Core.Base.DataStructures.TaskOptions.html#parameters). 
+
+### TaskOptions: Priority
+
+As previously exposed, a task is in Pending state while its dependencies are unavailable. Once dependencies are ready the task is inserted into a high-performance queue to be acquired by a scheduling agent. The Priority is a numeric hint that affects the ordering the agent uses when picking (acquiring) tasks from that queue: higher-priority tasks are acquired before lower-priority ones.

--- a/.docs/content/1.concepts/2.tasks.md
+++ b/.docs/content/1.concepts/2.tasks.md
@@ -99,7 +99,7 @@ The MaxRetries parameter sets the number of retries allowed for the task in the 
 
 #### TaskOptions:  Priority
 
-As previously exposed, a task is in Pending state while its dependencies are unavailable. Once dependencies are ready the task is inserted into a high-performance queue to be acquired by a scheduling agent. The Priority is a numeric hint that affects the ordering the agent uses when picking (acquiring) tasks from that queue: higher-priority tasks are acquired before lower-priority ones.
+As previously exposed, a task is in Pending state while its dependencies are unavailable. Once dependencies are ready the task is inserted into a high-performance queue to be acquired by a scheduling agent. The Priority is a numeric hint that affects the ordering the agent uses when picking (acquiring) tasks from that queue: higher-priority tasks are acquired before lower-priority ones. Each partition has its own dedicated high-performance queue(s), hence the task priority applies in a partition basis.
 
 #### TaskOptions: PartitionId
 

--- a/.docs/content/1.concepts/9.partitions.md
+++ b/.docs/content/1.concepts/9.partitions.md
@@ -17,14 +17,20 @@ Partitions serve two complementary purposes:
 
 ## Partition properties
 
+```{warning}
+
+In the following discussion, fields other 
+than **`PartitionId`** are not used in the current version of the code. They are only there as an indication. They do not have default
+values.
+
+```
+
 ### Identity
 
 Each partition is identified by a unique **`PartitionId`** string, which is what clients use when
 creating sessions and submitting tasks. A list of **`ParentPartitionIds`** records the chain of
 ancestor partitions from the direct parent up to the root; this is used to express partition
-hierarchies (e.g. a specialised partition that belongs to a broader resource pool). Fields other 
-than **`PartitionId`** are not used. They are only there as an indication. They do not have default
-values.
+hierarchies (e.g. a specialised partition that belongs to a broader resource pool).
 
 ### Capacity and scheduling
 


### PR DESCRIPTION
# Motivation

To improve user understanding of task statuses and options in ArmoniK, enhancing overall documentation clarity.

# Description

- Added more explanations of task statuses  with a diagram and about the task options.

- In the Partitions section, emphasized  with a warning that fields other than PartitionId are currently not used.

# Testing

# Impact

# Additional Information

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x]  Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
