### PR TITLE
refactor(pollster): retry acquisition for pending tasks

### DIFF
--- a/Common/src/Injection/Options/Pollster.cs
+++ b/Common/src/Injection/Options/Pollster.cs
@@ -62,6 +62,18 @@ public class Pollster
   public int NbAcquisitionRetry { get; set; } = 3;
 
   /// <summary>
+  ///   Delay between consecutive re-reads of a task that is still in Pending status during acquisition,
+  ///   to allow the submitter time to complete the transition to Submitted.
+  /// </summary>
+  public TimeSpan PendingRetryDelay { get; set; } = TimeSpan.FromMilliseconds(100);
+
+  /// <summary>
+  ///   Number of times to re-read a Pending task before postponing the message.
+  ///   Covers the window between the queue push and the status update to Submitted that occurs during task submission.
+  /// </summary>
+  public int NbPendingRetry { get; set; } = 3;
+
+  /// <summary>
   ///   Root directory for per-task staging folders.
   ///   Sub-directories are created here for each task and deleted after it completes
   /// </summary>

--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -77,6 +77,8 @@ public sealed class TaskHandler : IAsyncDisposable
   private readonly IObjectStorage                        objectStorage_;
   private readonly string                                ownerPodId_;
   private readonly string                                ownerPodName_;
+  private readonly TimeSpan                              pendingRetryDelay_;
+  private readonly int                                   pendingRetryNb_;
   private readonly TimeSpan                              processingCrashedDelay_;
   private readonly IPushQueueStorage                     pushQueueStorage_;
   private readonly IResultTable                          resultTable_;
@@ -214,6 +216,8 @@ public sealed class TaskHandler : IAsyncDisposable
     delayBeforeAcquisition_  = pollsterOptions.TimeoutBeforeNextAcquisition + TimeSpan.FromSeconds(2);
     messageDuplicationDelay_ = pollsterOptions.MessageDuplicationDelay;
     processingCrashedDelay_  = pollsterOptions.ProcessingCrashedDelay;
+    pendingRetryDelay_       = pollsterOptions.PendingRetryDelay;
+    pendingRetryNb_          = pollsterOptions.NbPendingRetry;
 
     earlyCts_ = CancellationTokenSource.CreateLinkedTokenSource(exceptionManager.EarlyCancellationToken);
     lateCts_  = CancellationTokenSource.CreateLinkedTokenSource(exceptionManager.LateCancellationToken);
@@ -510,6 +514,23 @@ public sealed class TaskHandler : IAsyncDisposable
         logger_.LogDebug("Session paused; message deleted");
         messageHandler_.Status = QueueMessageStatus.Processed;
         return AcquisitionStatus.SessionPaused;
+      }
+
+      // During task submission, the task is pushed to the queue before its status is set to Submitted.
+      // An agent may therefore dequeue a task that is still Pending. Retry a few times to give the
+      // submitter time to complete the status transition before falling through to TaskIsPending.
+      for (var i = 0; i < pendingRetryNb_ && taskData_.Status == TaskStatus.Pending; i++)
+      {
+        logger_.LogInformation("Task is pending, waiting for {PendingRetryDelay} before retrying (retry {Retry}/{MaxRetries})",
+                               pendingRetryDelay_,
+                               i + 1,
+                               pendingRetryNb_);
+        await Task.Delay(pendingRetryDelay_,
+                         CancellationToken.None)
+                  .ConfigureAwait(false);
+        taskData_ = await taskTable_.ReadTaskAsync(messageHandler_.TaskId,
+                                                   CancellationToken.None)
+                                    .ConfigureAwait(false);
       }
 
       switch (taskData_.Status)

--- a/Common/tests/Pollster/TaskHandlerTest.cs
+++ b/Common/tests/Pollster/TaskHandlerTest.cs
@@ -1504,6 +1504,314 @@ public class TaskHandlerTest
                 Is.EqualTo(AcquisitionStatus.TaskIsPending));
   }
 
