### PR TITLE
docs: add quick-start guide for local development

### DIFF
--- a/.docs/content/0.installation/0.index.md
+++ b/.docs/content/0.installation/0.index.md
@@ -18,7 +18,7 @@ ArmoniK.Core can be installed only on Linux machines. For windows users, it is p
 
 - [Terraform](https://www.terraform.io/) version >= 1.4.2
 - [Just](https://github.com/casey/just) >= 1.29.0
-- [Dotnet](https://dotnet.microsoft.com/en-us/) >= 6.0
+- [Dotnet](https://dotnet.microsoft.com/en-us/) >= 10.0
 - [Docker](https://www.docker.com/) >= 20.10.16
 - [GitHub CLI](https://cli.github.com/)>= 2.23.0 (optional)
 

--- a/.docs/content/0.installation/0.index.md
+++ b/.docs/content/0.installation/0.index.md
@@ -22,6 +22,10 @@ ArmoniK.Core can be installed only on Linux machines. For windows users, it is p
 - [Docker](https://www.docker.com/) >= 20.10.16
 - [GitHub CLI](https://cli.github.com/)>= 2.23.0 (optional)
 
+### Quick Start
+
+New to ArmoniK.Core? The [Quick Start guide](./0.quickstart.md) walks you through prerequisites, a first local deployment, and running your first integration test — all in under 15 minutes.
+
 ### Local deployment
 
 To deploy ArmoniK.Core locally, you need first to clone the repository [ArmoniK.Core](https://github.com/aneoconsulting/armonik.core). Then, to see all the available recipes for deployment, place yourself at the root of the repository ArmoniK.Core where the justfile is located, and type on your command line:

--- a/.docs/content/0.installation/0.quickstart.md
+++ b/.docs/content/0.installation/0.quickstart.md
@@ -1,0 +1,113 @@
+# Quick Start — Local Development
+
+This guide gets you from zero to a running ArmoniK.Core deployment in under 15 minutes, using the recommended local stack (ActiveMQ + Redis + HtcMock worker).
+
+> **Platform:** Linux or WSL2. For native Windows, see [Install on Windows 11](./7.install-windows.md).
+
+---
+
+## Step 1 — Verify prerequisites
+
+Run these commands to confirm all tools are installed:
+
+```shell
+terraform -version      # must be >= 1.4.2
+just --version          # must be >= 1.29.0
+docker info             # Docker daemon must be running
+dotnet --version        # must be >= 6.0
+```
+
+If any tool is missing, follow [Prerequisites](./0.index.md#prerequisites) to install it.
+
+---
+
+## Step 2 — Clone the repository
+
+```shell
+git clone https://github.com/aneoconsulting/ArmoniK.Core.git
+cd ArmoniK.Core
+```
+
+---
+
+## Step 3 — Build and deploy locally
+
+This command builds all Docker images locally and deploys the full stack:
+
+```shell
+just local_images=true build-deploy
+```
+
+Default configuration: `queue=activemq`, `object=redis`, `worker=htcmock`, `replicas=3`, `partitions=2`.
+
+The first run takes a few minutes (image builds + Terraform apply). Subsequent runs are faster.
+
+> **What gets deployed?**
+> Submitter, PollingAgent × 3, HtcMock Worker × 3, ActiveMQ, Redis, MongoDB, Fluent Bit, Seq, Prometheus, and Grafana — all as local Docker containers.
+
+---
+
+## Step 4 — Verify the deployment is healthy
+
+```shell
+just healthChecks
+```
+
+Expected output: `startup: Healthy`, `liveness: Healthy`, `readiness: Healthy` for each PollingAgent and the Submitter.
+
+---
+
+## Step 5 — Run the unit tests
+
+```shell
+dotnet test Common/tests/
+```
+
+These tests run without any deployed service. All should pass in under a minute.
+
+---
+
+## Step 6 — Run an integration test
+
+With the deployment up, submit 100 HtcMock tasks to verify end-to-end processing:
+
+```shell
+just runHtcmock
+```
+
+You should see the client submit tasks and then collect results. A non-zero exit code indicates a failure.
+
+To try with more tasks or different parameters:
+
+```shell
+just ntasks=500 htcmock_levels=1 runHtcmock
+```
+
+---
+
+## Step 7 — Explore the monitoring
+
+| UI | URL | Purpose |
+|----|-----|---------|
+| Seq | http://localhost:9080 | Structured log search and filtering |
+| Prometheus | http://localhost:9090 | Raw metrics and alerts |
+| Grafana | http://localhost:3000 | Dashboards (admin / admin) |
+
+---
+
+## Tear down
+
+```shell
+just destroy
+```
+
+> **Important:** call `destroy` with the same variable values you used for `build-deploy`. Terraform needs to match the original configuration to clean up correctly.
+
+---
+
+## What's next?
+
+- [Local Deployment details](./1.local-deployment.md) — all deployment parameters explained
+- [Tests overview](./2.tests.md) — unit, partial, and integration test categories
+- [Execute tests](./3.execute-tests.md) — running adapter tests and integration tests
+- [Environment variables reference](https://armonikcore.readthedocs.io) — all configuration options

--- a/.docs/content/0.installation/0.quickstart.md
+++ b/.docs/content/0.installation/0.quickstart.md
@@ -14,7 +14,7 @@ Run these commands to confirm all tools are installed:
 terraform -version      # must be >= 1.4.2
 just --version          # must be >= 1.29.0
 docker info             # Docker daemon must be running
-dotnet --version        # must be >= 6.0
+dotnet --version        # must be >= 10.0
 ```
 
 If any tool is missing, follow [Prerequisites](./0.index.md#prerequisites) to install it.
@@ -54,6 +54,14 @@ just healthChecks
 ```
 
 Expected output: `startup: Healthy`, `liveness: Healthy`, `readiness: Healthy` for each PollingAgent and the Submitter.
+
+If any service reports `Unhealthy`, inspect the logs:
+
+```shell
+docker cp fluentd:/armonik-logs.json - | jq 'select(.["@l"] == "Error")'
+```
+
+Or open Seq at http://localhost:9080 and filter by level `Error`.
 
 ---
 


### PR DESCRIPTION
# Motivation

There is no single end-to-end guide for someone new to ArmoniK.Core. Onboarding requires reading `0.index.md`, `1.local-deployment.md`, `2.tests.md`, and `3.execute-tests.md` in sequence and inferring the correct order of operations. This creates unnecessary friction for new contributors and evaluators.

# Description

Add `0.installation/0.quickstart.md` — a single balisé path from zero to a working local deployment:

1. Prerequisites checklist with verification commands (`terraform -version`, `docker info`, etc.)
2. Clone the repository
3. Build and deploy with the recommended local stack (`activemq + redis + htcmock`, `local_images=true`)
4. Verify health (`just healthChecks`)
5. Run unit tests (`dotnet test Common/tests/`)
6. Run integration test (`just runHtcmock`)
7. Explore monitoring UIs (Seq, Prometheus, Grafana) with URLs and default credentials
8. Tear down (`just destroy`)

Also add a **Quick Start** callout section to `0.index.md` pointing to the new guide.

# Testing

- Follow the guide end-to-end on a clean Linux/WSL2 machine
- `just local_images=true build-deploy` completes without error
- `just healthChecks` returns Healthy for all PollingAgents and the Submitter
- `dotnet test Common/tests/` passes
- `just runHtcmock` exits 0
- `just destroy` cleans up all containers

# Impact

Improved onboarding experience. No code changes. No new dependencies.

# Additional Information

The recommended stack (`activemq + redis + htcmock`) was chosen as the default because it matches the Justfile defaults (`queue=activemq`, `object=redis`, `worker=htcmock`).