### PR TITLE
ci: remove redundant pip install requests steps from remove-artefacts workflow

### DIFF
--- a/.github/workflows/remove-artefacts.yml
+++ b/.github/workflows/remove-artefacts.yml
@@ -29,9 +29,6 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
 
-    - name: Install dependencies
-      run: pip install requests
-
     - name: Remove old branch images
       uses: aneoconsulting/ArmoniK.Actions.CleanupArtifacts/remove-images@40131ac01ff60baea9e02612ced7ac9b69916a3d # main
       with:
@@ -53,9 +50,6 @@ jobs:
 
     - name: Set up Python
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
-
-    - name: Install dependencies
-      run: pip install requests
 
     - name: Unlist old branch nugets
       uses: aneoconsulting/ArmoniK.Actions.CleanupArtifacts/unlist-nugets@40131ac01ff60baea9e02612ced7ac9b69916a3d # main


### PR DESCRIPTION
# Motivation

The `pip install requests` steps in the remove-artefacts workflow are no longer needed because the actions (`ArmoniK.Actions.CleanupArtifacts/remove-images` and `ArmoniK.Actions.CleanupArtifacts/unlist-nugets`) now handle the dependency installation themselves.

# Description

Removes the two `pip install requests` steps from the `remove-artefacts.yml` workflow — one from the job that removes old branch images and one from the job that unlists old branch NuGet packages.

# Testing

No code changes; the actions themselves handle the dependency. The workflow will continue to function as before.

# Impact

Slightly faster workflow runs by eliminating a redundant pip install step in each job.

# Additional Information

N/A

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.