### PR TITLE
refactor: make AMQP adaptor compatible with latest RabbitMQ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
 
     - name: Run tests
       run: |
-        sed -i "s/queue/localhost/" terraform/generated/queue_env.sh
+        sed -i "s/=queue/=localhost/;s%http://queue%http://localhost%" terraform/generated/queue_env.sh
         sed -i 's|/rabbitmq/certs/|../../../../../../terraform/generated/queue/certs/|g' terraform/generated/queue_env.sh
         source ./terraform/generated/queue_env.sh 
         MONITOR_PREFIX="monitor/test/" MONITOR_CD="Base/tests/Queue/" tools/monitor.sh \

--- a/Adaptors/Amqp/src/PullQueueStorage.cs
+++ b/Adaptors/Amqp/src/PullQueueStorage.cs
@@ -44,6 +44,7 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
 
   private readonly ConcurrentDictionary<string, AsyncLazy<IReceiverLink>[]> receivers_;
   private readonly ConcurrentDictionary<string, AsyncLazy<ISenderLink>[]>   senders_;
+  private readonly string                                                   separator_;
 
   public PullQueueStorage(QueueCommon.Amqp          options,
                           IConnectionAmqp           connectionAmqp,
@@ -55,6 +56,7 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
     receivers_ = new ConcurrentDictionary<string, AsyncLazy<IReceiverLink>[]>();
     senders_   = new ConcurrentDictionary<string, AsyncLazy<ISenderLink>[]>();
     prefix_    = options.Prefix;
+    separator_ = options.Separator;
   }
 
   public override Task<HealthCheckResult> Check(HealthCheckTag tag)
