### PR TITLE
fix(tests): use ConcurrentDictionary in ForwardingLogger to prevent race condition

### DIFF
--- a/Common/tests/Helpers/ForwardingLoggerProvider.cs
+++ b/Common/tests/Helpers/ForwardingLoggerProvider.cs
@@ -16,7 +16,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 
 using ArmoniK.Utils;
 
@@ -48,16 +50,16 @@ internal class ForwardingLoggerProvider : ILoggerProvider
 
   internal class ForwardingLogger : ILogger
   {
-    private readonly string                           categoryName_;
-    private readonly LogMessage                       logAction_;
-    private readonly List<Dictionary<string, object>> states_;
+    private readonly string                                                 categoryName_;
+    private readonly LogMessage                                             logAction_;
+    private readonly ConcurrentDictionary<Dictionary<string, object>, byte> states_;
 
     public ForwardingLogger(string     categoryName,
                             LogMessage logAction)
     {
       categoryName_ = categoryName;
       logAction_    = logAction;
-      states_       = new List<Dictionary<string, object>>();
+      states_       = new ConcurrentDictionary<Dictionary<string, object>, byte>(ReferenceEqualityComparer.Instance);
     }
 
     public bool IsEnabled(LogLevel logLevel)
@@ -73,11 +75,11 @@ internal class ForwardingLoggerProvider : ILoggerProvider
                             });
       }
 
-      states_.Add(d);
-      return new Deferrer(() =>
-                          {
-                            states_.Remove(d);
-                          });
+      states_.TryAdd(d,
+                     0);
+
+      return new Deferrer(() => states_.TryRemove(d,
+                                                  out _));
     }
 
     public void Log<TState>(LogLevel                         logLevel,
@@ -90,7 +92,7 @@ internal class ForwardingLoggerProvider : ILoggerProvider
                     eventId,
                     formatter(state,
                               exception),
-                    states_.ToArray(),
+                    states_.Keys.ToArray(),
                     exception);
   }
 }


### PR DESCRIPTION
# Motivation

`ForwardingLogger` (used by `ConsoleForwardingLoggerProvider` in test helpers) tracked active log scopes in a plain `List<Dictionary<string, object>>`. This list was accessed concurrently from multiple threads without synchronization, causing a data race that manifested as `NullReferenceException` in the `LoopCheckOtherAgent` test.

The race: `TaskHandler.ReleaseTaskHandler()` starts a background `Task.Run` that opens a log scope (adding to `states_`) and later disposes it (removing from `states_`). Concurrently, a second call to `TaskHandler.DisposeAsync()` — triggered by the DI container during `app_` disposal in `TestTaskHandlerProvider.Dispose()` — logs a debug message, calling `states_.ToArray()`. The concurrent `List<T>.Remove` (which nulls out the vacated slot for GC) and `List<T>.ToArray` (which copies by size) produced a `null` entry in the snapshot, causing `states.SelectMany(objects => objects.AsEnumerable())` to throw when iterating over the null element.

# Description

Replace `List<Dictionary<string, object>>` in `ForwardingLogger.states_` with `ConcurrentDictionary<Dictionary<string, object>, byte>` using `ReferenceEqualityComparer.Instance`.

- `TryAdd(d, 0)` replaces `Add(d)` in `BeginScope`
- `TryRemove(d, out _)` replaces `Remove(d)` in the scope-disposal `Deferrer`
- `states_.Keys.ToArray()` replaces `states_.ToArray()` in `Log` — `ConcurrentDictionary` snapshot is safe under concurrent modification

`ReferenceEqualityComparer` ensures the exact same `Dictionary` instance added on scope-open is the one removed on scope-close, regardless of dictionary contents.

# Testing

No new tests added — this fix resolves an existing flaky test (`TaskHandlerTest.LoopCheckOtherAgent`) that was failing with:

```
System.AggregateException : An error occurred while writing to logger(s). (Object reference not set to an instance of an object.)
  ----> System.NullReferenceException
     at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
     at ArmoniK.Core.Common.Tests.Helpers.ConsoleForwardingLoggerProvider.<>c__DisplayClass1_0.<.ctor>b__0(...)
     at ArmoniK.Core.Common.Tests.Helpers.ForwardingLoggerProvider.ForwardingLogger.Log[TState](...)
```

# Impact

Test-only change. No production code is modified. No new dependencies introduced (`System.Collections.Concurrent` is part of the BCL).

# Additional Information

The `ForwardingLoggerProvider` is used across multiple test helpers (`TestTaskHandlerProvider`, `GrpcSubmitterServiceHelper`, `SimpleAmqpClient`, etc.). All benefit from this fix since they share the same logger infrastructure.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.