### PR TITLE
fix(pollster): handle null taskData_ in catch blocks of ReleaseTaskHandler

### DIFF
--- a/Common/src/Pollster/TaskHandler.cs
+++ b/Common/src/Pollster/TaskHandler.cs
@@ -361,14 +361,14 @@ public sealed class TaskHandler : IAsyncDisposable
                      catch (OperationCanceledException)
                      {
                        logger_.LogDebug("Agent stopping: MessageHandler for {Task} is released with status {Status}",
-                                        taskData_.TaskId,
+                                        taskData_?.TaskId ?? "",
                                         messageHandler_.Status);
                      }
                      catch (Exception ex)
                      {
                        logger_.LogError(ex,
                                         "Error while checking other pod for {Task}: MessageHandler is released with status {Status}",
-                                        taskData_.TaskId,
+                                        taskData_?.TaskId ?? "",
                                         messageHandler_.Status);
                      }
                      finally


### PR DESCRIPTION
# Motivation

SonarQube rule `csharpsquid:S2259` flagged two potential `NullReferenceException` in `TaskHandler.cs`. The field `taskData_` is nullable and can be `null` when `ReleaseTaskHandler` is called before task data is acquired. In the `catch` blocks of the delayed release background task, `taskData_.TaskId` was accessed unconditionally.

# Description

In `Common/src/Pollster/TaskHandler.cs`, the `ReleaseTaskHandler` method spawns a background `Task` to delay message handler release. Inside the `catch (OperationCanceledException)` and `catch (Exception)` blocks, `taskData_.TaskId` was used directly without a null check, which could throw a `NullReferenceException` if `taskData_` is `null`.

Changed both occurrences to `taskData_?.TaskId ?? ""` to match the existing pattern used elsewhere in the same method (e.g. `taskData_?.SessionId ?? ""`).

Fixes SonarQube issues:
- `AZcTURahdf4-yBS6R6Vo` (line 364)
- `AZcTURahdf4-yBS6R6Vn` (line 371)

# Testing

No new tests added — the change is a null-safety guard in a log statement within a catch block. The fix aligns with the existing pattern already applied on line 340 of the same file.

# Impact

No behavioural change. If `taskData_` is null, the task ID in the log message will appear as an empty string instead of throwing an exception.

# Additional Information

The pattern `taskData_?.SessionId ?? ""` was already used at line 340 in the same lambda, confirming this is the established convention in this file.