### PR TITLE
fix(terraform): add pkcs12 provider and update to 0.3.1

### DIFF
--- a/terraform/modules/ingress/versions.tf
+++ b/terraform/modules/ingress/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     pkcs12 = {
       source  = "chilicat/pkcs12"
-      version = ">= 0.2.5"
+      version = ">= 0.3.2"
     }
   }
 }

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -12,9 +12,15 @@ terraform {
       source  = "registry.opentofu.org/hashicorp/external"
       version = "~> 2.3"
     }
+    pkcs12 = {
+      source  = "chilicat/pkcs12"
+      version = ">= 0.3.2"
+    }
   }
 }
 
 provider "docker" {
 
 }
+
+provider "pkcs12" {}


### PR DESCRIPTION
# Motivation

The pkcs12 Terraform provider (`chilicat/pkcs12`) was missing from the root `providers.tf` declaration and needed to be updated to version 0.3.1 in both the root and ingress module configurations.

# Description

- Added `pkcs12` to `required_providers` in `terraform/providers.tf` with version constraint `>= 0.3.1`
- Added `provider "pkcs12" {}` block to `terraform/providers.tf`
- Updated the `pkcs12` version constraint in `terraform/modules/ingress/versions.tf` from `>= 0.2.5` to `>= 0.3.1`
- Updated the `.terraform.lock.hcl` lock file with the hashes for `chilicat/pkcs12` v0.3.1

# Testing

Validated by running `just --tempdir .tmp init` which successfully resolved and installed `chilicat/pkcs12 v0.3.1`.

# Impact

- Requires `chilicat/pkcs12` >= 0.3.1 instead of >= 0.2.5.
- No behaviour changes expected; this aligns provider declarations and bumps the minimum version.

# Additional Information

None.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.