### PR TITLE
fix: use async methods to resolve SonarQube S6966 issues

### DIFF
--- a/Adaptors/MongoDB/src/Common/SessionProvider.cs
+++ b/Adaptors/MongoDB/src/Common/SessionProvider.cs
@@ -37,8 +37,11 @@ namespace ArmoniK.Core.Adapters.MongoDB.Common;
 /// </summary>
 public class SessionProvider : IInitializable
 {
-  private readonly IMongoClient          client_;
-  private readonly object                lockObj_ = new();
+  private readonly IMongoClient client_;
+
+  private readonly SemaphoreSlim initSemaphore_ = new(1,
+                                                      1);
+
   private readonly Options.MongoDB       options_;
   private          IClientSessionHandle? clientSessionHandle_;
 
@@ -89,13 +92,20 @@ public class SessionProvider : IInitializable
       return;
     }
 
-    lock (lockObj_)
+    await initSemaphore_.WaitAsync(cancellationToken)
+                        .ConfigureAwait(false);
+    try
     {
-      clientSessionHandle_ ??= client_.StartSession(new ClientSessionOptions
-                                                    {
-                                                      CausalConsistency = options_.CausalConsistency,
-                                                    },
-                                                    cancellationToken);
+      clientSessionHandle_ ??= await client_.StartSessionAsync(new ClientSessionOptions
+                                                               {
+                                                                 CausalConsistency = options_.CausalConsistency,
+                                                               },
+                                                               cancellationToken)
+                                            .ConfigureAwait(false);
+    }
+    finally
+    {
+      initSemaphore_.Release();
     }
 
     // Force cluster topology discovery to complete so that the liveness check (which inspects

