### PR TITLE
ci: update Docker Hub secret names in remove-artefacts workflow

### DIFF
--- a/.github/workflows/remove-artefacts.yml
+++ b/.github/workflows/remove-artefacts.yml
@@ -37,8 +37,8 @@ jobs:
       with:
         org: dockerhubaneo
         image: ${{ matrix.image }}
-        user: ${{ secrets.DOCKERHUB_USER }}
-        token: ${{ secrets.DOCKERHUB_TOKEN }}
+        user: ${{ secrets.DOCKER_HUB_LOGIN }}
+        token: ${{ secrets.DOCKER_HUB_TOKEN }}
 
   nugets:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Motivation

The Docker Hub secret names referenced in the `remove-artefacts` workflow were mismatched with the actual secrets configured in the repository, causing authentication failures when the workflow attempted to interact with Docker Hub.

# Description

Updated secret references in `.github/workflows/remove-artefacts.yml`:
- `DOCKERHUB_USER` → `DOCKER_HUB_LOGIN`
- `DOCKERHUB_TOKEN` → `DOCKER_HUB_TOKEN`

These names now match the actual secret names stored in the repository/organization settings.

# Testing

This is a CI configuration change only. No application code was modified. The fix can be verified by triggering the `remove-artefacts` workflow and confirming successful Docker Hub authentication.

# Impact

The `remove-artefacts` workflow will now correctly authenticate with Docker Hub using the properly named secrets. No impact on application behaviour, performance, or configuration outside of this workflow.

# Additional Information

No additional changes required. Secret values themselves remain unchanged — only the reference names in the workflow file were corrected.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.