### PR TITLE
chore(deps): upgrade MongoDB.Driver from 2.x to 3.x

### DIFF
--- a/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
+++ b/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
@@ -32,8 +32,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.7.3" />
-    <PackageReference Include="MongoDB.Driver" Version="2.30.0" />
-    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+    <PackageReference Include="MongoDB.Driver" Version="3.8.1" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.500.80" />
   </ItemGroup>
 

--- a/Adaptors/MongoDB/src/AuthenticationTable.cs
+++ b/Adaptors/MongoDB/src/AuthenticationTable.cs
@@ -34,6 +34,7 @@ using JetBrains.Annotations;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
+using MongoDB.Bson;
 using MongoDB.Bson.Serialization;
 using MongoDB.Driver;
 
@@ -316,17 +317,37 @@ public class AuthenticationTable : IAuthenticationTable
     - Roles : user's role names
     - Permissions : permissions list, extracted from the roles. Permissions are not repeated
     */
-    var projectionStage = PipelineStageDefinitionBuilder.Project<UserDataAfterLookup, MongoAuthResult>(ual => new MongoAuthResult(ual.UserId,
-                                                                                                                                  ual.Username,
-                                                                                                                                  ual.Roles.Select(r => r.RoleName),
-                                                                                                                                  ual.Roles
-                                                                                                                                     .Aggregate<RoleData,
-                                                                                                                                       IEnumerable<string>>(new HashSet<
-                                                                                                                                                              string>(),
-                                                                                                                                                            (set,
-                                                                                                                                                             data) => set
-                                                                                                                                                              .Union(data
-                                                                                                                                                                       .Permissions))));
+    var projectionDoc = new BsonDocument("$project",
+                                         new BsonDocument
+                                         {
+                                           {
+                                             "Username", "$Username"
+                                           },
+                                           {
+                                             "Roles", "$Roles.RoleName"
+                                           },
+                                           {
+                                             "Permissions", new BsonDocument("$reduce",
+                                                                             new BsonDocument
+                                                                             {
+                                                                               {
+                                                                                 "input", "$Roles"
+                                                                               },
+                                                                               {
+                                                                                 "initialValue", new BsonArray()
+                                                                               },
+                                                                               {
+                                                                                 "in", new BsonDocument("$setUnion",
+                                                                                                        new BsonArray
+                                                                                                        {
+                                                                                                          "$$value",
+                                                                                                          "$$this.Permissions",
+                                                                                                        })
+                                                                               },
+                                                                             })
+                                           },
+                                         });
+    var projectionStage = new BsonDocumentPipelineStageDefinition<UserDataAfterLookup, MongoAuthResult>(projectionDoc);
     var pipeline = new IPipelineStageDefinition[]
                    {
                      lookup,

--- a/Adaptors/MongoDB/src/IMongoQueryableExt.cs
+++ b/Adaptors/MongoDB/src/IMongoQueryableExt.cs
@@ -29,8 +29,8 @@ namespace ArmoniK.Core.Adapters.MongoDB;
 
 internal static class IMongoQueryableExt
 {
-  public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this                     IMongoQueryable<T> queryable,
-                                                               [EnumeratorCancellation] CancellationToken  cancellationToken = default)
+  public static async IAsyncEnumerable<T> ToAsyncEnumerable<T>(this                     IQueryable<T>     queryable,
+                                                               [EnumeratorCancellation] CancellationToken cancellationToken = default)
   {
     var cursor = await queryable.ToCursorAsync(cancellationToken)
                                 .ConfigureAwait(false);
@@ -63,9 +63,9 @@ internal static class IMongoQueryableExt
   }
 
 
-  public static IOrderedMongoQueryable<T> OrderByList<T>(this IMongoQueryable<T>                   queryable,
-                                                         ICollection<Expression<Func<T, object?>>> orderFields,
-                                                         bool                                      ascOrder = true)
+  public static IOrderedQueryable<T> OrderByList<T>(this IQueryable<T>                        queryable,
+                                                    ICollection<Expression<Func<T, object?>>> orderFields,
+                                                    bool                                      ascOrder = true)
   {
     if (ascOrder)
     {

--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -59,9 +59,9 @@ internal class MongoDatabaseProvider : IDisposable
                   {
                     UseSingleNodeReplicaSet = useSingleNodeReplicaSet,
 #pragma warning disable CA2254 // log inputs should be constant
-                    StandardOuputLogger = showMongoLogs
-                                            ? line => logger.LogInformation(line)
-                                            : null,
+                    StandardOutputLogger = showMongoLogs
+                                             ? line => logger.LogInformation(line)
+                                             : null,
                     StandardErrorLogger = showMongoLogs
                                             ? line => logger.LogError(line)
                                             : null,

--- a/Common/tests/ArmoniK.Core.Common.Tests.csproj
+++ b/Common/tests/ArmoniK.Core.Common.Tests.csproj
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="EphemeralMongo6" Version="1.1.3" />
+    <PackageReference Include="EphemeralMongo" Version="3.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.24" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="NUnit" Version="4.4.0" />

--- a/Common/tests/Helpers/TestDatabaseProvider.cs
+++ b/Common/tests/Helpers/TestDatabaseProvider.cs
@@ -53,8 +53,8 @@ public class TestDatabaseProvider : IDisposable
   private const           string         DatabaseName   = "ArmoniK_TestDB";
   private static readonly ActivitySource ActivitySource = new("ArmoniK.Core.Common.Tests.TestPollsterProvider");
   public readonly         WebApplication App;
-  private readonly        IMongoClient   client_;
-  private readonly        IMongoRunner   runner_;
+
+  private readonly IMongoRunner runner_;
 
 
   public TestDatabaseProvider(Action<IServiceCollection>?    collectionConfigurator           = null,
@@ -69,8 +69,8 @@ public class TestDatabaseProvider : IDisposable
                   {
                     UseSingleNodeReplicaSet = useSingleNodeReplicaSet,
 #pragma warning disable CA2254 // log inputs should be constant
-                    StandardOuputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger = line => logger.LogError(line),
+                    StandardOutputLogger = line => logger.LogInformation(line),
+                    StandardErrorLogger  = line => logger.LogError(line),
 #pragma warning restore CA2254
                   };
 
@@ -96,7 +96,7 @@ public class TestDatabaseProvider : IDisposable
                                      };
     }
 
-    client_ = new MongoClient(settings);
+    var client = new MongoClient(settings);
 
     // Minimal set of configurations to operate on a toy DB
     Dictionary<string, string?> minimalConfig = new()
@@ -155,7 +155,7 @@ public class TestDatabaseProvider : IDisposable
                                                               Injection.Options.Submitter.SettingSection)
            .AddSingleton(loggerProvider.CreateLogger("root"))
            .AddSingleton(ActivitySource)
-           .AddSingleton(_ => client_);
+           .AddSingleton<IMongoClient>(client);
 
     if (validateGrpcRequests)
     {

--- a/Common/tests/Helpers/TestPollingAgentProvider.cs
+++ b/Common/tests/Helpers/TestPollingAgentProvider.cs
@@ -64,8 +64,8 @@ public class TestPollingAgentProvider : IDisposable
                   {
                     UseSingleNodeReplicaSet = false,
 #pragma warning disable CA2254 // log inputs should be constant
-                    StandardOuputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger = line => logger.LogError(line),
+                    StandardOutputLogger = line => logger.LogInformation(line),
+                    StandardErrorLogger  = line => logger.LogError(line),
 #pragma warning restore CA2254
                   };
 

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -60,13 +60,13 @@ public class TestPollsterProvider : IDisposable
   private const           string         DatabaseName   = "ArmoniK_TestDB";
   private static readonly ActivitySource ActivitySource = new("ArmoniK.Core.Common.Tests.TestPollsterProvider");
   private readonly        WebApplication app_;
-  private readonly        IMongoClient   client_;
 
   [SuppressMessage("Usage",
                    "CA2213: Disposable fields must be disposed")]
   public readonly ExceptionManager ExceptionManager;
 
-  private readonly TimeSpan?                graceDelay_;
+  private readonly TimeSpan? graceDelay_;
+
   public readonly  HealthCheckRecord        HealthCheckRecord;
   public readonly  IHostApplicationLifetime Lifetime;
   private readonly IObjectStorage           objectStorage_;
@@ -93,8 +93,8 @@ public class TestPollsterProvider : IDisposable
                   {
                     UseSingleNodeReplicaSet = false,
 #pragma warning disable CA2254 // log inputs should be constant
-                    StandardOuputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger = line => logger.LogError(line),
+                    StandardOutputLogger = line => logger.LogInformation(line),
+                    StandardErrorLogger  = line => logger.LogError(line),
 #pragma warning restore CA2254
                   };
 
@@ -105,7 +105,7 @@ public class TestPollsterProvider : IDisposable
     }
 
     runner_ = MongoRunner.Run(options);
-    client_ = new MongoClient(runner_.ConnectionString);
+    var client = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB
     Dictionary<string, string?> minimalConfig = new()
@@ -186,7 +186,7 @@ public class TestPollsterProvider : IDisposable
     builder.Services.AddMongoStorages(builder.Configuration,
                                       NullLogger.Instance)
            .AddSingleton(ActivitySource)
-           .AddSingleton(_ => client_)
+           .AddSingleton<IMongoClient>(client)
            .AddLogging()
            .AddSingleton<ISubmitter, gRPC.Services.Submitter>()
            .AddInitializedOption<Injection.Options.Submitter>(builder.Configuration,

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -56,19 +56,19 @@ public class TestTaskHandlerProvider : IDisposable
   private const           string            DatabaseName   = "ArmoniK_TestDB";
   private static readonly ActivitySource    ActivitySource = new("ArmoniK.Core.Common.Tests.TestTaskHandlerProvider");
   private readonly        WebApplication    app_;
-  private readonly        IMongoClient      client_;
   public readonly         HealthCheckRecord HealthCheckRecord;
   public readonly         ILogger           Logger;
-  private readonly        LoggerFactory     loggerFactory_;
-  private readonly        IObjectStorage    objectStorage_;
-  public readonly         IPartitionTable   PartitionTable;
-  public readonly         IPushQueueStorage PushQueueStorage;
-  public readonly         IResultTable      ResultTable;
-  private readonly        IMongoRunner      runner_;
-  public readonly         ISessionTable     SessionTable;
-  public readonly         ISubmitter        Submitter;
-  public readonly         TaskHandler       TaskHandler;
-  public readonly         ITaskTable        TaskTable;
+
+  private readonly LoggerFactory     loggerFactory_;
+  private readonly IObjectStorage    objectStorage_;
+  public readonly  IPartitionTable   PartitionTable;
+  public readonly  IPushQueueStorage PushQueueStorage;
+  public readonly  IResultTable      ResultTable;
+  private readonly IMongoRunner      runner_;
+  public readonly  ISessionTable     SessionTable;
+  public readonly  ISubmitter        Submitter;
+  public readonly  TaskHandler       TaskHandler;
+  public readonly  ITaskTable        TaskTable;
 
 
   public IHostApplicationLifetime Lifetime;
@@ -89,8 +89,8 @@ public class TestTaskHandlerProvider : IDisposable
                   {
                     UseSingleNodeReplicaSet = false,
 #pragma warning disable CA2254 // log inputs should be constant
-                    StandardOuputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger = line => logger.LogError(line),
+                    StandardOutputLogger = line => logger.LogInformation(line),
+                    StandardErrorLogger  = line => logger.LogError(line),
 #pragma warning restore CA2254
                   };
 
@@ -101,7 +101,7 @@ public class TestTaskHandlerProvider : IDisposable
     }
 
     runner_ = MongoRunner.Run(options);
-    client_ = new MongoClient(runner_.ConnectionString);
+    var client = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB
     Dictionary<string, string?> minimalConfig = new()
@@ -167,7 +167,7 @@ public class TestTaskHandlerProvider : IDisposable
     builder.Services.AddMongoStorages(builder.Configuration,
                                       logger)
            .AddSingleton(ActivitySource)
-           .AddSingleton(_ => client_)
+           .AddSingleton<IMongoClient>(client)
            .AddLogging()
            .AddSingleton(loggerFactory_.CreateLogger(nameof(TestTaskHandlerProvider)))
            .AddSingleton<ISubmitter, gRPC.Services.Submitter>()

--- a/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
+++ b/ProfilingTools/src/ArmoniK.Core.ProfilingTools.csproj
@@ -31,7 +31,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="8.1.0" />
-    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="1.5.0" />
+    <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageReference Include="OpenTelemetry" Version="1.15.3" />
   </ItemGroup>
 

--- a/ProfilingTools/src/OpenTelemetryExporter/MongoExporter.cs
+++ b/ProfilingTools/src/OpenTelemetryExporter/MongoExporter.cs
@@ -74,5 +74,8 @@ internal class MongoExporter : BaseExporter<Activity>
 
   /// <inheritdoc />
   protected override void Dispose(bool disposing)
-    => session_.Dispose();
+  {
+    session_.Dispose();
+    client_.Dispose();
+  }
 }


### PR DESCRIPTION
# Motivation

MongoDB.Driver 2.x ships a transitive dependency on `Snappier` with a known vulnerability. Upgrading to 3.x resolves this and picks up the LINQ v3 provider with improved query translation. `SharpCompress` `IArchive.WriteToDirectory()` is not used by the driver : https://github.com/mongodb/mongo-csharp-driver/releases/tag/v3.8.1

# Description

Upgrades `MongoDB.Driver` from 2.30.0 to 3.8.1 and resolves all breaking changes introduced in the major version bump.

**Package changes:**
- `MongoDB.Driver` 2.30.0 → 3.8.1
- `MongoDB.Driver.Core.Extensions.DiagnosticSources` 1.5.0 → 3.0.0 (both in the adapter and ProfilingTools projects)
- `EphemeralMongo6` 1.1.3 → `EphemeralMongo` 3.2.0 in Common tests (the v6 package references `MongoDB.Driver.Core` as a separate assembly which no longer exists in v3.x)

**Breaking change fixes:**
- `IMongoQueryableExt`: replace removed `IMongoQueryable<T>` / `IOrderedMongoQueryable<T>` with `IQueryable<T>` / `IOrderedQueryable<T>`
- `AuthenticationTable`: LINQ v3 cannot translate the `HashSet` + `Union` + `Aggregate` expression used in the `$project` stage — replaced with a `BsonDocumentPipelineStageDefinition`. The projection no longer explicitly maps `_id → Id`; the `BsonClassMap` registered for `MongoAuthResult` already handles that mapping, and suppressing `_id` in the projection caused a deserialization error (`Required element '_id' ... is missing`)
- `MongoExporter`: `IMongoClient` is now `IDisposable` in v3.x; added `client_.Dispose()` in the `Dispose` override
- Five test helpers: `StandardOuputLogger` (typo) renamed to `StandardOutputLogger` in EphemeralMongo 3.x; updated all call sites
- Three test helpers: `IMongoClient` is now `IDisposable`; instead of suppressing CA2213, the client is now created as a local variable and registered via `AddSingleton<IMongoClient>(client)` so the DI container fully owns and disposes it

# Testing

All 307 MongoDB adapter tests pass, including the full authentication test suite (`GetIdentityFromCnAndFingerprintShouldSucceed/Fail`, `GetIdentityFromIdShouldSucceed`, `GetIdentityFromNameShouldSucceed`, `UserHasAllClaimsOfItsRoles`, `UserHasClaimShouldMatch`, `UserHasRoleShouldMatch`).

# Impact

- Removes the `Snappier` vulnerability warning from builds.
- MongoDB.Driver 3.x defaults to LINQ v3, which is stricter about expression translation — any future query additions should be tested against LINQ v3 behaviour.
- No configuration or API surface changes visible to callers.

# Additional Information

EphemeralMongo requires a working `mongod` binary at test time. Set `EphemeralMongo__BinaryDirectory` to point to a compatible binary if the bundled one is unavailable (e.g. missing `libcrypto.so.1.1` on newer distros).