### PR TITLE
fix(pollster): properly finalize task status to Cancelled on disposal

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -93,6 +93,7 @@ public sealed class TaskHandler : IAsyncDisposable
   private          Action?                               onDispose_;
   private          Output?                               output_;
   private          SessionData?                          sessionData_;
+  private          bool                                  taskCancelled_;
   private          TaskData?                             taskData_;
 
   /// <summary>
@@ -219,6 +220,13 @@ public sealed class TaskHandler : IAsyncDisposable
                                           ("taskId", messageHandler_.TaskId),
                                           ("messageHandler", messageHandler_.MessageId),
                                           ("sessionId", taskData_?.SessionId ?? ""));
+
+    if (taskData_ != null && (taskCancelled_ || taskData_.Status is TaskStatus.Cancelling))
+    {
+      taskData_ = await taskTable_.SetCancelledAsync(taskData_.TaskId,
+                                                     CancellationToken.None)
+                                  .ConfigureAwait(false) ?? taskData_;
+    }
 
     await ReleaseTaskHandler()
       .ConfigureAwait(false);
@@ -375,7 +383,7 @@ public sealed class TaskHandler : IAsyncDisposable
                                           ("messageHandler", messageHandler_.MessageId),
                                           ("sessionId", taskData_?.SessionId ?? ""));
 
-    if (taskData_?.Status is not null or TaskStatus.Cancelled or TaskStatus.Cancelling)
+    if (taskData_?.Status is not null)
     {
       taskData_ = await taskTable_.ReadTaskAsync(messageHandler_.TaskId,
                                                  CancellationToken.None)
@@ -383,7 +391,7 @@ public sealed class TaskHandler : IAsyncDisposable
       sessionData_ = await sessionTable_.GetSessionAsync(taskData_.SessionId,
                                                          CancellationToken.None)
                                         .ConfigureAwait(false);
-      if (taskData_.Status is TaskStatus.Cancelling || sessionData_.Status is SessionStatus.Cancelled)
+      if (taskData_.Status is TaskStatus.Cancelling or TaskStatus.Cancelled || sessionData_.Status is SessionStatus.Cancelled)
       {
         logger_.LogWarning("Task has been cancelled, trigger cancellation from exterior.");
         await earlyCts_.CancelAsync()
@@ -393,10 +401,8 @@ public sealed class TaskHandler : IAsyncDisposable
 
         // Upon cancellation, dispose the messageHandler to remove the message from the queue, and call onDispose
         // Calling the TaskHandler dispose is not possible here as the cancellationTokenSource is still in use
-        messageHandler_.Status = QueueMessageStatus.Cancelled;
-        await ReleaseTaskHandler()
-          .ConfigureAwait(false);
-
+        messageHandler_.Status = QueueMessageStatus.Processed;
+        taskCancelled_         = true;
         return true;
       }
     }
@@ -1300,7 +1306,7 @@ public sealed class TaskHandler : IAsyncDisposable
       throw new NullReferenceException(nameof(sessionData_) + " is null.");
     }
 
-    if (taskData.Status is TaskStatus.Cancelled or TaskStatus.Cancelling)
+    if (taskData.Status is TaskStatus.Cancelled or TaskStatus.Cancelling || taskCancelled_)
     {
       messageHandler_.Status = QueueMessageStatus.Processed;
     }

--- a/Common/src/Storage/TaskTableExtensions.cs
+++ b/Common/src/Storage/TaskTableExtensions.cs
@@ -163,6 +163,30 @@ public static class TaskTableExtensions
   }
 
   /// <summary>
