### PR TITLE
ci: do not show verbose logs in the pipeline for the main repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -471,7 +471,7 @@ jobs:
           only-summary: ${{ env.REPOSITORY != github.repository }}
 
       - name: Show logs
-        if: ${{ always() }}
+        if: ${{ always() && (env.REPOSITORY != github.repository || matrix.log-level != 'Verbose') }}
         run: docker cp fluentd:/armonik-logs.json -
       - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
@@ -485,7 +485,7 @@ jobs:
         with:
           dest: './container-logs'
       - name: Show docker container logs
-        if: ${{ always() }}
+        if: ${{ always() && (env.REPOSITORY != github.repository || matrix.log-level != 'Verbose') }}
         run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
@@ -687,7 +687,7 @@ jobs:
           time curl localhost:5002/metrics
 
       - name: Show logs
-        if: ${{ always() }}
+        if: ${{ always() && (env.REPOSITORY != github.repository || matrix.target.log-level != 'Verbose') }}
         run: docker cp fluentd:/armonik-logs.json -
       - name: Upload logs
         if: ${{ always() && env.REPOSITORY == github.repository }}
@@ -703,7 +703,7 @@ jobs:
         with:
           dest: './container-logs'
       - name: Show docker container logs
-        if: ${{ always() }}
+        if: ${{ always() && (env.REPOSITORY != github.repository || matrix.target.log-level != 'Verbose') }}
         run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
       - name: Upload docker container logs
         if: ${{ always() && env.REPOSITORY == github.repository }}


### PR DESCRIPTION
# Motivation

Verbose log runs produce very large log files. In the main organisation repository, logs are already uploaded to S3, so streaming them to the pipeline console is unnecessary overhead and makes the CI take too much time to print the logs.

# Description

Suppress the **Show logs** and **Show docker container logs** steps when running in the organisation's own repository (`env.REPOSITORY == github.repository`) with a `Verbose` log level. The steps now only execute when:
- the run is on a fork (where logs are not stored elsewhere), **or**
- the log level is not `Verbose`.

This change applies to two jobs in `.github/workflows/build.yml`: the main build matrix job and the metrics job.

# Testing

No new tests — this is a CI workflow change. The conditional expression was verified against both the fork path (unchanged behaviour) and the org-repo + Verbose path (steps now skipped).

# Impact

- Verbose-level CI runs in the main repo will no longer stream potentially gigabyte-scale log files to the console.
- No impact on fork runs or non-Verbose runs.
- Logs remain available via the S3 upload step that follows.
