### PR TITLE
fix(options): use IReadOnlyCollection for public fields in InitDatabase

### DIFF
--- a/Common/src/Injection/Options/Database/InitDatabase.cs
+++ b/Common/src/Injection/Options/Database/InitDatabase.cs
@@ -30,32 +30,6 @@ namespace ArmoniK.Core.Common.Injection.Options.Database;
 public class InitDatabase
 {
   /// <summary>
-  ///   Collection of data to insert in the database for Authentication during ArmoniK initialization
-  /// </summary>
-  public readonly IReadOnlyCollection<AuthData> Auths;
-
-  /// <summary>
-  ///   Whether to init the database
-  /// </summary>
-  public readonly bool Init;
-
-  /// <summary>
-  ///   Collection of data to insert in the database for Partitions during ArmoniK initialization
-  /// </summary>
-  public readonly IReadOnlyCollection<PartitionData> Partitions;
-
-  /// <summary>
-  ///   Collection of data to insert in the database for Roles during ArmoniK initialization
-  /// </summary>
-  public readonly IReadOnlyCollection<RoleData> Roles;
-
-  /// <summary>
-  ///   Collection of data to insert in the database for Users during ArmoniK initialization
-  /// </summary>
-  public readonly IReadOnlyCollection<UserData> Users;
-
-
-  /// <summary>
   ///   Instantiate <see cref="InitDatabase" /> from the configurations received from the Dependency Injection
   /// </summary>
   /// <param name="initServices">Data structure containing the raw data</param>
@@ -105,4 +79,29 @@ public class InitDatabase
                                                                     new PodConfiguration(partition.PodConfiguration)))
                              .ToList();
   }
+
+  /// <summary>
+  ///   Whether to init the database
+  /// </summary>
+  public bool Init { get; init; }
+
+  /// <summary>
+  ///   Collection of data to insert in the database for Partitions during ArmoniK initialization
+  /// </summary>
+  public IReadOnlyCollection<PartitionData> Partitions { get; init; }
+
+  /// <summary>
+  ///   Collection of data to insert in the database for Roles during ArmoniK initialization
+  /// </summary>
+  public IReadOnlyCollection<RoleData> Roles { get; init; }
+
+  /// <summary>
+  ///   Collection of data to insert in the database for Users during ArmoniK initialization
+  /// </summary>
+  public IReadOnlyCollection<UserData> Users { get; init; }
+
+  /// <summary>
+  ///   Collection of data to insert in the database for Authentication during ArmoniK initialization
+  /// </summary>
+  public IReadOnlyCollection<AuthData> Auths { get; init; }
 }

--- a/Common/src/Injection/Options/Database/InitDatabase.cs
+++ b/Common/src/Injection/Options/Database/InitDatabase.cs
@@ -20,7 +20,6 @@ using System.Linq;
 
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Storage;
-using ArmoniK.Utils;
 
 namespace ArmoniK.Core.Common.Injection.Options.Database;
 
@@ -33,7 +32,7 @@ public class InitDatabase
   /// <summary>
   ///   Collection of data to insert in the database for Authentication during ArmoniK initialization
   /// </summary>
-  public readonly ICollection<AuthData> Auths;
+  public readonly IReadOnlyCollection<AuthData> Auths;
 
   /// <summary>
   ///   Whether to init the database
@@ -43,17 +42,17 @@ public class InitDatabase
   /// <summary>
   ///   Collection of data to insert in the database for Partitions during ArmoniK initialization
   /// </summary>
-  public readonly ICollection<PartitionData> Partitions;
+  public readonly IReadOnlyCollection<PartitionData> Partitions;
 
   /// <summary>
   ///   Collection of data to insert in the database for Roles during ArmoniK initialization
   /// </summary>
-  public readonly ICollection<RoleData> Roles;
+  public readonly IReadOnlyCollection<RoleData> Roles;
 
   /// <summary>
   ///   Collection of data to insert in the database for Users during ArmoniK initialization
   /// </summary>
-  public readonly ICollection<UserData> Users;
+  public readonly IReadOnlyCollection<UserData> Users;
 
 
   /// <summary>
@@ -70,7 +69,7 @@ public class InitDatabase
                                  i) => new RoleData(i,
                                                     role.Name,
                                                     role.Permissions.ToArray()))
-                        .AsICollection();
+                        .ToList();
 
     var roleDic = Roles.ToDictionary(data => data.RoleName,
                                      data => data.RoleId);
@@ -82,7 +81,7 @@ public class InitDatabase
                                                     user.Name,
                                                     user.Roles.Select(roleName => roleDic[roleName])
                                                         .ToArray()))
-                        .AsICollection();
+                        .ToList();
 
     var userDic = Users.ToDictionary(data => data.Username,
                                      data => data.UserId);
@@ -94,7 +93,7 @@ public class InitDatabase
                                                     userDic[certificate.User],
                                                     certificate.Cn,
                                                     certificate.Fingerprint))
-                        .AsICollection();
+                        .ToList();
 
     Partitions = initServices.Partitioning.Partitions.Select(Partition.FromJson)
                              .Select(partition => new PartitionData(partition.PartitionId,
@@ -104,6 +103,6 @@ public class InitDatabase
                                                                     partition.PreemptionPercentage,
                                                                     partition.Priority,
                                                                     new PodConfiguration(partition.PodConfiguration)))
-                             .AsICollection();
+                             .ToList();
   }
 }


### PR DESCRIPTION
# Motivation

SonarQube rule csharpsquid:S3887 flags non-private `readonly` fields that expose a mutable collection type (`ICollection<T>`). Even though the field reference itself cannot be reassigned, callers can still call `Add()`, `Remove()`, etc. on the collection, undermining the intent of `readonly`.

# Description

In `Common/src/Injection/Options/Database/InitDatabase.cs`, the four public `readonly` fields (`Auths`, `Partitions`, `Roles`, `Users`) were declared as `ICollection<T>`. This resolves all four S3887 issues (keys `AZhf4x7ieH5Prju62F73`–`76`):

- Converted the four public `readonly` fields to `{ get; init; }` init-only properties typed as `IReadOnlyCollection<T>`, which satisfies both S3887 and the style linter.
- Replaced `.AsICollection()` with `.ToList()` at the end of each LINQ chain — `List<T>` implements `IReadOnlyCollection<T>` directly.
- Removed the now-unused `using ArmoniK.Utils;` import.

All callers only read from these collections (`.Any()`, `.Select()`, `.Count`), so the narrower interface is non-breaking.

# Testing

No new tests required. Existing unit tests in `Common/tests/` cover `InitDatabase` construction and the downstream MongoDB mapping code that consumes these fields. Build verified locally with `dotnet build`.

# Impact

No behaviour change. The concrete runtime type (`List<T>`) is unchanged; only the declared interface type is narrowed and the members are now properties instead of fields. No configuration or dependency changes.

# Additional Information

All four S3887 issues were in the same file and had the same root cause, so they are fixed together.