+  public class SequentialReadTaskTable : ITaskTable
+  {
+    private readonly int nbPendingReads_;
+    private          int readCount_;
+
+    public SequentialReadTaskTable(int nbPendingReads)
+    {
+      nbPendingReads_ = nbPendingReads;
+      Logger          = NullLogger.Instance;
+    }
+
+    public int ReadTaskAsyncCallCount
+      => readCount_;
+
+    public Task<HealthCheckResult> Check(HealthCheckTag tag)
+      => Task.FromResult(HealthCheckResult.Healthy());
+
+    public Task Init(CancellationToken cancellationToken)
+      => Task.CompletedTask;
+
+    public TimeSpan PollingDelayMin { get; } = TimeSpan.Zero;
+    public TimeSpan PollingDelayMax { get; } = TimeSpan.Zero;
+    public ILogger  Logger          { get; }
+
+    public Task CreateTasks(IEnumerable<TaskData> tasks,
+                            CancellationToken     cancellationToken = default)
+      => Task.CompletedTask;
+
+    public Task<T> ReadTaskAsync<T>(string                        taskId,
+                                    Expression<Func<TaskData, T>> selector,
+                                    CancellationToken             cancellationToken = default)
+    {
+      var count = Interlocked.Increment(ref readCount_);
+      var status = count <= nbPendingReads_
+                     ? TaskStatus.Pending
+                     : TaskStatus.Submitted;
+      return Task.FromResult(selector.Compile()
+                                     .Invoke(new TaskData("SessionId",
+                                                          taskId,
+                                                          "",
+                                                          "",
+                                                          "payload",
+                                                          new List<string>(),
+                                                          new List<string>(),
+                                                          new Dictionary<string, bool>(),
+                                                          new List<string>(),
+                                                          taskId,
+                                                          "createdby",
+                                                          new List<string>(),
+                                                          status,
+                                                          "",
+                                                          new TaskOptions(new Dictionary<string, string>(),
+                                                                          TimeSpan.FromMinutes(4),
+                                                                          2,
+                                                                          1,
+                                                                          "part1",
+                                                                          "",
+                                                                          "",
+                                                                          "",
+                                                                          "",
+                                                                          ""),
+                                                          DateTime.UtcNow,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          new Output(OutputStatus.Error,
+                                                                     ""))));
+    }
+
+    public Task<IEnumerable<TaskStatusCount>> CountTasksAsync(Expression<Func<TaskData, bool>> filter,
+                                                              CancellationToken                cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public Task<IEnumerable<PartitionTaskStatusCount>> CountPartitionTasksAsync(CancellationToken cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public Task<int> CountAllTasksAsync(TaskStatus        status,
+                                        CancellationToken cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public Task DeleteTaskAsync(string            id,
+                                CancellationToken cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public Task DeleteTasksAsync(string            sessionId,
+                                 CancellationToken cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public Task DeleteTasksAsync(ICollection<string> taskIds,
+                                 CancellationToken   cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public Task<(IEnumerable<T> tasks, long totalCount)> ListTasksAsync<T>(Expression<Func<TaskData, bool>>    filter,
+                                                                           Expression<Func<TaskData, object?>> orderField,
+                                                                           Expression<Func<TaskData, T>>       selector,
+                                                                           bool                                ascOrder,
+                                                                           int                                 page,
+                                                                           int                                 pageSize,
+                                                                           CancellationToken                   cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public async IAsyncEnumerable<T> FindTasksAsync<T>(Expression<Func<TaskData, bool>>           filter,
+                                                       Expression<Func<TaskData, T>>              selector,
+                                                       [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+      yield return await ReadTaskAsync("taskId",
+                                       selector,
+                                       cancellationToken)
+                     .ConfigureAwait(false);
+    }
+
+    public Task<TaskData?> UpdateOneTask(string                            taskId,
+                                         Expression<Func<TaskData, bool>>? filter,
+                                         UpdateDefinition<TaskData>        updates,
+                                         bool                              before            = false,
+                                         CancellationToken                 cancellationToken = default)
+      => Task.FromResult<TaskData?>(new TaskData("SessionId",
+                                                 taskId,
+                                                 "ownerpodid",
+                                                 "ownerpodname",
+                                                 "payload",
+                                                 new List<string>(),
+                                                 new List<string>(),
+                                                 new Dictionary<string, bool>(),
+                                                 new List<string>(),
+                                                 taskId,
+                                                 "createdby",
+                                                 new List<string>(),
+                                                 TaskStatus.Dispatched,
+                                                 "",
+                                                 new TaskOptions(new Dictionary<string, string>(),
+                                                                 TimeSpan.FromMinutes(4),
+                                                                 2,
+                                                                 1,
+                                                                 "part1",
+                                                                 "",
+                                                                 "",
+                                                                 "",
+                                                                 "",
+                                                                 ""),
+                                                 DateTime.UtcNow,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 DateTime.UtcNow,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 null,
+                                                 new Output(OutputStatus.Error,
+                                                            "")));
+
+    public Task<long> UpdateManyTasks(Expression<Func<TaskData, bool>> filter,
+                                      UpdateDefinition<TaskData>       updates,
+                                      CancellationToken                cancellationToken = default)
+      => Task.FromResult<long>(0);
+
+    public Task<(IEnumerable<Application> applications, int totalCount)> ListApplicationsAsync(Expression<Func<TaskData, bool>> filter,
+                                                                                               ICollection<Expression<Func<Application, object?>>> orderFields,
+                                                                                               bool ascOrder,
+                                                                                               int page,
+                                                                                               int pageSize,
+                                                                                               CancellationToken cancellationToken = default)
+      => throw new NotImplementedException();
+
+    public IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>           taskIds,
+                                                                       ICollection<string>           dependenciesToRemove,
+                                                                       Expression<Func<TaskData, T>> selector,
+                                                                       CancellationToken             cancellationToken = default)
+      => AsyncEnumerable.Empty<T>();
+  }
+
+  [Test]
+  public async Task AcquirePendingTaskWithNbPendingRetryZeroShouldReturnPending()
+  {
+    var taskId = Guid.NewGuid()
+                     .ToString();
+    var sqmh = new SimpleQueueMessageHandler
+               {
+                 CancellationToken = CancellationToken.None,
+                 Status            = QueueMessageStatus.Waiting,
+                 MessageId = Guid.NewGuid()
+                                 .ToString(),
+                 TaskId = taskId,
+               };
+
+    var mockStreamHandler = new Mock<IWorkerStreamHandler>();
+    var mockAgentHandler  = new Mock<IAgentHandler>();
+    var conf = new Dictionary<string, string>
+               {
+                 {
+                   $"{nameof(Injection.Options.Pollster)}:{nameof(Injection.Options.Pollster.NbPendingRetry)}", "0"
+                 },
+               };
+
+    var taskTable    = new SequentialReadTaskTable(int.MaxValue);
+    var sessionTable = new WaitSessionTable(0);
+
+    using var testServiceProvider = new TestTaskHandlerProvider(mockStreamHandler.Object,
+                                                                mockAgentHandler.Object,
+                                                                sqmh,
+                                                                taskTable,
+                                                                sessionTable,
+                                                                additionalConfig: conf);
+
+    await testServiceProvider.SessionTable.SetSessionDataAsync(new List<string>
+                                                               {
+                                                                 "part1",
+                                                               },
+                                                               new TaskOptions(new Dictionary<string, string>(),
+                                                                               TimeSpan.FromMinutes(4),
+                                                                               2,
+                                                                               1,
+                                                                               "part1",
+                                                                               "",
+                                                                               "",
+                                                                               "",
+                                                                               "",
+                                                                               ""))
+                             .ConfigureAwait(false);
+
+    var acquired = await testServiceProvider.TaskHandler.AcquireTask()
+                                            .ConfigureAwait(false);
+
+    Assert.That(acquired,
+                Is.EqualTo(AcquisitionStatus.TaskIsPending));
+    Assert.That(sqmh.Status,
+                Is.EqualTo(QueueMessageStatus.Postponed));
+    Assert.That(taskTable.ReadTaskAsyncCallCount,
+                Is.EqualTo(1));
+  }
+
+  [Test]
+  public async Task AcquirePendingTaskThatBecomesSubmittedDuringRetryShouldSucceed()
+  {
+    var taskId = Guid.NewGuid()
+                     .ToString();
+    var sqmh = new SimpleQueueMessageHandler
+               {
+                 CancellationToken = CancellationToken.None,
+                 Status            = QueueMessageStatus.Waiting,
+                 MessageId = Guid.NewGuid()
+                                 .ToString(),
+                 TaskId = taskId,
+               };
+
+    var mockStreamHandler = new Mock<IWorkerStreamHandler>();
+    var mockAgentHandler  = new Mock<IAgentHandler>();
+    var conf = new Dictionary<string, string>
+               {
+                 {
+                   $"{nameof(Injection.Options.Pollster)}:{nameof(Injection.Options.Pollster.NbPendingRetry)}", "5"
+                 },
+                 {
+                   $"{nameof(Injection.Options.Pollster)}:{nameof(Injection.Options.Pollster.PendingRetryDelay)}", TimeSpan.FromMilliseconds(1)
+                                                                                                                           .ToString()
+                 },
+               };
+
+    // Returns Pending on the first 2 reads, then Submitted; the acquisition loop sees:
+    // read 1 (initial) = Pending, read 2 (retry i=0) = Pending, read 3 (retry i=1) = Submitted → exits loop
+    var taskTable    = new SequentialReadTaskTable(2);
+    var sessionTable = new WaitSessionTable(0);
+
+    using var testServiceProvider = new TestTaskHandlerProvider(mockStreamHandler.Object,
+                                                                mockAgentHandler.Object,
+                                                                sqmh,
+                                                                taskTable,
+                                                                sessionTable,
+                                                                additionalConfig: conf);
+
+    await testServiceProvider.SessionTable.SetSessionDataAsync(new List<string>
+                                                               {
+                                                                 "part1",
+                                                               },
+                                                               new TaskOptions(new Dictionary<string, string>(),
+                                                                               TimeSpan.FromMinutes(4),
+                                                                               2,
+                                                                               1,
+                                                                               "part1",
+                                                                               "",
+                                                                               "",
+                                                                               "",
+                                                                               "",
+                                                                               ""))
+                             .ConfigureAwait(false);
+
+    var acquired = await testServiceProvider.TaskHandler.AcquireTask()
+                                            .ConfigureAwait(false);
+
+    Assert.That(acquired,
+                Is.EqualTo(AcquisitionStatus.Acquired));
+    // 1 initial read + 2 retry reads (i=0 still Pending, i=1 sees Submitted and exits)
+    Assert.That(taskTable.ReadTaskAsyncCallCount,
+                Is.EqualTo(3));
+  }
+
   public class TestRpcException : RpcException
   {
     public TestRpcException()


### PR DESCRIPTION
# Motivation

During task submission, the task is pushed to the queue **before** its status is updated to `Submitted`. There is therefore a window during which an agent can dequeue a task that is still in `Pending` status. Without this fix, the agent immediately postpones the message and the task must go through another full queue round-trip before it can be executed, adding unnecessary latency.

# Description

- Added two new options to `Injection.Options.Pollster`:
  - `PendingRetryDelay` (default: 100 ms) — delay between re-reads of a pending task.
  - `NbPendingRetry` (default: 3) — maximum number of re-reads before giving up.
- In `TaskHandler.AcquireTask`, after the session status check and before the main status switch, a loop re-reads the task up to `NbPendingRetry` times (with `PendingRetryDelay` between each attempt) while its status remains `Pending`. If the task transitions to `Submitted` within the retry window, acquisition proceeds normally; otherwise it falls through to the existing `TaskIsPending` path.

# Testing

Two new deterministic unit tests were added to `TaskHandlerTest`:

- `AcquirePendingTaskWithNbPendingRetryZeroShouldReturnPending` — configures `NbPendingRetry = 0` and verifies that `AcquireTask` returns `TaskIsPending` after exactly one `ReadTaskAsync` call (no retries).
- `AcquirePendingTaskThatBecomesSubmittedDuringRetryShouldSucceed` — configures `NbPendingRetry = 5` with a 1 ms delay; the `SequentialReadTaskTable` stub returns `Pending` on the first two reads and `Submitted` on the third. Asserts `Acquired` is returned and that `ReadTaskAsync` was called exactly 3 times.

A new `SequentialReadTaskTable` inner class was introduced to support these tests without relying on timing or a real database.

# Impact

- Tasks that are dequeued while still `Pending` will incur up to `NbPendingRetry × PendingRetryDelay` of additional latency before being postponed. With defaults (3 × 100 ms = 300 ms max), this is negligible compared to the cost of a queue round-trip.
- Both new options are fully configurable and can be set to `0` to restore the previous behaviour.
- No changes to existing public API or storage schema.

# Additional Information

The retry delay uses `CancellationToken.None` intentionally, consistent with the pattern used elsewhere in `AcquireTask` for short waits that should not be interrupted by early cancellation.
