### PR TITLE
chore(deps): update OpenTelemetry NuGet packages

### DIFF
--- a/Compute/PollingAgent/src/ArmoniK.Core.Compute.PollingAgent.csproj
+++ b/Compute/PollingAgent/src/ArmoniK.Core.Compute.PollingAgent.csproj
@@ -31,9 +31,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MongoDB.Driver.Core.Extensions.OpenTelemetry" Version="1.0.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Control/Submitter/src/ArmoniK.Core.Control.Submitter.csproj
+++ b/Control/Submitter/src/ArmoniK.Core.Control.Submitter.csproj
@@ -32,9 +32,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Grpc.AspNetCore.Web" Version="2.76.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.0-beta.1" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Exporter.Prometheus.AspNetCore" Version="1.15.3-beta.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
+++ b/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
@@ -32,7 +32,7 @@
     </PackageReference>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
-    <PackageReference Include="OpenTelemetry" Version="1.15.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.15.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Motivation

Keep OpenTelemetry NuGet packages up to date to benefit from the latest bug fixes, stability improvements, and performance enhancements shipped in the 1.15.3 release.

# Description

Bumps OpenTelemetry-related NuGet packages from `1.15.0` to `1.15.3` across three projects:

| Package | Old | New |
|---|---|---|
| `OpenTelemetry` | 1.15.0 | 1.15.3 |
| `OpenTelemetry.Extensions.Hosting` | 1.15.0 | 1.15.3 |
| `OpenTelemetry.Exporter.OpenTelemetryProtocol` | 1.15.0 | 1.15.3 |
| `OpenTelemetry.Exporter.Prometheus.AspNetCore` | 1.15.0-beta.1 | 1.15.3-beta.1 |

Affected projects:
- `Compute/PollingAgent/src/ArmoniK.Core.Compute.PollingAgent.csproj`
- `Control/Submitter/src/ArmoniK.Core.Control.Submitter.csproj`
- `ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj`

# Testing

No functional changes — pure dependency version bumps. Existing CI tests cover the relevant code paths.

# Impact

No behaviour changes expected. The patch versions (1.15.0 → 1.15.3) include only bug fixes and stability improvements according to the OpenTelemetry .NET versioning policy.

# Additional Information

The Prometheus exporter remains on a `-beta.1` qualifier as upstream has not released a stable version for that minor yet.