### PR TITLE
docs: add conventional commit format to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,38 @@ Hi! We are very happy that you are interested in contributing to ArmoniK.Core pr
 - `<Nullable>enable</Nullable>` is set project-wide; all new code must annotate nullability
 - Run `just cleanupcode` (JetBrains `jb cleanupcode`) before committing C# changes
 
+## Commit Message Format
+
+Pull request titles must follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specification. This is enforced by CI on every PR.
+
+Format: `<type>(<scope>): <description>`
+
+The `<scope>` is optional. Allowed types:
+
+| Type | When to use |
+|------|-------------|
+| `feat` | A new feature |
+| `fix` | A bug fix |
+| `docs` | Documentation changes only |
+| `refactor` | Code change that neither fixes a bug nor adds a feature |
+| `test` | Adding or updating tests |
+| `perf` | Performance improvement |
+| `ci` | Changes to CI/CD configuration or workflows |
+| `build` | Changes to build system or external dependencies |
+| `chore` | Routine tasks, dependency updates, tooling |
+| `revert` | Reverts a previous commit |
+| `style` | Code style/formatting changes (no logic change) |
+
+Examples:
+```
+feat(auth): add mTLS certificate impersonation support
+fix(mongodb): handle connection pool exhaustion on high load
+docs: update local deployment prerequisites
+chore(deps): update RabbitMQ client to 7.x
+```
+
+> **Note:** Individual commit messages within a branch are not validated — only the PR title is checked.
+
 ## Release Process
 
 When necessary, maintainers can release a new version. This new version will publish packages to registries.


### PR DESCRIPTION
# Motivation

The CI enforces [Conventional Commits](https://www.conventionalcommits.org/) on PR titles via the `semantic-pull-request` workflow, but the allowed types and format are not documented anywhere in the repository. Contributors discover the rules only when the CI fails on their first PR.

# Description

Add a **Commit Message Format** section to `CONTRIBUTING.md` between the Style and Release Process sections:

- Table of all allowed types (`feat`, `fix`, `docs`, `refactor`, `test`, `perf`, `ci`, `build`, `chore`, `revert`, `style`) with usage guidance
- Format description: `<type>(<scope>): <description>` with scope being optional
- Concrete examples covering common scenarios
- Note clarifying that only the PR title is validated (not individual commits)

# Testing

Documentation-only change.

- Read `CONTRIBUTING.md` — new section present and correctly formatted
- Verified types match the default configuration of `amannn/action-semantic-pull-request` (no custom type list in the workflow)

# Impact

Improved contributor onboarding. New contributors can read the rules before opening a PR rather than discovering them through CI failures.

# Additional Information

The workflow file is `.github/workflows/semantic-pull-request.yml`. It uses `amannn/action-semantic-pull-request` with no custom type configuration, so the default Conventional Commits type list applies.
