### PR TITLE
docs: mark Artemis adapter as abandoned

### DIFF
--- a/.docs/content/1.concepts/4.adaptors.md
+++ b/.docs/content/1.concepts/4.adaptors.md
@@ -34,7 +34,7 @@ Core components have two primary tasks when interacting with the queue: pushing 
 Pre-included queue adaptors are also available such as:
 
 - `ArmoniK.Core.Adapters.Amqp` provides an AMQP connector for ArmoniK.
-It allows using any AMQP server such as ActiveMQ, ActiveMQ Artemis, RabbitMQ or IBM MQ
+It allows using any AMQP 1.0 compatible server such as ActiveMQ or IBM MQ
 - `ArmoniK.Core.Adapters.RabbitMQ` provides a dedicated adaptor for RabbitMQ.
 It uses RabbitMQ native client that supports priorities better than the AMQ protocol in our AMQP adaptor.
 

--- a/.docs/content/1.concepts/4.adaptors.md
+++ b/.docs/content/1.concepts/4.adaptors.md
@@ -34,16 +34,12 @@ Core components have two primary tasks when interacting with the queue: pushing 
 Pre-included queue adaptors are also available such as:
 
 - `ArmoniK.Core.Adapters.Amqp` provides an AMQP connector for ArmoniK.
-It allows using any AMQP 1.0 compatible server such as ActiveMQ or IBM MQ
-- `ArmoniK.Core.Adapters.RabbitMQ` provides a dedicated adaptor for RabbitMQ.
-It uses RabbitMQ native client that supports priorities better than the AMQ protocol in our AMQP adaptor.
-
+It allows using any AMQP 1.0 compatible server such as ActiveMQ, RabbitMQ or IBM MQ
 - `ArmoniK.Core.Adapters.Nats` provides an Nats Jets Stream connector for ArmoniK. It allows using a Nats server.
 
 Other adaptors for queue may also be available:
 
 - `ArmoniK.Core.Adapters.SQS` AmazonSQS (supports priority)
-
 - `ArmoniK.Core.Adapters.PubSub` GCP Pub/Sub
 
 ## Object Storage Adaptors

--- a/.docs/content/2.dependencies/1.artemis.md
+++ b/.docs/content/2.dependencies/1.artemis.md
@@ -1,6 +1,6 @@
 # Artemis
 
-> **Status: abandoned** — The Artemis adapter is not actively supported. The issues described below are unresolved and there is no planned fix. Use a supported queue adapter instead: [ActiveMQ, RabbitMQ, NATS, SQS, Pub/Sub](../1.concepts/4.adaptors.md).
+> **Status: abandoned** — ActiveMQ Artemis is no longer a supported queue target. The issues described below are unresolved and there is no planned fix. Use [a supported queue adapter](../1.concepts/4.adaptors.md) (ActiveMQ, RabbitMQ, NATS, SQS, or Pub/Sub) instead.
 
 [Apache ActiveMQ Artemis](https://activemq.apache.org/components/artemis/) is a message broker that can be used as a queue in ArmoniK.
 We deployed an instance of artemis in ArmoniK.Core to include it in our test pipelines and ensure that it works well with ArmoniK.

--- a/.docs/content/2.dependencies/1.artemis.md
+++ b/.docs/content/2.dependencies/1.artemis.md
@@ -1,5 +1,7 @@
 # Artemis
 
+> **Status: abandoned** — The Artemis adapter is not actively supported. The issues described below are unresolved and there is no planned fix. Use a supported queue adapter instead: [ActiveMQ, RabbitMQ, NATS, SQS, Pub/Sub](../1.concepts/4.adaptors.md).
+
 [Apache ActiveMQ Artemis](https://activemq.apache.org/components/artemis/) is a message broker that can be used as a queue in ArmoniK.
 We deployed an instance of artemis in ArmoniK.Core to include it in our test pipelines and ensure that it works well with ArmoniK.
 It allowed us to find an appropriate deployment and configuration for Artemis but we encountered several issues.

--- a/Adaptors/README.md
+++ b/Adaptors/README.md
@@ -8,7 +8,7 @@ services corresponding to the specific deployment choices.
 ArmoniK provides multiple queue adapter implementations:
 
 - **AMQP (Generic)** - `ArmoniK.Core.Adapters.Amqp`
-  - Supports any AMQP 1.0 compatible server (ActiveMQ Artemis, IBM MQ, etc.)
+  - Supports any AMQP 1.0 compatible server (ActiveMQ, IBM MQ, etc.)
 
 - **RabbitMQ** - `ArmoniK.Core.Adapters.RabbitMQ`
   - Dedicated RabbitMQ adapter using AMQP 0.9.1 protocol

--- a/Adaptors/README.md
+++ b/Adaptors/README.md
@@ -8,11 +8,7 @@ services corresponding to the specific deployment choices.
 ArmoniK provides multiple queue adapter implementations:
 
 - **AMQP (Generic)** - `ArmoniK.Core.Adapters.Amqp`
-  - Supports any AMQP 1.0 compatible server (ActiveMQ, IBM MQ, etc.)
-
-- **RabbitMQ** - `ArmoniK.Core.Adapters.RabbitMQ`
-  - Dedicated RabbitMQ adapter using AMQP 0.9.1 protocol
-  - Enhanced priority support
+  - Supports any AMQP 1.0 compatible server (ActiveMQ, RabbitMQ, IBM MQ, etc.)
 
 - **Amazon SQS** - `ArmoniK.Core.Adapters.SQS`
   - AWS Simple Queue Service integration

--- a/justfile
+++ b/justfile
@@ -202,7 +202,7 @@ _usage:
       queue: allowed values below
         activemq    :  for ActiveMQ (default)
         rabbitmq    :  for RabbitMQ
-        artemis     :  for ActiveMQ Artemis
+        artemis     :  for ActiveMQ Artemis (abandoned, unsupported - use activemq instead)
         sqs         :  for AWS SQS (using elasticmq)
         pubsub      :  for Google PubSub
         nats        :  for Nats with JetStream


### PR DESCRIPTION
# Motivation

The Artemis adapter has unresolved issues (SenderLink timeout that prevents creating new connections after close) that make it unsuitable for tasks that create sub-tasks. Keeping it documented as a valid option wastes contributors' time and misleads users who choose it for deployments.

# Description

- Add an `> **Status: abandoned**` banner to `2.dependencies/1.artemis.md` with a redirect to supported adapters
- Remove Artemis from the valid AMQP target list in `1.concepts/4.adaptors.md` (was listed alongside ActiveMQ and IBM MQ)
- Remove Artemis from the AMQP entry in `Adaptors/README.md`
- Mark `artemis` as unsupported in the `justfile` `_usage` output so users see the warning when running `just`

# Testing

Documentation-only change. No code or behaviour is modified.

- Read `1.artemis.md` — abandoned banner visible at top
- Run `just` — artemis entry shows the unsupported warning
- Read `4.adaptors.md` and `Adaptors/README.md` — Artemis no longer listed as a working target

# Impact

Documentation clarity. Users are redirected to supported queue adapters instead of spending time on a broken one.

# Additional Information

The underlying issues are documented in `1.artemis.md` (ANYCAST vs MULTICAST misconfiguration and the SenderLink timeout). No fix is planned at this time.