@@ -96,8 +98,8 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
                                                         .Select(i => new AsyncLazy<ISenderLink>(async () => new SenderLink(new Session(await ConnectionAmqp
                                                                                                                                              .GetConnectionAsync()
                                                                                                                                              .ConfigureAwait(false)),
-                                                                                                                           $"{prefix_}{partitionId}SenderLink{i}",
-                                                                                                                           $"{prefix_}{partitionId}q{i}")))
+                                                                                                                           $"{prefix_}{partitionId}{separator_}SenderLink{i}",
+                                                                                                                           $"{prefix_}{partitionId}{separator_}q{i}")))
                                                         .ToArray());
     while (nbPulledMessage < nbMessages)
     {
@@ -176,8 +178,8 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
            {
              var rl = new ReceiverLink(new Session(await connection.GetConnectionAsync()
                                                                    .ConfigureAwait(false)),
-                                       $"{prefix_}{partitionId}ReceiverLink{link}",
-                                       $"{prefix_}{partitionId}q{link}");
+                                       $"{prefix_}{partitionId}{separator_}ReceiverLink{link}",
+                                       $"{prefix_}{partitionId}{separator_}q{link}");
 
              /* linkCredit_: the maximum number of messages the
               * remote peer can send to the receiver.

--- a/Adaptors/Amqp/src/PullQueueStorage.cs
+++ b/Adaptors/Amqp/src/PullQueueStorage.cs
@@ -39,6 +39,7 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
 {
   private readonly TimeSpan                  baseDelay_ = TimeSpan.FromMilliseconds(100);
   private readonly ILogger<PullQueueStorage> logger_;
+  private readonly string                    prefix_;
 
 
   private readonly ConcurrentDictionary<string, AsyncLazy<IReceiverLink>[]> receivers_;
@@ -53,6 +54,7 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
     logger_    = logger;
     receivers_ = new ConcurrentDictionary<string, AsyncLazy<IReceiverLink>[]>();
     senders_   = new ConcurrentDictionary<string, AsyncLazy<ISenderLink>[]>();
+    prefix_    = options.Prefix;
   }
 
   public override Task<HealthCheckResult> Check(HealthCheckTag tag)
@@ -94,8 +96,8 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
                                                         .Select(i => new AsyncLazy<ISenderLink>(async () => new SenderLink(new Session(await ConnectionAmqp
                                                                                                                                              .GetConnectionAsync()
                                                                                                                                              .ConfigureAwait(false)),
-                                                                                                                           $"{partitionId}###SenderLink{i}",
-                                                                                                                           $"{partitionId}###q{i}")))
+                                                                                                                           $"{prefix_}{partitionId}SenderLink{i}",
+                                                                                                                           $"{prefix_}{partitionId}q{i}")))
                                                         .ToArray());
     while (nbPulledMessage < nbMessages)
     {
@@ -174,8 +176,8 @@ public class PullQueueStorage : QueueStorage, IPullQueueStorage
            {
              var rl = new ReceiverLink(new Session(await connection.GetConnectionAsync()
                                                                    .ConfigureAwait(false)),
-                                       $"{partitionId}###ReceiverLink{link}",
-                                       $"{partitionId}###q{link}");
+                                       $"{prefix_}{partitionId}ReceiverLink{link}",
+                                       $"{prefix_}{partitionId}q{link}");
 
              /* linkCredit_: the maximum number of messages the
               * remote peer can send to the receiver.

--- a/Adaptors/Amqp/src/PushQueueStorage.cs
+++ b/Adaptors/Amqp/src/PushQueueStorage.cs
@@ -43,6 +43,7 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
   private readonly int                                                  parallelismLimit_;
   private readonly string                                               prefix_;
   private readonly ConcurrentDictionary<string, ObjectPool<SenderLink>> senders_ = new();
+  private readonly string                                               separator_;
 
   public PushQueueStorage(QueueCommon.Amqp          options,
                           IConnectionAmqp           connectionAmqp,
@@ -53,6 +54,7 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
     parallelismLimit_ = options.ParallelismLimit;
     logger_           = logger;
     prefix_           = options.Prefix;
+    separator_        = options.Separator;
   }
 
   /// <inheritdoc />
@@ -88,10 +90,11 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
     var whichQueue       = (priority - 1) / MaxInternalQueuePriority;
     var internalPriority = (priority - 1) % MaxInternalQueuePriority;
 
-    logger_.LogDebug("Priority is {priority} ; will use queue {prefix_}{partitionId}q{whichQueue} with internal priority {internalPriority}",
+    logger_.LogDebug("Priority is {priority} ; will use queue {prefix_}{partitionId}{separator_}q{whichQueue} with internal priority {internalPriority}",
                      priority,
                      prefix_,
                      partitionId,
+                     separator_,
                      whichQueue,
                      internalPriority);
 
@@ -104,7 +107,7 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
                                      {
                                        try
                                        {
-                                         var pool = GetPool($"{prefix_}{partitionId}q{whichQueue}");
+                                         var pool = GetPool($"{prefix_}{partitionId}{separator_}q{whichQueue}");
 
                                          await pool.WithInstanceAsync(sender => sender.SendAsync(new Message(Encoding.UTF8.GetBytes(msgData.TaskId))
                                                                                                  {

--- a/Adaptors/Amqp/src/PushQueueStorage.cs
+++ b/Adaptors/Amqp/src/PushQueueStorage.cs
@@ -41,6 +41,7 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
   private readonly TimeSpan                                             baseDelay_               = TimeSpan.FromMilliseconds(100);
   private readonly ILogger<PushQueueStorage>                            logger_;
   private readonly int                                                  parallelismLimit_;
+  private readonly string                                               prefix_;
   private readonly ConcurrentDictionary<string, ObjectPool<SenderLink>> senders_ = new();
 
   public PushQueueStorage(QueueCommon.Amqp          options,
@@ -51,6 +52,7 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
   {
     parallelismLimit_ = options.ParallelismLimit;
     logger_           = logger;
+    prefix_           = options.Prefix;
   }
 
   /// <inheritdoc />
@@ -86,8 +88,9 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
     var whichQueue       = (priority - 1) / MaxInternalQueuePriority;
     var internalPriority = (priority - 1) % MaxInternalQueuePriority;
 
-    logger_.LogDebug("Priority is {priority} ; will use queue {partitionId}###q{whichQueue} with internal priority {internalPriority}",
+    logger_.LogDebug("Priority is {priority} ; will use queue {prefix_}{partitionId}q{whichQueue} with internal priority {internalPriority}",
                      priority,
+                     prefix_,
                      partitionId,
                      whichQueue,
                      internalPriority);
@@ -101,7 +104,7 @@ public class PushQueueStorage : QueueStorage, IPushQueueStorage
                                      {
                                        try
                                        {
-                                         var pool = GetPool($"{partitionId}###q{whichQueue}");
+                                         var pool = GetPool($"{prefix_}{partitionId}q{whichQueue}");
 
                                          await pool.WithInstanceAsync(sender => sender.SendAsync(new Message(Encoding.UTF8.GetBytes(msgData.TaskId))
                                                                                                  {

--- a/Adaptors/QueueCommon/src/Amqp.cs
+++ b/Adaptors/QueueCommon/src/Amqp.cs
@@ -105,4 +105,9 @@ public class Amqp
   ///   Path prefix for the AMQP resources.
   /// </summary>
   public string Prefix { get; set; } = "";
+
+  /// <summary>
+  ///   Separator inserted between the partition ID and the queue/link index in AMQP resource names.
+  /// </summary>
+  public string Separator { get; set; } = "###";
 }

--- a/Adaptors/QueueCommon/src/Amqp.cs
+++ b/Adaptors/QueueCommon/src/Amqp.cs
@@ -100,4 +100,9 @@ public class Amqp
   ///   Whether to allow insecure TLS connections.
   /// </summary>
   public bool AllowInsecureTls { get; set; }
+
+  /// <summary>
+  ///   Path prefix for the AMQP resources.
+  /// </summary>
+  public string Prefix { get; set; } = "";
 }

--- a/Base/tests/Queue/QueueStorageTests.cs
+++ b/Base/tests/Queue/QueueStorageTests.cs
@@ -188,7 +188,7 @@ public class QueueStorageTests
                                           TimeSpan.FromHours(2),
                                           2,
                                           1,
-                                          "testPartition",
+                                          "TestPartition0",
                                           "testApplication",
                                           "testVersion",
                                           "testNamespace",
@@ -214,7 +214,7 @@ public class QueueStorageTests
                        };
 
     await PushQueueStorage.PushMessagesAsync(testMessages,
-                                             "testPartition",
+                                             "TestPartition0",
                                              CancellationToken.None)
                           .ConfigureAwait(false);
   }
@@ -236,7 +236,7 @@ public class QueueStorageTests
                                           TimeSpan.FromHours(2),
                                           2,
                                           1,
-                                          "testPartition",
+                                          "TestPartition0",
                                           "testApplication",
                                           "testVersion",
                                           "testNamespace",
@@ -262,13 +262,13 @@ public class QueueStorageTests
                        };
     /* Push 5 messages to the queue to test the pull */
     await PushQueueStorage.PushMessagesAsync(testMessages,
-                                             "testPartition",
+                                             "TestPartition0",
                                              CancellationToken.None)
                           .ConfigureAwait(false);
 
     /* Pull 3 messages from the queue, their default status being pending means that
      they should be pushed again to the queue */
-    var messages = PullQueueStorage.PullMessagesAsync("testPartition",
+    var messages = PullQueueStorage.PullMessagesAsync("TestPartition0",
                                                       3,
                                                       CancellationToken.None);
 
@@ -284,7 +284,7 @@ public class QueueStorageTests
     /* Pull 2 messages from the queue and change their status to processing; this means that
      these two should be treated as dequeued  by the broker and the remaining three
      as Pending if the test passes */
-    var messages2 = PullQueueStorage.PullMessagesAsync("testPartition",
+    var messages2 = PullQueueStorage.PullMessagesAsync("TestPartition0",
                                                        2,
                                                        CancellationToken.None);
 
@@ -317,7 +317,7 @@ public class QueueStorageTests
                                           TimeSpan.FromHours(2),
                                           2,
                                           1,
-                                          "testPartition",
+                                          "TestPartition0",
                                           "testApplication",
                                           "testVersion",
                                           "testNamespace",
@@ -342,11 +342,11 @@ public class QueueStorageTests
                              testTaskOptions),
                        };
     await PushQueueStorage.PushMessagesAsync(testMessages,
-                                             "testPartition",
+                                             "TestPartition0",
                                              CancellationToken.None)
                           .ConfigureAwait(false);
 
-    var messages = PullQueueStorage.PullMessagesAsync("testPartition",
+    var messages = PullQueueStorage.PullMessagesAsync("TestPartition0",
                                                       5,
                                                       CancellationToken.None);
 

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,6 +1,7 @@
 locals {
   partitions = toset([for s in range(var.num_partitions) : tostring(s)])
   replicas   = toset([for s in range(var.num_replicas) : tostring(s)])
+  queue_list = [for i in sort(tolist(local.partitions)) : "${var.partition_data.PartitionId}${i}"]
   logging_env_vars = { "Serilog__MinimumLevel" = "${var.serilog.loggin_level}",
     "Serilog__MinimumLevel__Override__Microsoft.AspNetCore.Hosting.Diagnostics"              = "${var.serilog.loggin_level_routing}",
     "Serilog__MinimumLevel__Override__Microsoft.AspNetCore.Routing"                          = "${var.serilog.loggin_level_routing}",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,6 +74,7 @@ module "queue_rabbitmq" {
   source     = "./modules/storage/queue/rabbitmq"
   count      = var.queue_storage.name == "rabbitmq" ? 1 : 0
   queue_envs = var.queue_env_vars
+  queue_list = local.queue_list
   image      = var.queue_storage.image
   network    = local.network
   windows    = var.windows
@@ -83,6 +84,7 @@ module "queue_activemq" {
   source     = "./modules/storage/queue/activemq"
   count      = var.queue_storage.name == "activemq" ? 1 : 0
   queue_envs = var.queue_env_vars
+  queue_list = local.queue_list
   image      = var.queue_storage.image
   network    = local.network
 }
@@ -91,6 +93,7 @@ module "queue_artemis" {
   source     = "./modules/storage/queue/artemis"
   count      = var.queue_storage.name == "artemis" ? 1 : 0
   queue_envs = var.queue_env_vars
+  queue_list = local.queue_list
   image      = var.queue_storage.image
   network    = local.network
 }
@@ -99,6 +102,7 @@ module "queue_pubsub" {
   source     = "./modules/storage/queue/pubsub"
   count      = var.queue_storage.name == "pubsub" ? 1 : 0
   queue_envs = var.queue_env_vars
+  queue_list = local.queue_list
   image      = var.queue_storage.image
   network    = local.network
 }
@@ -107,6 +111,7 @@ module "queue_nats" {
   source     = "./modules/storage/queue/nats"
   count      = var.queue_storage.name == "nats" ? 1 : 0
   queue_envs = var.queue_env_vars
+  queue_list = local.queue_list
   image      = var.queue_storage.image
   network    = local.network
   windows    = var.windows
@@ -116,6 +121,7 @@ module "queue_sqs" {
   source     = "./modules/storage/queue/sqs"
   count      = var.queue_storage.name == "sqs" ? 1 : 0
   queue_envs = var.queue_env_vars
+  queue_list = local.queue_list
   image      = var.queue_storage.image
   network    = local.network
 }

--- a/terraform/modules/storage/queue/activemq/inputs.tf
+++ b/terraform/modules/storage/queue/activemq/inputs.tf
@@ -18,8 +18,11 @@ variable "queue_envs" {
     max_priority = number,
     max_retries  = number,
     link_credit  = number,
-    partition    = string
   })
+}
+
+variable "queue_list" {
+  type = list(string)
 }
 
 variable "exposed_ports" {

--- a/terraform/modules/storage/queue/artemis/inputs.tf
+++ b/terraform/modules/storage/queue/artemis/inputs.tf
@@ -18,8 +18,11 @@ variable "queue_envs" {
     max_priority = number,
     max_retries  = number,
     link_credit  = number,
-    partition    = string
   })
+}
+
+variable "queue_list" {
+  type = list(string)
 }
 
 variable "exposed_ports" {

--- a/terraform/modules/storage/queue/nats/inputs.tf
+++ b/terraform/modules/storage/queue/nats/inputs.tf
@@ -18,8 +18,11 @@ variable "queue_envs" {
     max_priority = number,
     max_retries  = number,
     link_credit  = number,
-    partition    = string
   })
+}
+
+variable "queue_list" {
+  type = list(string)
 }
 
 variable "exposed_ports" {

--- a/terraform/modules/storage/queue/pubsub/inputs.tf
+++ b/terraform/modules/storage/queue/pubsub/inputs.tf
@@ -18,8 +18,11 @@ variable "queue_envs" {
     max_priority = number,
     max_retries  = number,
     link_credit  = number,
-    partition    = string
   })
+}
+
+variable "queue_list" {
+  type = list(string)
 }
 
 variable "exposed_ports" {

--- a/terraform/modules/storage/queue/rabbitmq/inputs.tf
+++ b/terraform/modules/storage/queue/rabbitmq/inputs.tf
@@ -19,8 +19,11 @@ variable "queue_envs" {
     max_priority = number,
     max_retries  = number,
     link_credit  = number,
-    partition    = string
   })
+}
+
+variable "queue_list" {
+  type = list(string)
 }
 
 variable "exposed_ports" {

--- a/terraform/modules/storage/queue/rabbitmq/locals.tf
+++ b/terraform/modules/storage/queue/rabbitmq/locals.tf
@@ -1,0 +1,66 @@
+locals {
+  # Mirrors the C# constant MaxInternalQueuePriority = 10 in PushQueueStorage
+  max_internal_queue_priority = 10
+
+  # Number of physical RabbitMQ queues per partition (one per priority band)
+  nb_links = floor((var.queue_envs.max_priority - 1) / local.max_internal_queue_priority) + 1
+
+  # Exchange name is the common prefix of partition names (e.g. "TestPartition0" → "TestPartition")
+  exchange_name = replace(var.queue_list[0], "/\\d+$/", "")
+
+  # Flat list of every (partition, priority-band) pair
+  queue_items = flatten([
+    for idx, partition in var.queue_list : [
+      for j in range(local.nb_links) : {
+        partition = partition
+        idx       = idx
+        level     = j
+      }
+    ]
+  ])
+
+  definitions = {
+    rabbit_version = "4.0.0"
+    users = [{
+      name              = "guest"
+      password_hash     = data.external.rabbit_guest_password_hash.result.hash
+      hashing_algorithm = "rabbit_password_hashing_sha256"
+      tags              = ["administrator"]
+    }]
+    vhosts = [{ name = "/" }]
+    permissions = [{
+      user      = "guest"
+      vhost     = "/"
+      configure = ".*"
+      write     = ".*"
+      read      = ".*"
+    }]
+    queues = [for item in local.queue_items : {
+      name        = "${item.partition}q${item.level}"
+      vhost       = "/"
+      durable     = true
+      auto_delete = false
+      arguments   = {}
+    }]
+    exchanges = [{
+      name        = local.exchange_name
+      vhost       = "/"
+      type        = "direct"
+      durable     = true
+      auto_delete = false
+      arguments   = {}
+    }]
+    bindings = [for item in local.queue_items : {
+      source           = local.exchange_name
+      vhost            = "/"
+      destination      = "${item.partition}q${item.level}"
+      destination_type = "queue"
+      routing_key      = tostring(item.idx * local.nb_links + item.level)
+      arguments        = {}
+    }]
+    policies   = []
+    parameters = []
+  }
+
+  definitions_json = jsonencode(local.definitions)
+}

--- a/terraform/modules/storage/queue/rabbitmq/main.tf
+++ b/terraform/modules/storage/queue/rabbitmq/main.tf
@@ -38,6 +38,11 @@ resource "docker_container" "queue" {
     content = "[rabbitmq_management ,rabbitmq_management_agent]."
   }
 
+  upload {
+    file    = "/etc/rabbitmq/definitions.json"
+    content = local.definitions_json
+  }
+
   dynamic "upload" {
     for_each = var.windows ? [] : [
       {

--- a/terraform/modules/storage/queue/rabbitmq/outputs.tf
+++ b/terraform/modules/storage/queue/rabbitmq/outputs.tf
@@ -18,6 +18,7 @@ output "generated_env_vars" {
     "Amqp__EndpointUrl"                                     = "queue:${var.windows ? 5672 : 5671}"
     "Amqp__AllowInsecureTls"                                = !var.windows ? true : false
     "Amqp__Prefix"                                          = "/queues/"
+    "Amqp__Separator"                                       = ""
   })
 }
 

--- a/terraform/modules/storage/queue/rabbitmq/outputs.tf
+++ b/terraform/modules/storage/queue/rabbitmq/outputs.tf
@@ -17,6 +17,7 @@ output "generated_env_vars" {
     "Amqp__LinkCredit"                                      = "${var.queue_envs.link_credit}"
     "Amqp__EndpointUrl"                                     = "queue:${var.windows ? 5672 : 5671}"
     "Amqp__AllowInsecureTls"                                = !var.windows ? true : false
+    "Amqp__Prefix"                                          = "/queues/"
   })
 }
 

