### PR TITLE
fix(ci): prefix image name with armonik_ in remove-artefacts workflow

### DIFF
--- a/.github/workflows/remove-artefacts.yml
+++ b/.github/workflows/remove-artefacts.yml
@@ -12,16 +12,16 @@ jobs:
       fail-fast: false
       matrix:
         image:
-          - pollingagent
-          - control_metrics
-          - control_partition_metrics
-          - control
-          - core_stream_test_worker
-          - core_stream_test_client
-          - core_htcmock_test_worker
-          - core_htcmock_test_client
-          - core_bench_test_worker
-          - core_bench_test_client
+          - armonik_pollingagent
+          - armonik_control_metrics
+          - armonik_control_partition_metrics
+          - armonik_control
+          - armonik_core_stream_test_worker
+          - armonik_core_stream_test_client
+          - armonik_core_htcmock_test_worker
+          - armonik_core_htcmock_test_client
+          - armonik_core_bench_test_worker
+          - armonik_core_bench_test_client
     steps:
     - name: Checkout
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
# Motivation

The weekly cleanup workflow (`remove-artefacts.yml`) was passing bare image names (e.g. `pollingagent`) to the `remove-images` action. Images published to Docker Hub under the `dockerhubaneo` org are actually named with an `armonik_` prefix (e.g. `armonik_pollingagent`), so the cleanup job was silently targeting non-existent images and failing to remove stale branch artifacts.

# Description

All 10 image names in the `images` job matrix now carry the `armonik_` prefix to match the actual names on Docker Hub:

| Before | After |
|---|---|
| `pollingagent` | `armonik_pollingagent` |
| `control_metrics` | `armonik_control_metrics` |
| `control_partition_metrics` | `armonik_control_partition_metrics` |
| `control` | `armonik_control` |
| `core_stream_test_worker` | `armonik_core_stream_test_worker` |
| `core_stream_test_client` | `armonik_core_stream_test_client` |
| `core_htcmock_test_worker` | `armonik_core_htcmock_test_worker` |
| `core_htcmock_test_client` | `armonik_core_htcmock_test_client` |
| `core_bench_test_worker` | `armonik_core_bench_test_worker` |
| `core_bench_test_client` | `armonik_core_bench_test_client` |

No other part of the workflow is changed. The `nugets` job and all action pins are unaffected.

# Testing

No automated tests — this is a CI workflow fix. It can be verified by triggering the workflow manually via `workflow_dispatch` and confirming that the `remove-images` action now targets the correct image tags on Docker Hub.

# Impact

The Monday cleanup cron job will correctly identify and delete stale branch images from Docker Hub, preventing accumulation of unused artifacts over time. No application code is affected.
