### PR TITLE
docs: add decision table to Windows installation guides and fix Terraform version

### DIFF
--- a/.docs/content/0.installation/6.create-windows-vm.md
+++ b/.docs/content/0.installation/6.create-windows-vm.md
@@ -1,4 +1,13 @@
-# Create a Windows Virtual Machine on AWS to Deploy ArmoniK Core
+# Install on Windows — AWS EC2 Virtual Machine
+
+> **Choose your installation path:**
+>
+> | Scenario | Guide |
+> |----------|-------|
+> | You want to run ArmoniK on an existing **Windows 11 desktop or laptop** | [Install on Windows 11](./7.install-windows.md) |
+> | You want a **dedicated cloud VM** (e.g. for CI/CD, shared dev, perf testing) | **This guide** (AWS EC2 Windows Server) |
+>
+> Both paths result in an equivalent ArmoniK deployment. Choose the VM path if you need an isolated, reproducible environment or do not want to install tools on your local machine.
 
 ## Step 1: Launch an EC2 Instance
 
@@ -100,7 +109,6 @@ choco install just --confirm
 choco install terraform --confirm
 choco install mongodb-shell -y
 choco install 7zip -y
-choco install terraform --version=1.10.1 -y
 ```
 Verify Installation:
 

--- a/.docs/content/0.installation/7.install-windows.md
+++ b/.docs/content/0.installation/7.install-windows.md
@@ -1,4 +1,11 @@
-# Install on Windows 11
+# Install on Windows 11 (native)
+
+> **Choose your installation path:**
+>
+> | Scenario | Guide |
+> |----------|-------|
+> | You want to run ArmoniK on your **Windows 11 desktop or laptop** | **This guide** |
+> | You want a **dedicated cloud VM** (e.g. for CI/CD, shared dev, perf testing) | [AWS EC2 VM](./6.create-windows-vm.md) |
 
 ## Step 1: Install Docker
 


### PR DESCRIPTION
# Motivation

Two separate Windows installation guides exist (`6.create-windows-vm.md` for AWS EC2, `7.install-windows.md` for native Windows 11) with no guidance on which to choose. Additionally, the VM guide pinned Terraform to `1.10.1` via a second `choco install terraform --version=1.10.1` call, conflicting with the `>=1.4.2` requirement stated in `0.index.md`.

# Description

- Add a **decision table** at the top of both Windows guides mapping use-case to the right guide (local laptop → `7.install-windows.md`, cloud VM → `6.create-windows-vm.md`), with cross-links between them
- Update the title of `6.create-windows-vm.md` to reflect its scope more clearly
- Remove the duplicate `choco install terraform --version=1.10.1 -y` line in the VM guide that caused a conflicting version pin

# Testing

Documentation-only change.

- Read `6.create-windows-vm.md` — decision table visible at top; Chocolatey section installs Terraform only once
- Read `7.install-windows.md` — decision table visible at top with link to VM guide

# Impact

Improved clarity for Windows users. No behaviour change. The Terraform version is now consistent across all documentation (`>=1.4.2`, install latest stable via Chocolatey).