### PR TITLE
chore: add AI agent guidance files and justfile test recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -381,4 +381,7 @@ terraform/terraform.tfstate.backup
 terraform/logs/armonik-logs.json
 terraform/generated
 
+# Local agent overrides
+.agents-local.md
+
 tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,180 @@
+# ArmoniK.Core — AI Agent Guide
+
+> **Local overrides**: create `.agents-local.md` in the repo root for machine-specific notes (gitignored). Merge its guidance with this file when present.
+
+## Project overview
+
+ArmoniK.Core is a distributed task processing system. It exposes a gRPC API and uses a plugin/adapter architecture so queue, object storage, and database backends are interchangeable at deploy time. Three core services run in Docker containers orchestrated by Terraform:
+
+- **PollingAgent** (`Compute/PollingAgent/`) — pulls tasks from the queue, dispatches them to workers
+- **Submitter** (`Control/Submitter/`) — accepts task submissions from clients
+- **Metrics** (`Control/Metrics/`) — collects and exposes Prometheus metrics
+
+## Repository layout
+
+```
+Common/           Core library: Pollster, gRPC services, storage abstractions, state machines
+Adaptors/         Pluggable backends
+  AMQP/           Queue — AMQP 1.0
+  RabbitMQ/       Queue — RabbitMQ
+  Nats/           Queue — NATS JetStream
+  SQS/            Queue — AWS SQS
+  PubSub/         Queue — Google Pub/Sub
+  Memory/         Queue — in-memory (testing)
+  MongoDB/        Database — MongoDB
+  Redis/          Object storage — Redis
+  S3/             Object storage — AWS S3
+  LocalStorage/   Object storage — local filesystem
+  Embed/          Object storage — embedded
+  NullStorage/    Object storage — no-op (testing)
+Compute/          PollingAgent service
+Control/          Submitter and Metrics services
+Tests/            Integration test workers: HtcMock, Bench, Stream, CrashingWorker, Connectivity
+terraform/        Terraform modules for Docker-based deployment (no docker-compose)
+tools/            Helper scripts: deployment, testing, monitoring, DB ops
+.github/          CI/CD workflows
+```
+
+Each adapter lives under `Adaptors/<Name>/src/` with a sibling `Adaptors/<Name>/tests/` test project.
+
+## Documentation
+
+Full documentation lives in `.docs/content/` and is published at [armonikcore.readthedocs.io](https://armonikcore.readthedocs.io):
+
+- **Installation & local deployment**: `.docs/content/0.installation/1.local-deployment.md`
+- **Running tests**: `.docs/content/0.installation/2.tests.md`, `3.execute-tests.md`
+- **Concepts** (components, tasks, auth, adapters, partitions, cache): `.docs/content/1.concepts/`
+- **gRPC service APIs** (tasks, sessions, results): `.docs/content/services/`
+- **Adapter guide**: `Adaptors/README.md`
+- **Coding standards & naming conventions**: `CONTRIBUTING.md#coding-standards`
+
+## Build
+
+```bash
+dotnet build                          # build entire solution
+dotnet build ArmoniK.Core.sln -c Release   # release build with warnings-as-errors subset
+
+just build-core                       # build core Docker images (PollingAgent, Submitter, Metrics)
+just build-all                        # build all images including test workers
+just tag=<tag> queue=<q> worker=<w> object=<o> build-deploy   # full build + deploy
+just destroy                          # tear down the deployment
+```
+
+Justfile variables: `tag` (default `0.0.0.0-local`), `queue` (activemq|rabbitmq|artemis|pubsub|nats|sqs), `worker` (htcmock|stream|bench|crashingworker), `object` (redis|minio|local|embed|null), `replicas`, `partitions`, `log_level`.
+
+## Tests
+
+```bash
+dotnet test                           # run all unit tests
+dotnet test Common/tests/             # Common library tests only
+dotnet test Adaptors/<Name>/tests/    # specific adapter tests
+```
+
+Test categories:
+- **Unit** (no external services): Common, Memory, MongoDB (uses EphemeralMongo), Redis adapters
+- **Partial** (need one service running): AMQP, RabbitMQ, S3, LocalStorage adapters
+- **Integration** (full deployment required): HtcMock, Stream, Bench, Connectivity
+
+Integration tests run against a live deployment. Deploy first, then run the client:
+
+```bash
+# HtcMock — defaults: 100 tasks, 4 levels, 100ms total computation
+just worker=htcmock build-deploy
+just runHtcmock
+just ntasks=1000 htcmock_levels=1 runHtcmock             # override any variable
+
+# Bench — defaults: 100 tasks, 100ms each, payload 1KB, result 1KB
+just worker=bench build-deploy
+just runBench
+just ntasks=1000 bench_duration_ms=100 runBench          # override any variable
+```
+
+Shared variables (apply to both `runHtcmock` and `runBench`): `ntasks` (default `100`) `partition` (default `""` = default partition) `endpoint` (default `http://armonik.control.submitter:1080`) `network` (default `armonik_network`)
+
+Overridable variables for `runHtcmock`: `htcmock_time` `htcmock_datasize` `htcmock_memsize` `htcmock_levels` `htcmock_fast_compute` `htcmock_low_mem` `htcmock_small_output` `htcmock_purge_data` `htcmock_task_rpc_exception` `htcmock_task_error`
+
+Overridable variables for `runBench`: `bench_duration_ms` `bench_payload_size` `bench_result_size` `bench_batch_size` `bench_max_retries` `bench_degree_of_parallelism` `bench_show_events` `bench_purge_data` `bench_download_results` `bench_exit_after_submission` `bench_pause_session` `bench_max_duration` `bench_priority` `bench_task_rpc_exception` `bench_task_error`
+
+Test framework: **NUnit**. Mock library: **Moq**.
+
+## Viewing logs
+
+All containers ship logs to a **Fluent Bit** container named `fluentd` via the Docker `fluentd` log driver. Fluent Bit aggregates them into a single JSON-lines file and also forwards to Seq.
+
+### All logs in one file (preferred)
+
+```bash
+# dump to stdout
+docker cp fluentd:/armonik-logs.json -
+
+# save to a local file
+docker cp fluentd:/armonik-logs.json ./armonik-logs.json
+
+# filter by level with jq
+docker cp fluentd:/armonik-logs.json - | jq 'select(.@l == "Error")'
+
+# grep for a keyword
+docker cp fluentd:/armonik-logs.json - | grep "TaskId"
+
+# extract a structured field with jq
+docker cp fluentd:/armonik-logs.json - | jq '{time: .@t, msg: .@mt, task: .TaskId}'
+```
+
+The file format is CLEF (Compact Log Event Format) — one JSON object per line. Common fields: `@t` (timestamp), `@mt` (message template), `@l` (level, absent = Information), `@x` (exception).
+
+### Per-container logs
+
+```bash
+docker logs <container-name>          # e.g. armonik.control.submitter
+docker logs -f <container-name>       # follow
+docker logs <container-name> 2>&1 | grep "ERROR"
+```
+
+### Seq UI
+
+Seq is deployed alongside the stack (enabled by default via `seq=true`). Open **http://localhost:9080** in a browser for structured log search and filtering.
+
+### Log verbosity
+
+```bash
+just log_level=Verbose build-deploy   # default is "Information"
+```
+
+## Code formatting
+
+```bash
+just cleanupcode          # formats all staged/modified .cs files (detected from git diff)
+just cleanupcode <file>   # formats specific files
+sh tools/applyformatpatch.sh   # apply formatting patch downloaded from a failed CI run
+```
+
+Internally uses JetBrains `jb cleanupcode --profile="Full Cleanup With Headers"`. CI checks formatting on every PR and uploads a patch artifact when it fails.
+
+Pre-commit hooks (`.pre-commit-config.yaml`) enforce: Terraform format, YAML/XML validity, LF line endings, no large files.
+
+## Architecture patterns
+
+- **Adapter registration**: all adapters implement `IDependencyInjectionBuildable` and register services via `Build()`. Never bypass DI with `new ConcreteType()`.
+- **Task lifecycle**: driven by a state machine in `Common/src/StateMachines/`. Do not mutate task status outside the state machine.
+- **Logging**: Serilog structured logging. Inject `ILogger<T>`; never use `Console.Write*`.
+- **Nullable**: `<Nullable>enable</Nullable>` is set project-wide. All new code must handle nullability correctly.
+- **New adapters**: must include a `/tests/` sibling project with integration tests.
+
+## Conventions
+
+- Target framework for new projects: `net10.0`.
+- Use NUnit + Moq for tests; match the style of the nearest existing `tests/` directory.
+- Inter-service communication uses gRPC.
+- Run `just cleanupcode` before committing C# changes.
+- PRs go to `main`; follow the PR template at `.github/PULL_REQUEST_TEMPLATE.md`.
+- Versioning is semantic and computed by CI — do not manually bump version files.
+- Naming conventions and style rules: see `CONTRIBUTING.md#coding-standards`.
+
+## Things to avoid
+
+- Do not add `docker-compose.yml` — deployment is Terraform-managed.
+- Do not bypass DI with `new ConcreteType()` for services.
+- Do not use `Console.Write*` for logging.
+- Do not target `net8.0` in new projects without an explicit reason.
+- Do not push breaking changes to public adapter interfaces without a documented migration path.
+- Do not run `just destroy` or other destructive Terraform operations without confirming with the user.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# ArmoniK.Core — Claude Code Guide
+
+@AGENTS.md
+
+## Claude-specific notes
+
+- When exploring unfamiliar code, start from `Common/src/` for abstractions, then follow DI registrations to concrete implementations in `Adaptors/`.
+- When writing tests, match the style of existing tests in the nearest `tests/` sibling directory.
+- Do not run `just destroy` or destructive Terraform commands without explicit user confirmation.
+- Integration tests require a running deployment — confirm infra is up before attempting them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,28 @@ Hi! We are very happy that you are interested in contributing to ArmoniK.Core pr
 2. Make sure you clearly define the changes in the description of the PR
 3. Make sure all tests pass by following the instructions available [here](.docs/content/0.installation/3.execute-tests.md)
 
+## Coding Standards
+
+### Naming
+
+| Element | Convention | Example |
+|---|---|---|
+| Classes, structs, records | `PascalCase` | `TaskHandler` |
+| Interfaces | `I` prefix + `PascalCase` | `ITaskTable`, `IObjectStorage` |
+| Methods and properties | `PascalCase` | `GetStatus`, `CancelSession` |
+| Async methods | `Async` suffix | `CreateSessionAsync` |
+| Private fields | `_camelCase` | `_logger`, `_taskTable` |
+| Local variables and parameters | `camelCase` | `taskId`, `cancellationToken` |
+| Constants and `static readonly` | `PascalCase` | `MaxRetries`, `DefaultPartition` |
+
+### Style
+
+- Use `var` when the type is obvious from the right-hand side
+- Prefer `async`/`await` over raw `Task` continuations
+- No magic numbers — use named constants or config-bound values
+- `<Nullable>enable</Nullable>` is set project-wide; all new code must annotate nullability
+- Run `just cleanupcode` (JetBrains `jb cleanupcode`) before committing C# changes
+
 ## Release Process
 
 When necessary, maintainers can release a new version. This new version will publish packages to registries.

--- a/justfile
+++ b/justfile
@@ -23,6 +23,42 @@ seq          := "true"
 socket_type  := "unixdomainsocket"
 cinit        := "true"
 
+# Shared test parameters
+ntasks    := "100"
+network   := "armonik_network"
+net_arg   := if network != "" { "--net " + network } else { "" }
+partition := ""
+endpoint  := "http://armonik.control.submitter:1080"
+
+# HtcMock test client parameters (defaults match HtcMock.cs)
+htcmock_time               := "00:00:00.100"
+htcmock_datasize           := "1"
+htcmock_memsize            := "1"
+htcmock_levels             := "4"
+htcmock_fast_compute       := "true"
+htcmock_low_mem            := "true"
+htcmock_small_output       := "true"
+htcmock_purge_data         := "true"
+htcmock_task_rpc_exception := ""
+htcmock_task_error         := ""
+
+# Bench test client parameters (defaults match BenchOptions.cs)
+bench_duration_ms              := "100"
+bench_payload_size             := "1"
+bench_result_size              := "1"
+bench_batch_size               := "100"
+bench_max_retries              := "1"
+bench_degree_of_parallelism    := "1"
+bench_show_events              := "false"
+bench_purge_data               := "true"
+bench_download_results         := "true"
+bench_exit_after_submission    := "false"
+bench_pause_session            := "false"
+bench_max_duration             := "01:00:00"
+bench_priority                 := "1"
+bench_task_rpc_exception       := ""
+bench_task_error               := ""
+
 # Export them as terraform environment variables
 export TF_VAR_core_tag          := tag
 export TF_VAR_use_local_image   := local_images
@@ -300,6 +336,51 @@ buildStreamClient: (build STREAM_CLIENT_IMAGE  "./Tests/Stream/Client/Dockerfile
 
 # Build Bench Client
 buildBenchClient: (build BENCH_CLIENT_IMAGE  "./Tests/Bench/Client/src/Dockerfile")
+
+# Run HtcMock test client against a running deployment
+# Note: always rebuilds the client image to pick up local changes
+# Override any variable: just ntasks=1000 htcmock_levels=1 runHtcmock
+runHtcmock: buildHtcmockClient
+  docker run {{net_arg}} --rm \
+    -e HtcMock__NTasks={{ntasks}} \
+    -e HtcMock__TotalCalculationTime={{htcmock_time}} \
+    -e HtcMock__DataSize={{htcmock_datasize}} \
+    -e HtcMock__MemorySize={{htcmock_memsize}} \
+    -e HtcMock__SubTasksLevels={{htcmock_levels}} \
+    -e HtcMock__EnableFastCompute={{htcmock_fast_compute}} \
+    -e HtcMock__EnableUseLowMem={{htcmock_low_mem}} \
+    -e HtcMock__EnableSmallOutput={{htcmock_small_output}} \
+    -e HtcMock__Partition={{partition}} \
+    -e HtcMock__PurgeData={{htcmock_purge_data}} \
+    -e HtcMock__TaskRpcException={{htcmock_task_rpc_exception}} \
+    -e HtcMock__TaskError={{htcmock_task_error}} \
+    -e GrpcClient__Endpoint={{endpoint}} \
+    {{HTCMOCK_CLIENT_IMAGE}}
+
+# Run Bench test client against a running deployment
+# Note: always rebuilds the client image to pick up local changes
+# Override any variable: just ntasks=1000 bench_payload_size=1000 runBench
+runBench: buildBenchClient
+  docker run {{net_arg}} --rm \
+    -e BenchOptions__NTasks={{ntasks}} \
+    -e BenchOptions__TaskDurationMs={{bench_duration_ms}} \
+    -e BenchOptions__PayloadSize={{bench_payload_size}} \
+    -e BenchOptions__ResultSize={{bench_result_size}} \
+    -e BenchOptions__BatchSize={{bench_batch_size}} \
+    -e BenchOptions__Partition={{partition}} \
+    -e BenchOptions__MaxRetries={{bench_max_retries}} \
+    -e BenchOptions__DegreeOfParallelism={{bench_degree_of_parallelism}} \
+    -e BenchOptions__ShowEvents={{bench_show_events}} \
+    -e BenchOptions__PurgeData={{bench_purge_data}} \
+    -e BenchOptions__DownloadResults={{bench_download_results}} \
+    -e BenchOptions__ExitAfterSubmission={{bench_exit_after_submission}} \
+    -e BenchOptions__PauseSessionDuringSubmission={{bench_pause_session}} \
+    -e BenchOptions__MaxDuration={{bench_max_duration}} \
+    -e BenchOptions__TaskPriority={{bench_priority}} \
+    -e BenchOptions__TaskRpcException={{bench_task_rpc_exception}} \
+    -e BenchOptions__TaskError={{bench_task_error}} \
+    -e GrpcClient__Endpoint={{endpoint}} \
+    {{BENCH_CLIENT_IMAGE}}
 
 # Build Crashing Worker Client
 buildCrashingWorkerClient: (build CRASHINGWORKER_CLIENT_IMAGE  "./Tests/CrashingWorker/Client/src/Dockerfile")


### PR DESCRIPTION
# Motivation

AI coding agents (Claude Code, Kiro, Copilot, etc.) work best when the repository provides explicit guidance on project structure, conventions, and common workflows. Without it, agents must infer context from the code, which leads to inconsistent suggestions and repeated corrections.

# Description

Adds two documentation files and improves the justfile to support streamlined test runs:

- **`AGENTS.md`**: A comprehensive AI agent guide covering project overview, repository layout, build commands, test categories and how to run them, log viewing, code formatting, architecture patterns, conventions, and things to avoid. This file is the single source of truth for all AI agents.
- **`CLAUDE.md`**: A Claude Code–specific guide that includes `AGENTS.md` via `@AGENTS.md` and adds Claude-specific notes (e.g. where to start when exploring unfamiliar code, integration test prerequisites, destructive-command guard).
- **`justfile`**: Adds `runHtcmock` and `runBench` recipes (and their associated parameter variables) so developers and agents can run integration test clients against a live deployment with a single `just` command. All parameters are overridable on the command line.

# Testing

No code changes — documentation and justfile recipes only. The `runHtcmock` and `runBench` recipes were validated against the existing `buildHtcmockClient` / `buildBenchClient` targets and the environment variables match the option bindings in `HtcMock.cs` / `BenchOptions.cs`.

# Impact

- No runtime behaviour change.
- Adds two new `just` recipes that make it easier to run integration test clients without manually constructing `docker run` commands.
- AI agents interacting with this repository will now have accurate, up-to-date guidance and are less likely to suggest incorrect commands or patterns.

# Additional Information

`CLAUDE.md` uses the `@AGENTS.md` include syntax supported by Claude Code, so there is a single authoritative file (`AGENTS.md`) that is also readable by non-Claude agents (Kiro, GitHub Copilot, etc.).

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.