--- a/terraform/modules/storage/queue/rabbitmq/passwords.tf
+++ b/terraform/modules/storage/queue/rabbitmq/passwords.tf
@@ -1,0 +1,15 @@
+resource "random_id" "rabbit_password_salt" {
+  byte_length = 4
+}
+
+# RabbitMQ SHA256 hash: base64(salt + SHA256(salt + password))
+data "external" "rabbit_guest_password_hash" {
+  program = [
+    "python3", "-c",
+    "import hashlib,base64,json,sys;d=json.load(sys.stdin);s=bytes.fromhex(d['s']);p=d['p'].encode();print(json.dumps({'hash':base64.b64encode(s+hashlib.sha256(s+p).digest()).decode()}))"
+  ]
+  query = {
+    s = random_id.rabbit_password_salt.hex
+    p = "guest"
+  }
+}

--- a/terraform/modules/storage/queue/rabbitmq/versions.tf
+++ b/terraform/modules/storage/queue/rabbitmq/versions.tf
@@ -4,5 +4,13 @@ terraform {
       source  = "registry.opentofu.org/kreuzwerker/docker"
       version = ">= 3.9.0"
     }
+    random = {
+      source  = "registry.opentofu.org/hashicorp/random"
+      version = ">= 3.0"
+    }
+    external = {
+      source  = "registry.opentofu.org/hashicorp/external"
+      version = ">= 2.0"
+    }
   }
 }

