### PR TITLE
fix(mongodb): wait for cluster connection in SessionProvider.Init

### DIFF
--- a/Adaptors/MongoDB/src/Common/SessionProvider.cs
+++ b/Adaptors/MongoDB/src/Common/SessionProvider.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
+using MongoDB.Bson;
 using MongoDB.Driver;
 using MongoDB.Driver.Core.Clusters;
 
@@ -81,11 +82,11 @@ public class SessionProvider : IInitializable
   /// </summary>
   /// <param name="cancellationToken">A cancellation token to observe while waiting for the initialization to complete.</param>
   /// <returns>A task that represents the asynchronous initialization operation.</returns>
-  public Task Init(CancellationToken cancellationToken)
+  public async Task Init(CancellationToken cancellationToken)
   {
     if (clientSessionHandle_ is not null)
     {
-      return Task.CompletedTask;
+      return;
     }
 
     lock (lockObj_)
@@ -97,7 +98,13 @@ public class SessionProvider : IInitializable
                                                     cancellationToken);
     }
 
-    return Task.CompletedTask;
+    // Force cluster topology discovery to complete so that the liveness check (which inspects
+    // ClusterState) sees Connected immediately after Init returns.
+    await client_.GetDatabase("admin")
+                 .RunCommandAsync<BsonDocument>(new BsonDocument("ping",
+                                                                 1),
+                                                cancellationToken: cancellationToken)
+                 .ConfigureAwait(false);
   }
 
   /// <summary>


### PR DESCRIPTION
# Motivation

`SessionProviderInitShouldSucceed` was intermittently failing on the CI pipeline with the liveness check returning `Unhealthy` immediately after `Init`. The root cause is that the MongoDB .NET driver performs cluster topology discovery asynchronously in the background. `StartSession` (synchronous) could return successfully while `client_.Cluster.Description.State` had not yet transitioned to `ClusterState.Connected`, causing the liveness health check to fail on slow CI runners.

# Description

**`SessionProvider.Init`** is now `async` and runs a lightweight `ping` command against the `admin` database after starting the session. This forces the driver to complete server selection and topology discovery before `Init` returns, guaranteeing that `ClusterState.Connected` is visible to the liveness check immediately after initialisation.

# Testing

- The fix removes the race condition at its source, so the test should now be deterministic on CI.

# Impact

- `Init` now performs one extra round-trip to MongoDB (a no-op `ping`) on first call. This is negligible in practice — `Init` is called once at startup.
- No behavioural change for callers: the method signature (`Task Init(CancellationToken)`) is unchanged.
- No new dependencies: `MongoDB.Bson` is already part of the `MongoDB.Driver` package.
