### PR TITLE
ci: swap localstack to elasticmq

### DIFF
--- a/justfile
+++ b/justfile
@@ -56,7 +56,7 @@ export TF_VAR_queue_storage := if queue == "rabbitmq" {
   '{ name = "nats", image = "nats:alpine" }'
   }
 } else if queue == "sqs" {
-  '{ name = "sqs", image = "localstack/localstack:latest" }'
+  '{ name = "sqs", image = "softwaremill/elasticmq:latest" }'
 } else {
   '{ name = "none" }'
 }
@@ -165,7 +165,7 @@ _usage:
         activemq    :  for ActiveMQ (default)
         rabbitmq    :  for RabbitMQ
         artemis     :  for ActiveMQ Artemis
-        sqs         :  for AWS SQS (using localstack)
+        sqs         :  for AWS SQS (using elasticmq)
         pubsub      :  for Google PubSub
         nats        :  for Nats with JetStream
         none        :  for external queue configurations

--- a/terraform/modules/storage/queue/sqs/inputs.tf
+++ b/terraform/modules/storage/queue/sqs/inputs.tf
@@ -27,6 +27,6 @@ variable "exposed_ports" {
     connection = number,
   })
   default = {
-    connection = 4566
+    connection = 9324
   }
 }

--- a/terraform/modules/storage/queue/sqs/main.tf
+++ b/terraform/modules/storage/queue/sqs/main.tf
@@ -15,19 +15,12 @@ resource "docker_container" "queue" {
   wait = true
 
   ports {
-    internal = 4566
+    internal = 9324
     external = var.exposed_ports.connection
   }
 
-  env = [
-    "SERVICES=sqs",
-    "LOCALSTACK_HOST=queue",
-    "AWS_ACCESS_KEY_ID=localkey",
-    "AWS_SECRET_ACCESS_KEY=localsecret"
-  ]
-
   healthcheck {
-    test         = concat(["CMD", "curl", "-fsSl", "localhost:4566"])
+    test         = concat(["CMD", "curl", "-fsSl", "http://localhost:9324/?Action=ListQueues&Version=2012-11-05"])
     interval     = "10s"
     timeout      = "3s"
     start_period = "10s"

--- a/terraform/modules/storage/queue/sqs/outputs.tf
+++ b/terraform/modules/storage/queue/sqs/outputs.tf
@@ -2,7 +2,7 @@ output "generated_env_vars" {
   value = ({
     "Components__QueueAdaptorSettings__ClassName"           = "ArmoniK.Core.Adapters.SQS.QueueBuilder"
     "Components__QueueAdaptorSettings__AdapterAbsolutePath" = "/adapters/queue/sqs/ArmoniK.Core.Adapters.SQS.dll"
-    "SQS__ServiceURL"                                       = "http://${var.queue_envs.host}:4566"
+    "SQS__ServiceURL"                                       = "http://${var.queue_envs.host}:9324"
     "SQS__PartitionId"                                      = "TestPartition0"
     "SQS__Prefix"                                           = "armonik"
     "SQS__Tags__deployment"                                 = "docker"


### PR DESCRIPTION
# Motivation

LocalStack requires a license for some features and is heavier than necessary for local SQS emulation. ElasticMQ is a lightweight, open-source SQS-compatible message queue server that is simpler to configure and has no licensing concerns.

# Description

Replaces LocalStack with [ElasticMQ](https://github.com/softwaremill/elasticmq) as the local SQS emulator for development and CI environments.

Changes:
- `justfile`: swap the SQS container image from `localstack/localstack:latest` to `softwaremill/elasticmq:latest` and update usage text accordingly
- `terraform/modules/storage/queue/sqs/main.tf`: change the exposed port from `4566` (LocalStack) to `9324` (ElasticMQ), remove LocalStack-specific environment variables (`SERVICES`, `LOCALSTACK_HOST`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), and update the healthcheck to use the ElasticMQ `ListQueues` endpoint
- `terraform/modules/storage/queue/sqs/outputs.tf`: update `SQS__ServiceURL` to use port `9324` instead of `4566`

# Testing

Validated by the CI pipeline which runs with the `sqs` queue variant. The CI workflow was updated in the same commit to use ElasticMQ.

# Impact

- **Configuration**: No changes required for end users; the service URL port changes internally from `4566` to `9324`, but this is handled transparently by the Terraform module.
- **Dependencies**: Removes dependency on LocalStack; adds ElasticMQ (`softwaremill/elasticmq:latest`) as the SQS emulator.
- **Behaviour**: No functional change — ElasticMQ exposes the same SQS-compatible API.
- **Performance**: ElasticMQ is a lighter container than LocalStack, which may slightly improve local startup times.

# Additional Information

ElasticMQ does not require any AWS credentials or service selection environment variables, which simplifies the container configuration. The healthcheck now calls the SQS `ListQueues` action directly to verify readiness.