--- a/terraform/modules/storage/queue/sqs/inputs.tf
+++ b/terraform/modules/storage/queue/sqs/inputs.tf
@@ -18,8 +18,11 @@ variable "queue_envs" {
     max_priority = number,
     max_retries  = number,
     link_credit  = number,
-    partition    = string
   })
+}
+
+variable "queue_list" {
+  type = list(string)
 }
 
 variable "exposed_ports" {

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -4,6 +4,14 @@ terraform {
       source  = "registry.opentofu.org/kreuzwerker/docker"
       version = "~> 3.9.0"
     }
+    random = {
+      source  = "registry.opentofu.org/hashicorp/random"
+      version = "~> 3.0"
+    }
+    external = {
+      source  = "registry.opentofu.org/hashicorp/external"
+      version = "~> 2.0"
+    }
   }
 }
 

--- a/terraform/rabbitmq/rabbitmq.conf
+++ b/terraform/rabbitmq/rabbitmq.conf
@@ -33,3 +33,6 @@ management.ssl.certfile = /rabbitmq/certs/rabbit.crt
 management.ssl.keyfile = /rabbitmq/certs/rabbit.key
 management.ssl.verify = verify_none
 management.ssl.fail_if_no_peer_cert = false
+
+definitions.import_backend = local_filesystem
+definitions.local.path = /etc/rabbitmq/definitions.json

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -89,7 +89,6 @@ variable "queue_env_vars" {
     max_priority = optional(number, 10)
     max_retries  = optional(number, 10)
     link_credit  = optional(number, 2)
-    partition    = optional(string, "TestPartition")
   })
   description = "Environment variables for the queue"
   default     = {}


