### PR TITLE
docs: add migration policy and backup warnings to version-migration.md

### DIFF
--- a/.docs/content/0.installation/5.version-migration.md
+++ b/.docs/content/0.installation/5.version-migration.md
@@ -68,4 +68,4 @@ db.Result.updateMany({},
 
 This version changes the structure of the authentication related tables (AuthData, RoleData and UserData). Identifiers are now integers instead of strings. They are also used to build the relations between items in the database. The migration procedure is to delete the three tables, set up initialisation related environment variables for authentication that can be found [here](../1.concepts/3.authentication.md) and let ArmoniK regenerate the database.
 
-> **Before deleting tables:** ensure you have a full MongoDB backup. Deleting these tables removes all existing users, roles, and certificates — they must be re-provisioned via environment variables after the migration.
+> **Before deleting tables:** ensure you have a full MongoDB backup. Deleting these tables removes all existing users, roles, and user–certificate associations (the certificates themselves are not deleted) — users and roles must be re-provisioned via environment variables after the migration.

--- a/.docs/content/0.installation/5.version-migration.md
+++ b/.docs/content/0.installation/5.version-migration.md
@@ -1,5 +1,17 @@
 # How to migrate ArmoniK.Core dependencies during upgrade ?
 
+## Migration policy
+
+Most minor version upgrades are transparent and require no manual steps — simply update the Docker images to the new tag and restart the deployment.
+
+Manual migration steps are required only when a release changes the **database schema** (MongoDB collections) or the **authentication table structure**. Such changes are documented in the sections below. If a version is not listed here, no migration is needed.
+
+**Before any migration:**
+
+1. Back up your MongoDB data before running any migration script.
+2. Test the migration procedure in a staging environment before applying to production.
+3. If the migration fails, restore from backup and re-deploy the previous version.
+
 ## 0.29.x -> 0.30.x
 
 ### Database
@@ -55,3 +67,5 @@ db.Result.updateMany({},
 ### Database
 
 This version changes the structure of the authentication related tables (AuthData, RoleData and UserData). Identifiers are now integers instead of strings. They are also used to build the relations between items in the database. The migration procedure is to delete the three tables, set up initialisation related environment variables for authentication that can be found [here](../1.concepts/3.authentication.md) and let ArmoniK regenerate the database.
+
+> **Before deleting tables:** ensure you have a full MongoDB backup. Deleting these tables removes all existing users, roles, and certificates — they must be re-provisioned via environment variables after the migration.


### PR DESCRIPTION
# Motivation

The version migration guide lists manual steps for two version jumps but gives no context on when steps are required vs when an upgrade is transparent. The 0.34→0.35 migration instructs users to "delete the three tables" without any backup warning, which is a destructive operation with no rollback path documented.

# Description

- Add a **Migration policy** section at the top of `5.version-migration.md` explaining that:
  - Most minor upgrades are transparent (update Docker images, restart)
  - Manual steps are only needed when a release changes the database schema or authentication table structure
  - Versions not listed in the guide require no manual migration
- Add a **pre-migration checklist**: back up MongoDB data, test in staging, restore procedure if migration fails
- Add an explicit warning before the auth table deletion step in the 0.34→0.35 section, noting that all users, roles, and certificates will be lost and must be re-provisioned

# Testing

Documentation-only change.

- Read `5.version-migration.md` — policy section appears before the first version entry
- Warning visible immediately before the table deletion instruction in 0.34→0.35

# Impact

Reduces risk of data loss during upgrades. Operators now have clear guidance on what to back up and what to expect before running migration scripts.

# Additional Information

No new migration steps have been added. Only the 0.29→0.30 and 0.34→0.35 jumps have ever required manual steps.