--- a/Adaptors/Nats/src/Heart.cs
+++ b/Adaptors/Nats/src/Heart.cs
@@ -59,7 +59,7 @@ public class Heart
   /// <returns>A task finishing with the last heartbeat</returns>
   public async Task Stop()
   {
-    stoppedHeartCts_?.Cancel();
+    await (stoppedHeartCts_?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false);
     try
     {
       if (runningTask_ is not null)

--- a/Adaptors/PubSub/src/Heart.cs
+++ b/Adaptors/PubSub/src/Heart.cs
@@ -59,7 +59,7 @@ public class Heart
   /// <returns>A task finishing with the last heartbeat</returns>
   public async Task Stop()
   {
-    stoppedHeartCts_?.Cancel();
+    await (stoppedHeartCts_?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false);
     try
     {
       if (runningTask_ is not null)

--- a/Adaptors/SQS/src/Heart.cs
+++ b/Adaptors/SQS/src/Heart.cs
@@ -59,7 +59,7 @@ public class Heart
   /// <returns>A task finishing with the last heartbeat</returns>
   public async Task Stop()
   {
-    stoppedHeartCts_?.Cancel();
+    await (stoppedHeartCts_?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false);
     try
     {
       if (runningTask_ != null)

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -285,7 +285,8 @@ public static class Program
     }
     finally
     {
-      Log.CloseAndFlush();
+      await Log.CloseAndFlushAsync()
+               .ConfigureAwait(false);
     }
   }
 }

--- a/Tests/Bench/Server/src/Program.cs
+++ b/Tests/Bench/Server/src/Program.cs
@@ -18,5 +18,5 @@
 using ArmoniK.Api.Worker.Utils;
 using ArmoniK.Samples.Bench.Server;
 
-WorkerServer.Create<BenchComputerService>()
-            .Run();
+await WorkerServer.Create<BenchComputerService>()
+                  .RunAsync();

--- a/Tests/Common/Client/src/GrpcChannelExt.cs
+++ b/Tests/Common/Client/src/GrpcChannelExt.cs
@@ -153,15 +153,15 @@ public static class GrpcChannelExt
 
     foreach (var agg in taskAggregation)
     {
-      var result2Task = resultClient.GetOwnerTaskId(new GetOwnerTaskIdRequest
-                                                    {
-                                                      ResultId =
-                                                      {
-                                                        agg.DataDependencies,
-                                                      },
-                                                      SessionId = sessionId,
-                                                    })
-                                    .ResultTask.Select(m => m.TaskId);
+      var result2Task = (await resultClient.GetOwnerTaskIdAsync(new GetOwnerTaskIdRequest
+                                                                {
+                                                                  ResultId =
+                                                                  {
+                                                                    agg.DataDependencies,
+                                                                  },
+                                                                  SessionId = sessionId,
+                                                                })
+                                           .ConfigureAwait(false)).ResultTask.Select(m => m.TaskId);
 
       var lastDependencyFinished = taskDependencies.Where(pair => result2Task.Contains(pair.Key) && pair.Value.EndedAt is not null)
                                                    .Select(pair => pair.Value)

--- a/Tests/CrashingWorker/Server/src/Program.cs
+++ b/Tests/CrashingWorker/Server/src/Program.cs
@@ -18,5 +18,5 @@
 using ArmoniK.Api.Worker.Utils;
 using ArmoniK.Samples.CrashingWorker.Server;
 
-WorkerServer.Create<CrashingService>()
-            .Run();
+await WorkerServer.Create<CrashingService>()
+                  .RunAsync();

--- a/Tests/HtcMock/Server/src/Program.cs
+++ b/Tests/HtcMock/Server/src/Program.cs
@@ -18,5 +18,5 @@
 using ArmoniK.Api.Worker.Utils;
 using ArmoniK.Samples.HtcMock.Server;
 
-WorkerServer.Create<SampleComputerService>()
-            .Run();
+await WorkerServer.Create<SampleComputerService>()
+                  .RunAsync();

--- a/Tests/Stream/Server/Program.cs
+++ b/Tests/Stream/Server/Program.cs
@@ -18,5 +18,5 @@
 using ArmoniK.Api.Worker.Utils;
 using ArmoniK.Extensions.Common.StreamWrapper.Tests.Server;
 
-WorkerServer.Create<WorkerService>()
-            .Run();
+await WorkerServer.Create<WorkerService>()
+                  .RunAsync();


### PR DESCRIPTION
# Motivation

SonarQube rule S6966 flags synchronous method calls where an awaitable async counterpart exists. These 10 violations were identified across adapters, services, and test workers and should be fixed to improve reliability and avoid potential deadlocks.

# Description

Replaced synchronous calls with their async equivalents across 10 files:

- **`Adaptors/MongoDB/src/Common/SessionProvider.cs`**: Replaced `lock` + `client_.StartSession(...)` with `SemaphoreSlim` + `await client_.StartSessionAsync(...)`. A plain `lock` cannot contain `await`, so the locking primitive was also migrated to `SemaphoreSlim`.
- **`Adaptors/Nats/src/Heart.cs`**, **`Adaptors/PubSub/src/Heart.cs`**, **`Adaptors/SQS/src/Heart.cs`**: Replaced `stoppedHeartCts_?.Cancel()` with `await (stoppedHeartCts_?.CancelAsync() ?? Task.CompletedTask)`.
- **`Control/Submitter/src/Program.cs`**: Replaced `Log.CloseAndFlush()` with `await Log.CloseAndFlushAsync()`.
- **`Tests/Bench/Server/src/Program.cs`**, **`Tests/CrashingWorker/Server/src/Program.cs`**, **`Tests/HtcMock/Server/src/Program.cs`**, **`Tests/Stream/Server/Program.cs`**: Replaced `WorkerServer.Create<T>().Run()` with `await WorkerServer.Create<T>().RunAsync()`.
- **`Tests/Common/Client/src/GrpcChannelExt.cs`**: Replaced `resultClient.GetOwnerTaskId(...)` with `await resultClient.GetOwnerTaskIdAsync(...)`.

# Testing

All 10 affected projects build successfully. No new tests were added as these are straightforward async API migrations with no logic changes.

# Impact

No behavioral change is expected. The async variants are equivalent to their synchronous counterparts but avoid thread-pool starvation and potential deadlocks in async contexts. The MongoDB change also makes the session initialization correctly async end-to-end.

# Additional Information

All 10 issues were retrieved directly from SonarQube (rule `csharpsquid:S6966`, project `aneoconsulting_ArmoniK.Core`).

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.