### PR TITLE
ci(release): scope contents:write permission to versionning job only

### DIFF
--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -1,8 +1,5 @@
 name: Release
 
-permissions:
-  contents: write
-
 on:
   push:
     tags:
@@ -11,6 +8,8 @@ on:
 jobs:
   versionning:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       version: ${{ steps.snapshot.outputs.version }}
       release: ${{ steps.release.outputs.version }}


### PR DESCRIPTION
# Motivation

The `contents: write` permission was declared at the workflow level in `make-release.yml`, granting write access to all three jobs. Only the `versionning` job actually needs it (to delete an invalid tag on failure via `git push origin -d`). The `images` and `publish-nuget` jobs push to Docker Hub and NuGet respectively — neither touches the GitHub repo contents.

# Description

Moves the `contents: write` permission from the workflow level to the `versionning` job, following the principle of least privilege. The `images` and `publish-nuget` jobs now fall back to the default read-only access.

# Testing

No functional change — the `versionning` job retains the write permission it needs. CI behaviour is unchanged.

# Impact

Slight security improvement: a compromised step in `images` or `publish-nuget` can no longer write to the repository.