+  ///   Marks the specified task as cancelled in the task table asynchronously, if it has not already reached a final
+  ///   status.
+  /// </summary>
+  /// <remarks>
+  ///   If the task has already reached a final status, its status will not be updated. The method sets
+  ///   the task's status to Cancelled and updates its end date to the current UTC time.
+  /// </remarks>
+  /// <param name="taskTable">The task table in which the task status will be updated. Cannot be null.</param>
+  /// <param name="taskId">The unique identifier of the task to mark as cancelled. Cannot be null or empty.</param>
+  /// <param name="cancellationToken">A cancellation token that can be used to cancel the asynchronous operation.</param>
+  /// <returns>A task that represents the asynchronous operation.</returns>
+  public static async Task<TaskData?> SetCancelledAsync(this ITaskTable   taskTable,
+                                                        string            taskId,
+                                                        CancellationToken cancellationToken = default)
+    => await taskTable.UpdateOneTask(taskId,
+                                     data => !FinalStatus.Contains(data.Status),
+                                     new UpdateDefinition<TaskData>().Set(tdm => tdm.Status,
+                                                                          TaskStatus.Cancelled)
+                                                                     .Set(tdm => tdm.EndDate,
+                                                                          DateTime.UtcNow),
+                                     cancellationToken: cancellationToken)
+                      .ConfigureAwait(false);
+
+  /// <summary>
   ///   Tag a collection of tasks as submitted
   /// </summary>
   /// <param name="taskTable">Interface to manage tasks lifecycle</param>

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -264,12 +264,12 @@ public class TestTaskHandlerProvider : IDisposable
 
   public void Dispose()
   {
-    ((IDisposable)app_)?.Dispose();
-    loggerFactory_?.Dispose();
-    runner_?.Dispose();
     TaskHandler.DisposeAsync()
                .AsTask()
                .Wait();
+    ((IDisposable)app_)?.Dispose();
+    runner_?.Dispose();
+    loggerFactory_?.Dispose();
     GC.SuppressFinalize(this);
   }
 

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -2556,7 +2556,14 @@ public class TaskHandlerTest
                 Is.EqualTo(TaskStatus.Cancelling));
 
     Assert.That(sqmh.Status,
-                Is.EqualTo(QueueMessageStatus.Cancelled));
+                Is.EqualTo(QueueMessageStatus.Processed));
+
+    await testServiceProvider.TaskHandler.DisposeAsync()
+                             .ConfigureAwait(false);
+
+    Assert.That(await testServiceProvider.TaskTable.GetTaskStatus(taskId)
+                                         .ConfigureAwait(false),
+                Is.EqualTo(TaskStatus.Cancelled));
   }
 
   [Test]


### PR DESCRIPTION
# Motivation

When a task is detected as cancelling (or already cancelled) during explicit cancellation checks, the previous implementation marked the queue message as `Cancelled` and was calling `ReleaseTaskHandler`. `ReleaseTaskHandler` is also called in `DisposeAsync`, calling it twice and setting the task status to `Submitted`. Additionally, the task status in the database was never transitioned from `Cancelling` to `Cancelled`, leaving tasks stuck in an intermediate state.

# Description

- Remove the call to `ReleaseTaskHandler` from `StopCancelledTask`.
- Introduces a `taskCancelled_` flag in `TaskHandler` to track external cancellation detected during pre-execution checks.
- Changes the queue message status from `QueueMessageStatus.Cancelled` to `QueueMessageStatus.Processed` when early cancellation is detected, it changes nothing as both are treated the same in the Adaptors.
- Defers the `SetCancelledAsync` call to `DisposeAsync` so the task status is correctly transitioned to `Cancelled` in the task table after all cleanup is complete.
- Adds `TaskStatus.Cancelled` to the early-exit condition (previously only `Cancelling` was checked), so already-cancelled tasks are also handled correctly.
- Fixes the pre-check condition `taskData_?.Status is not null or TaskStatus.Cancelled or TaskStatus.Cancelling` (which was always true due to operator precedence) to the correct `taskData_?.Status is not null`.
- Adds `SetCancelledAsync` extension method in `TaskTableExtensions` that atomically sets a task to `Cancelled` with an end date, guarding against overwriting already-final statuses.
- Fixes disposal order in `TestTaskHandlerProvider` to dispose `TaskHandler` before the app and runner, preventing use-after-free during teardown.

# Testing

- Updated the existing cancellation test to assert that the queue message status is `Processed` (not `Cancelled`) after early cancellation detection.
- Extended the test to call `DisposeAsync` and verify the task status is ultimately `Cancelled` in the task table.

# Impact

Tasks that are cancelled externally (via `Cancelling` status or session cancellation) will now reliably reach the `Cancelled` terminal state rather than remaining stuck in `Cancelling`. Queue messages for such tasks will no longer be re-queued, avoiding redundant processing attempts. No configuration or API changes.

# Additional Information

The bug with `is not null or TaskStatus.Cancelled or TaskStatus.Cancelling` is a C# pattern matching pitfall: `not null or X` means `(not null) or X`, which is always true for non-null values. The fix simplifies it to `is not null`.