### PR DESCRIPTION
# Motivation

RabbitMQ 4.x requires AMQP 1.0 queue addresses to be prefixed with `/queues/` and queues to be pre-declared before use. The previous code used a hardcoded `###` separator in queue and link names, which is not valid AMQP 1.0 addressing and broke with the latest RabbitMQ image.

# Description

**AMQP adapter (`Adaptors/Amqp`, `Adaptors/QueueCommon`)**
- Add a `Prefix` property to `Amqp` options (defaults to `""`): prepended to all queue addresses and link names.
- Add a `Separator` property to `Amqp` options (defaults to `"###"`): inserted between the partition ID and the queue/link index in AMQP resource names, replacing the previously hardcoded `###`.
- Use `prefix_` and `separator_` in `PullQueueStorage` and `PushQueueStorage` when building queue addresses and link names.

**Terraform — queue modules**
- Replace the single `partition` string field in `queue_envs` with a dedicated `queue_list` variable (`list(string)`) in every queue module (activemq, artemis, nats, pubsub, rabbitmq, sqs, none).
- Derive `queue_list` in the root locals from the partition configuration and pass it to every queue module call.

**Terraform — RabbitMQ module**
- Generate a `definitions.json` from `queue_list` at plan time: queues (`{partition}q{priority_band}`), a direct exchange, bindings, vhosts, permissions, and a properly SHA-256-hashed guest credential (salt generated once via `random_id`, hash computed via `data "external"` + Python 3).
- Upload `definitions.json` into the container and configure `rabbitmq.conf` to import it at startup (`definitions.import_backend = local_filesystem`).
- Add `Amqp__Prefix = /queues/` to the generated environment variables.
- Add `hashicorp/random` and `hashicorp/external` provider requirements.

# Testing

Validated by running the full terraform deployment (`up` / `destroy`) locally against RabbitMQ 4. The adaptor successfully pushes and pulls messages across all configured partitions.

# Impact

- **Breaking for existing state**: queue and link names change (the hardcoded `###` separator is now configurable and the prefix is added). A `terraform destroy` + re-apply is required for existing environments.
- **New providers**: `hashicorp/random` and `hashicorp/external` are required — run `terraform init -upgrade` after pulling this change.
- **Python 3 required** on the machine running terraform (used to compute the RabbitMQ password hash).
- No impact on non-RabbitMQ queue backends (activemq, artemis, nats, pubsub, sqs, none) beyond the `queue_list` input being added. The default `Separator = "###"` preserves the previous naming scheme for those backends.

# Additional Information

The number of physical RabbitMQ queues per partition scales automatically with `max_priority`: `nb_links = floor((max_priority - 1) / 10) + 1`. With the default `max_priority = 10`, each partition gets one queue (`q0`).