### PR TITLE
ci: remove pip install awscli from workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,10 +63,6 @@ jobs:
         repository: ${{ env.REPOSITORY }}
         ref: ${{ env.REFERENCE }}
 
-    - name: Install AWSCLI (the one in the Github runner does not work)
-      run: |
-        pip install awscli
-     
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
       with:
@@ -155,10 +151,6 @@ jobs:
         repository: ${{ env.REPOSITORY }}
         ref: ${{ env.REFERENCE }}
 
-    - name: Install AWSCLI (the one in the Github runner does not work)
-      run: |
-        pip install awscli
-   
     - name: Setup Terraform
       uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
       with:
@@ -416,10 +408,6 @@ jobs:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
 
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
-
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
         with:
@@ -561,10 +549,6 @@ jobs:
         with:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
-
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
 
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
@@ -930,10 +914,6 @@ jobs:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
 
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
-
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
         with:
@@ -1042,10 +1022,6 @@ jobs:
         with:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
-
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
 
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
@@ -1184,10 +1160,6 @@ jobs:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
 
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
-
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
         with:
@@ -1273,10 +1245,6 @@ jobs:
         with:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
-
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
 
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
@@ -1367,10 +1335,6 @@ jobs:
         with:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
-
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
 
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2

--- a/.github/workflows/manual-test.yml
+++ b/.github/workflows/manual-test.yml
@@ -25,10 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
-
       - name: Setup just
         uses: taiki-e/install-action@213ccc1a076163c093f914550b94feb90fab916d # v2
         with:
@@ -91,10 +87,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-
-      - name: Install AWSCLI (the one in the Github runner does not work)
-        run: |
-          pip install awscli
 
       - name: Setup just
         run: |


### PR DESCRIPTION
# Motivation

The AWS CLI (`awscli`) is pre-installed on GitHub-hosted `ubuntu-latest` runners, making the explicit `pip install awscli` step redundant. These steps also included an outdated comment stating *"the one in the Github runner does not work"*, which is no longer accurate.

# Description

Removed 11 occurrences of the `Install AWSCLI` step across two workflow files:
- `.github/workflows/build.yml` (9 occurrences)
- `.github/workflows/manual-test.yml` (2 occurrences)

# Testing

No functional change — the AWS CLI is still available on the runners via the pre-installed version. Existing workflow steps that call `aws` (e.g. `aws s3 cp`) are unaffected.

# Impact

Marginally faster CI runs (no `pip install` step per job). No behaviour change.

# Additional Information

No additional information.
