### PR TITLE
docs: document how to generate environment variables reference locally

### DIFF
--- a/.docs/content/0.installation/0.index.md
+++ b/.docs/content/0.installation/0.index.md
@@ -38,6 +38,25 @@ There are a number of tests that help to verify the successful installation of A
 
 More about tests, see [Tests in ArmoniK.Core](./2.tests.md).
 
+## Environment Variables Reference
+
+All configurable environment variables are documented and published at [armonikcore.readthedocs.io](https://armonikcore.readthedocs.io) in the **Environment Variables** section. The documentation is auto-generated from the source code using [ArmoniK.Utils.DocExtractor](https://github.com/aneoconsulting/ArmoniK.Utils).
+
+To generate the reference locally, run:
+
+```shell
+dotnet tool install -g ArmoniK.Utils.DocExtractor
+cd .docs/content/envars/
+armonik.utils.docextractor -s ../../ArmoniK.Core.sln
+```
+
+The generated files will appear in `.docs/content/envars/`. You can also cross-reference the environment variables documented inline in the concept pages:
+
+- Initialization flags: [Initialization](../1.concepts/10.initialization.md)
+- Cache configuration: [Cache](../1.concepts/11.cache.md)
+- Authentication: [Authentication](../1.concepts/3.authentication.md)
+- Partitions: [Partitions](../1.concepts/9.partitions.md)
+
 ## Contribution
 
 Contributions are always welcome!


### PR DESCRIPTION
# Motivation

Environment variable documentation is auto-generated by `tools/generate-envvars-doc.sh` (via `ArmoniK.Utils.DocExtractor`) and only published on ReadTheDocs at build time. The `.docs/content/envars/` directory is empty locally. A developer working offline, or one unfamiliar with ReadTheDocs, must grep through `Common/src/Injection/Options/` to find configuration options. Additionally, env vars are spread across at least five concept pages with no central cross-reference.

# Description

Add an **Environment Variables Reference** section to `0.index.md`:

- Explains that env var docs are auto-generated and available on ReadTheDocs
- Provides the exact commands to generate the reference locally using `ArmoniK.Utils.DocExtractor`
- Lists cross-reference links to the concept pages where env vars are documented inline (initialization, cache, authentication, partitions)

# Testing

Documentation-only change.

- Read `0.index.md` — new section appears before the Contribution section
- Run the generation commands locally and verify that `.md` files appear in `.docs/content/envars/`

# Impact

Reduces friction for developers who need to find configuration options without a ReadTheDocs build. No code changes.

# Additional Information

The generation script is `tools/generate-envvars-doc.sh`. It installs `ArmoniK.Utils.DocExtractor` as a global .NET tool (version 0.7.3) and runs it against `ArmoniK.Core.sln`.