### PR TITLE
build: enable .NET analyzers with recommended analysis mode

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <AnalysisLevel>latest</AnalysisLevel>
+    <AnalysisMode>Recommended</AnalysisMode>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
# Motivation

Enable .NET source code analyzers project-wide to catch potential issues at build time and enforce consistent code quality standards.

# Description

Adds a `Directory.Build.props` file at the repository root that enables .NET analyzers for all projects in the solution with the following settings:

- `EnableNETAnalyzers`: enables the built-in .NET platform analyzers
- `AnalysisLevel`: set to `latest` to use the most recent ruleset
- `AnalysisMode`: set to `Recommended` to apply the recommended subset of rules without being overly strict

# Testing

No functional code changes — this only affects build-time analysis. Existing CI test runs will validate that the solution still builds cleanly with analyzers enabled.

# Impact

- Build-time warnings may appear for code patterns flagged by the recommended ruleset; these will need to be addressed in follow-up PRs.
- No runtime behaviour changes.
- No new dependencies.

# Additional Information

Using `AnalysisMode=Recommended` (rather than `All`) keeps the signal-to-noise ratio manageable as a starting point.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.