### PR TITLE
docs(justfile): add inline descriptions to all variables and fix wrong comment

### DIFF
--- a/justfile
+++ b/justfile
@@ -5,23 +5,23 @@ set shell := ["bash", "-exc"]
 set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 
 # Default values for the deployment
-tag          := "0.0.0.0-local"
-local_images := "false"
-log_level    := "Information"
-queue        := "activemq"
-worker       := "htcmock"
-object       := "redis"
-replicas     := "3"
-partitions   := "2"
-platform     := ""
-push         := "false"
-load         := "true"
-ingress      := "true"
-prometheus   := "true"
-grafana      := "true"
-seq          := "true"
-socket_type  := "unixdomainsocket"
-cinit        := "true"
+tag          := "0.0.0.0-local"  # Docker image tag; use "0.0.0.0-local" for locally built images
+local_images := "false"          # If true, Terraform builds images locally instead of pulling from registry
+log_level    := "Information"    # Serilog log level: Verbose, Debug, Information, Warning, Error, Fatal
+queue        := "activemq"       # Queue backend: activemq, rabbitmq, nats, sqs, pubsub, none
+worker       := "htcmock"        # Test worker: htcmock, stream, bench, crashingworker
+object       := "redis"          # Object storage: redis, minio, gcs, local, embed, null
+replicas     := "3"              # Number of PollingAgent+Worker pairs to deploy
+partitions   := "2"              # Number of ArmoniK partitions
+platform     := ""               # Docker build platform override (e.g. "linux/amd64"); empty = host platform
+push         := "false"          # If true, push built images to registry (requires login)
+load         := "true"           # If true, load built images into local Docker daemon
+ingress      := "true"           # If true, deploy the ingress (load balancer) container
+prometheus   := "true"           # If true, deploy Prometheus for metrics collection
+grafana      := "true"           # If true, deploy Grafana dashboards
+seq          := "true"           # If true, deploy Seq for structured log search (UI at http://localhost:9080)
+socket_type  := "unixdomainsocket" # Socket type for PollingAgent↔Worker communication: unixdomainsocket or tcp
+cinit        := "true"           # If true, use container-init (cinit) as PID 1 in worker containers
 
 # Shared test parameters
 ntasks    := "100"
@@ -238,6 +238,7 @@ _usage:
     same parameters used for deploy
   EOF
 
+# Print all environment variables (useful for debugging Terraform variable values)
 env:
   env
 
@@ -265,7 +266,7 @@ deploy: (init)
 deployTargetObject: (init)
   terraform -chdir=terraform apply -target="module.object_{{object}}" -auto-approve
 
-# Destroy target: queue standalone
+# Destroy target: object standalone
 destroyTargetObject:
   terraform -chdir=terraform destroy -target="module.object_{{object}}" -auto-approve
 

--- a/justfile
+++ b/justfile
@@ -21,7 +21,7 @@ prometheus   := "true"           # If true, deploy Prometheus for metrics collec
 grafana      := "true"           # If true, deploy Grafana dashboards
 seq          := "true"           # If true, deploy Seq for structured log search (UI at http://localhost:9080)
 socket_type  := "unixdomainsocket" # Socket type for PollingAgent↔Worker communication: unixdomainsocket or tcp
-cinit        := "true"           # If true, use container-init (cinit) as PID 1 in worker containers
+cinit        := "true"           # If true, run a one-shot init container to initialize the database before services start; services self-initialize when false
 
 # Shared test parameters
 ntasks    := "100"


### PR DESCRIPTION
# Motivation

The Justfile top-level variables have no inline descriptions, making it hard to understand their purpose and accepted values without reading the full file or the `_usage` output. The `destroyTargetObject` recipe had an incorrect comment ("queue standalone") and the `env` recipe had no comment at all.

# Description

- Add inline `# comment` to every top-level deployment variable explaining its purpose, accepted values, and default — with particular focus on the less-obvious ones: `cinit`, `socket_type`, `platform`, `push`, `load`, `ingress`, `prometheus`, `grafana`, `seq`
- Fix `destroyTargetObject` comment: was "Destroy target: queue standalone", corrected to "Destroy target: object standalone"
- Add a missing description to the `env` recipe

# Testing

- Run `just --list` — variable comments appear alongside variable names
- Run `just env` — works unchanged
- Run `just destroyTargetObject` (dry-run or with a test deployment) — behaviour unchanged

# Impact

Developer experience improvement. No behaviour change. No code changes.