### PR TITLE
fix(tests): use dynamic port in TestPollsterProvider to avoid address conflicts

### DIFF
--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -178,6 +178,8 @@ public class TestPollsterProvider : IDisposable
 
     var builder = WebApplication.CreateBuilder();
 
+    builder.WebHost.UseUrls("http://127.0.0.1:0");
+
     builder.Configuration.AddInMemoryCollection(minimalConfig);
 
     builder.Logging.ClearProviders();

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -42,6 +42,7 @@ using ArmoniK.Core.Utils;
 using EphemeralMongo;
 
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;


### PR DESCRIPTION
# Motivation

`TestPollsterProvider` builds a `WebApplication` that defaults to binding on `http://127.0.0.1:5000`. When multiple tests using this helper run in parallel, they race to bind the same port, causing `System.IO.IOException: Failed to bind to address http://127.0.0.1:5000: address already in use` and intermittent CI failures (e.g. `ExecuteTaskTimeoutAcquire`).

# Description

Added `builder.WebHost.UseUrls("http://127.0.0.1:0")` in `TestPollsterProvider` constructor, before the app is built. Port `0` instructs the OS to assign a free ephemeral port, eliminating the collision. Tests only consume services from the DI container, so the actual port number is irrelevant.

# Testing

- Ran `ExecuteTaskTimeoutAcquire` locally — passes consistently.
- No new tests needed; the fix removes a flaky infrastructure issue rather than changing logic.

# Impact

No impact on production code. Only the test helper is affected. Tests that previously flaked due to port contention will now reliably bind to distinct OS-assigned ports.

# Additional Information

The same pattern (`UseUrls("http://127.0.0.1:0")`) may be worth applying to `TestPollingAgentProvider` and `TestTaskHandlerProvider` if they also use `WebApplication.CreateBuilder()` without an explicit port.
