### PR TITLE
docs: add concept pages for NATS, SQS, and Pub/Sub queue adapters

### DIFF
--- a/.docs/content/1.concepts/12.nats.md
+++ b/.docs/content/1.concepts/12.nats.md
@@ -12,7 +12,7 @@ The local deployment runs the official `nats:alpine` Docker image (Linux) or `na
 
 ## Architecture in ArmoniK
 
-ArmoniK creates a single JetStream **stream** named `armonik-stream` with `WorkQueue` retention (messages are deleted once acknowledged). Each partition gets its own **consumer** (durable name = partition ID), so multiple PollingAgents can pull from the same stream without receiving duplicate messages.
+ArmoniK creates a single JetStream **stream** named `armonik-stream` with `WorkQueue` retention (messages are deleted once acknowledged). Each partition gets its own **consumer** (durable name = partition ID). The adapter uses **at-least-once** delivery: if a message is not acknowledged within `AckWait` seconds, NATS redelivers it.
 
 ```
 PollingAgent[0] ──pull── consumer:partition-0 ──┐
@@ -36,14 +36,14 @@ PollingAgent[2] ──pull── consumer:partition-0 ──┘  (WorkQueue rete
 | Task priorities | No — single stream, no priority routing |
 | Durable subscriptions | Yes — per-partition consumers survive restarts |
 | Automatic redelivery | Yes — via `AckWait` timeout |
-| Ordered delivery | Yes — `WorkQueue` stream guarantees each message is delivered once |
+| Delivery semantics | At-least-once — messages are redelivered if not acknowledged within `AckWait` |
 | TLS | Yes — configure via the NATS server; the client honors `nats://` vs `tls://` in the URL |
 
 ## Limitations
 
 - **No priority queues.** Unlike SQS, NATS does not split tasks across priority-based queues. All tasks compete equally in the stream.
 - **Stream name is fixed** to `armonik-stream`. If you share a NATS server across multiple ArmoniK deployments, use different subject prefixes.
-- Consumer configuration uses `WorkQueue` retention — messages not yet consumed are not retained after a configurable `MessageRetention` period.
+- **WorkQueue retention** — messages are removed from the stream as soon as they are acknowledged. Unacknowledged messages are redelivered after `AckWait` seconds.
 
 ## Health check
 

--- a/.docs/content/1.concepts/12.nats.md
+++ b/.docs/content/1.concepts/12.nats.md
@@ -1,0 +1,58 @@
+# NATS JetStream
+
+[NATS JetStream](https://docs.nats.io/nats-concepts/jetstream) is a persistent, replicated streaming engine built on top of the NATS messaging system. ArmoniK uses it as a durable task queue with explicit message acknowledgment and per-partition consumers.
+
+## Deployment
+
+```shell
+just queue=nats build-deploy
+```
+
+The local deployment runs the official `nats:alpine` Docker image (Linux) or `nats:nanoserver-ltsc2022` (Windows) with JetStream and HTTP management enabled.
+
+## Architecture in ArmoniK
+
+ArmoniK creates a single JetStream **stream** named `armonik-stream` with `WorkQueue` retention (messages are deleted once acknowledged). Each partition gets its own **consumer** (durable name = partition ID), so multiple PollingAgents can pull from the same stream without receiving duplicate messages.
+
+```
+PollingAgent[0] ──pull── consumer:partition-0 ──┐
+PollingAgent[1] ──pull── consumer:partition-1 ──┤── stream: armonik-stream ── NATS server
+PollingAgent[2] ──pull── consumer:partition-0 ──┘  (WorkQueue retention)
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `Nats__Url` | — | NATS server URL, e.g. `nats://localhost:4222` (**required**) |
+| `Nats__AckWait` | `120` | Seconds before an unacknowledged message is redelivered |
+| `Nats__AckExtendDeadlineStep` | `60` | Interval (seconds) between deadline renewals for long-running tasks |
+| `Nats__DegreeOfParallelism` | `0` | Max concurrent pull operations; `0` = CPU thread count; negative = unlimited |
+
+## Supported features
+
+| Feature | Supported |
+|---------|-----------|
+| Task priorities | No — single stream, no priority routing |
+| Durable subscriptions | Yes — per-partition consumers survive restarts |
+| Automatic redelivery | Yes — via `AckWait` timeout |
+| Ordered delivery | Yes — `WorkQueue` stream guarantees each message is delivered once |
+| TLS | Yes — configure via the NATS server; the client honors `nats://` vs `tls://` in the URL |
+
+## Limitations
+
+- **No priority queues.** Unlike SQS, NATS does not split tasks across priority-based queues. All tasks compete equally in the stream.
+- **Stream name is fixed** to `armonik-stream`. If you share a NATS server across multiple ArmoniK deployments, use different subject prefixes.
+- Consumer configuration uses `WorkQueue` retention — messages not yet consumed are not retained after a configurable `MessageRetention` period.
+
+## Health check
+
+The NATS container exposes an HTTP management endpoint. The Terraform module waits for:
+
+```shell
+curl -fsSL http://localhost:8222/healthz
+```
+
+## Monitoring
+
+Use the NATS management UI at `http://localhost:8222` to inspect stream and consumer state, message counts, and pending messages per partition.

--- a/.docs/content/1.concepts/12.nats.md
+++ b/.docs/content/1.concepts/12.nats.md
@@ -22,12 +22,7 @@ PollingAgent[2] ──pull── consumer:partition-0 ──┘  (WorkQueue rete
 
 ## Configuration
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `Nats__Url` | — | NATS server URL, e.g. `nats://localhost:4222` (**required**) |
-| `Nats__AckWait` | `120` | Seconds before an unacknowledged message is redelivered |
-| `Nats__AckExtendDeadlineStep` | `60` | Interval (seconds) between deadline renewals for long-running tasks |
-| `Nats__DegreeOfParallelism` | `0` | Max concurrent pull operations; `0` = CPU thread count; negative = unlimited |
+All configuration variables and their defaults are documented in the [Environment Variables reference](https://armonikcore.readthedocs.io/en/latest/content/envars/ArmoniK.Core.EnvVars.html#options-for-nats).
 
 ## Supported features
 

--- a/.docs/content/1.concepts/13.sqs.md
+++ b/.docs/content/1.concepts/13.sqs.md
@@ -1,0 +1,78 @@
+# Amazon SQS
+
+[Amazon Simple Queue Service (SQS)](https://aws.amazon.com/sqs/) is a fully managed message queuing service. ArmoniK uses it as a task queue with optional priority-based routing and batch operations. For local development, ArmoniK deploys [ElasticMQ](https://github.com/softwaremill/elasticmq) as a drop-in SQS emulator.
+
+## Deployment
+
+```shell
+# Local development (uses ElasticMQ emulator)
+just queue=sqs build-deploy
+
+# Production (against real AWS SQS — ensure AWS credentials are set)
+just queue=sqs build-deploy
+```
+
+AWS credentials must be available as environment variables before deployment:
+
+```shell
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+```
+
+## Architecture in ArmoniK
+
+ArmoniK creates one SQS queue per partition per priority level. With `MaxPriority=0` (default) a single queue is used per partition; with `MaxPriority=N` there are N+1 queues per partition, one per priority level (0 = lowest, N = highest).
+
+```
+partition-0-priority-0 ──┐
+partition-0-priority-1 ──┤── SQS
+partition-1-priority-0 ──┤
+partition-1-priority-1 ──┘
+```
+
+PollingAgents pull from the highest-priority non-empty queue first.
+
+Queue names follow the pattern: `{Prefix}-{partitionId}-{priority}` (or `{Prefix}-{partitionId}` when `MaxPriority=0`).
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SQS__ServiceURL` | AWS default | Override to target a local emulator, e.g. `http://localhost:4566` for LocalStack or `http://localhost:9324` for ElasticMQ |
+| `SQS__Prefix` | `""` | String prepended to all queue names |
+| `SQS__MaxPriority` | `0` | Number of priority levels; `0` = single queue per partition; `N` = N+1 queues |
+| `SQS__AckDeadlinePeriod` | `120` | Visibility timeout (seconds); message redelivered if not acknowledged within this window |
+| `SQS__AckExtendDeadlineStep` | `60` | Interval (seconds) between visibility timeout renewals for long-running tasks (must be < `AckDeadlinePeriod`) |
+| `SQS__WaitTimeSeconds` | `20` | Long-polling duration (0–20 s); 0 = short polling; values 1–20 reduce empty-response rate |
+| `SQS__DegreeOfParallelism` | `0` | Max concurrent receive operations; `0` = CPU thread count |
+| `SQS__MaxRetries` | `5` | Retry attempts on transient AWS API errors |
+| `SQS__UseSessionMessageGroupId` | `false` | Set the `MessageGroupId` to the session ID for FIFO ordering (requires FIFO queue names ending in `.fifo`) |
+| `SQS__Tags` | `{}` | AWS resource tags applied when queues are created |
+| `SQS__Attributes` | `{}` | Additional SQS queue attributes (e.g. `FifoQueue`, `KmsMasterKeyId`) |
+
+## Supported features
+
+| Feature | Supported |
+|---------|-----------|
+| Task priorities | Yes — one SQS queue per priority level per partition |
+| Batch operations | Yes — up to 10 messages per batch (SQS API limit) |
+| Long polling | Yes — configurable via `WaitTimeSeconds` |
+| FIFO ordering | Yes — requires FIFO queues and `UseSessionMessageGroupId=true` |
+| KMS encryption | Yes — via `Attributes["KmsMasterKeyId"]` |
+| Automatic redelivery | Yes — via visibility timeout (`AckDeadlinePeriod`) |
+
+## Limitations
+
+- **Message size:** SQS limits messages to 256 KB. ArmoniK task metadata stays well within this limit.
+- **Visibility timeout cap:** SQS maximum visibility timeout is 12 hours (43 200 s). `AckDeadlinePeriod` must stay below this.
+- **Queue URL caching:** ArmoniK caches queue URLs and refreshes on 404 or `NonExistentQueue` errors. Avoid deleting queues while tasks are in flight.
+- **FIFO queues:** `UseSessionMessageGroupId=true` requires queue names ending with `.fifo`. Standard SQS queues do not support ordering.
+- **Batch size:** SQS returns at most 10 messages per `ReceiveMessage` call. High-throughput workloads benefit from increasing `DegreeOfParallelism`.
+
+## Health check
+
+The ElasticMQ emulator (local) exposes an SQS-compatible endpoint. The Terraform module waits for:
+
+```shell
+curl -fsSL "http://localhost:9324/?Action=ListQueues&Version=2012-11-05"
+```

--- a/.docs/content/1.concepts/13.sqs.md
+++ b/.docs/content/1.concepts/13.sqs.md
@@ -21,13 +21,13 @@ export AWS_SECRET_ACCESS_KEY=...
 
 ## Architecture in ArmoniK
 
-ArmoniK creates one SQS queue per partition per priority level. With `MaxPriority=0` (default) a single queue is used per partition; with `MaxPriority=N` there are N+1 queues per partition, one per priority level (0 = lowest, N = highest).
+ArmoniK creates one SQS queue per partition per priority level. With `MaxPriority=0` (default) a single queue is used per partition; with `MaxPriority=N` there are N queues per partition, one per priority level (1 = lowest, N = highest).
 
 ```
-partition-0-priority-0 ──┐
-partition-0-priority-1 ──┤── SQS
-partition-1-priority-0 ──┤
-partition-1-priority-1 ──┘
+partition-0-1 ──┐
+partition-0-2 ──┤── SQS
+partition-1-1 ──┤
+partition-1-2 ──┘
 ```
 
 PollingAgents pull from the highest-priority non-empty queue first.
@@ -40,15 +40,14 @@ Queue names follow the pattern: `{Prefix}-{partitionId}-{priority}` (or `{Prefix
 |----------|---------|-------------|
 | `SQS__ServiceURL` | AWS default | Override to target a local emulator, e.g. `http://localhost:4566` for LocalStack or `http://localhost:9324` for ElasticMQ |
 | `SQS__Prefix` | `""` | String prepended to all queue names |
-| `SQS__MaxPriority` | `0` | Number of priority levels; `0` = single queue per partition; `N` = N+1 queues |
+| `SQS__MaxPriority` | `0` | Number of priority levels; `0` = single queue per partition; `N` = N queues (priorities 1..N) |
 | `SQS__AckDeadlinePeriod` | `120` | Visibility timeout (seconds); message redelivered if not acknowledged within this window |
 | `SQS__AckExtendDeadlineStep` | `60` | Interval (seconds) between visibility timeout renewals for long-running tasks (must be < `AckDeadlinePeriod`) |
 | `SQS__WaitTimeSeconds` | `20` | Long-polling duration (0–20 s); 0 = short polling; values 1–20 reduce empty-response rate |
 | `SQS__DegreeOfParallelism` | `0` | Max concurrent receive operations; `0` = CPU thread count |
 | `SQS__MaxRetries` | `5` | Retry attempts on transient AWS API errors |
-| `SQS__UseSessionMessageGroupId` | `false` | Set the `MessageGroupId` to the session ID for FIFO ordering (requires FIFO queue names ending in `.fifo`) |
 | `SQS__Tags` | `{}` | AWS resource tags applied when queues are created |
-| `SQS__Attributes` | `{}` | Additional SQS queue attributes (e.g. `FifoQueue`, `KmsMasterKeyId`) |
+| `SQS__Attributes` | `{}` | Additional SQS queue attributes (e.g. `KmsMasterKeyId`) |
 
 ## Supported features
 
@@ -57,7 +56,6 @@ Queue names follow the pattern: `{Prefix}-{partitionId}-{priority}` (or `{Prefix
 | Task priorities | Yes — one SQS queue per priority level per partition |
 | Batch operations | Yes — up to 10 messages per batch (SQS API limit) |
 | Long polling | Yes — configurable via `WaitTimeSeconds` |
-| FIFO ordering | Yes — requires FIFO queues and `UseSessionMessageGroupId=true` |
 | KMS encryption | Yes — via `Attributes["KmsMasterKeyId"]` |
 | Automatic redelivery | Yes — via visibility timeout (`AckDeadlinePeriod`) |
 
@@ -66,7 +64,6 @@ Queue names follow the pattern: `{Prefix}-{partitionId}-{priority}` (or `{Prefix
 - **Message size:** SQS limits messages to 256 KB. ArmoniK task metadata stays well within this limit.
 - **Visibility timeout cap:** SQS maximum visibility timeout is 12 hours (43 200 s). `AckDeadlinePeriod` must stay below this.
 - **Queue URL caching:** ArmoniK caches queue URLs and refreshes on 404 or `NonExistentQueue` errors. Avoid deleting queues while tasks are in flight.
-- **FIFO queues:** `UseSessionMessageGroupId=true` requires queue names ending with `.fifo`. Standard SQS queues do not support ordering.
 - **Batch size:** SQS returns at most 10 messages per `ReceiveMessage` call. High-throughput workloads benefit from increasing `DegreeOfParallelism`.
 
 ## Health check

--- a/.docs/content/1.concepts/13.sqs.md
+++ b/.docs/content/1.concepts/13.sqs.md
@@ -36,18 +36,7 @@ Queue names follow the pattern: `{Prefix}-{partitionId}-{priority}` (or `{Prefix
 
 ## Configuration
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `SQS__ServiceURL` | AWS default | Override to target a local emulator, e.g. `http://localhost:4566` for LocalStack or `http://localhost:9324` for ElasticMQ |
-| `SQS__Prefix` | `""` | String prepended to all queue names |
-| `SQS__MaxPriority` | `0` | Number of priority levels; `0` = single queue per partition; `N` = N queues (priorities 1..N) |
-| `SQS__AckDeadlinePeriod` | `120` | Visibility timeout (seconds); message redelivered if not acknowledged within this window |
-| `SQS__AckExtendDeadlineStep` | `60` | Interval (seconds) between visibility timeout renewals for long-running tasks (must be < `AckDeadlinePeriod`) |
-| `SQS__WaitTimeSeconds` | `20` | Long-polling duration (0–20 s); 0 = short polling; values 1–20 reduce empty-response rate |
-| `SQS__DegreeOfParallelism` | `0` | Max concurrent receive operations; `0` = CPU thread count |
-| `SQS__MaxRetries` | `5` | Retry attempts on transient AWS API errors |
-| `SQS__Tags` | `{}` | AWS resource tags applied when queues are created |
-| `SQS__Attributes` | `{}` | Additional SQS queue attributes (e.g. `KmsMasterKeyId`) |
+All configuration variables and their defaults are documented in the [Environment Variables reference](https://armonikcore.readthedocs.io/en/latest/content/envars/ArmoniK.Core.EnvVars.html#options-for-sqs).
 
 ## Supported features
 

--- a/.docs/content/1.concepts/14.pubsub.md
+++ b/.docs/content/1.concepts/14.pubsub.md
@@ -28,17 +28,7 @@ subscription:a{Prefix}-partition-0-ak-sub ──pull── PollingAgent[0]
 
 ## Configuration
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `PubSub__ProjectId` | — | GCP project ID containing the Pub/Sub instance (**required**) |
-| `PubSub__Prefix` | `""` | Prefix prepended to topic and subscription names |
-| `PubSub__MessageRetention` | `1 day` | How long undelivered messages are retained on the topic |
-| `PubSub__AckDeadlinePeriod` | `120` | Acknowledgment deadline (seconds); message redelivered if not acked within this window |
-| `PubSub__AckExtendDeadlineStep` | `60` | Interval (seconds) between deadline modifications for long-running tasks |
-| `PubSub__MessageOrdering` | `false` | Set `EnableMessageOrdering` on subscriptions (note: has no effect on delivery order — the adapter does not set `OrderingKey` when publishing) |
-| `PubSub__ExactlyOnceDelivery` | `false` | Enable exactly-once delivery semantics (adds processing overhead) |
-| `PubSub__KmsKeyName` | `""` | KMS key for message encryption at rest |
-| `PUBSUB_EMULATOR_HOST` | — | Emulator endpoint for local testing, e.g. `localhost:8085` (set by Terraform automatically) |
+All configuration variables and their defaults are documented in the [Environment Variables reference](https://armonikcore.readthedocs.io/en/latest/content/envars/ArmoniK.Core.EnvVars.html#options-for-pubsub).
 
 ## Supported features
 

--- a/.docs/content/1.concepts/14.pubsub.md
+++ b/.docs/content/1.concepts/14.pubsub.md
@@ -1,0 +1,68 @@
+# Google Cloud Pub/Sub
+
+[Google Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/overview) is a fully managed, asynchronous messaging service. ArmoniK uses it as a task queue with topics and pull subscriptions, supporting optional message ordering and exactly-once delivery. For local development, ArmoniK deploys the [Pub/Sub emulator](https://cloud.google.com/pubsub/docs/emulator).
+
+## Deployment
+
+```shell
+# Local development (uses the GCP Pub/Sub emulator)
+just queue=pubsub build-deploy
+
+# Production (against real GCP Pub/Sub — ensure credentials are set)
+just queue=pubsub build-deploy
+```
+
+For production, GCP credentials must be available (Application Default Credentials or a service account key file).
+
+## Architecture in ArmoniK
+
+ArmoniK creates one **topic** and one **subscription** per partition. Topics and subscriptions are created on demand (a 404 at startup triggers creation).
+
+Naming pattern: `a{Prefix}-{partitionId}` (topic) and `a{Prefix}-{partitionId}-ak-sub` (subscription).
+
+```
+subscription:partition-0-ak-sub ──pull── PollingAgent[0]
+        │
+        topic:partition-0  ──── Submitter (push)
+```
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PubSub__ProjectId` | — | GCP project ID containing the Pub/Sub instance (**required**) |
+| `PubSub__Prefix` | `""` | Prefix prepended to topic and subscription names |
+| `PubSub__MessageRetention` | `1 day` | How long undelivered messages are retained on the topic |
+| `PubSub__AckDeadlinePeriod` | `120` | Acknowledgment deadline (seconds); message redelivered if not acked within this window |
+| `PubSub__AckExtendDeadlineStep` | `60` | Interval (seconds) between deadline modifications for long-running tasks |
+| `PubSub__MessageOrdering` | `false` | Enable message ordering on subscriptions (disables parallel pulls within a subscription) |
+| `PubSub__ExactlyOnceDelivery` | `false` | Enable exactly-once delivery semantics (adds processing overhead) |
+| `PubSub__KmsKeyName` | `""` | KMS key for message encryption at rest |
+| `PUBSUB_EMULATOR_HOST` | — | Emulator endpoint for local testing, e.g. `localhost:8085` (set by Terraform automatically) |
+
+## Supported features
+
+| Feature | Supported |
+|---------|-----------|
+| Task priorities | No — single subscription per partition, no priority routing |
+| Message ordering | Yes — `PubSub__MessageOrdering=true` (serializes delivery within a subscription) |
+| Exactly-once delivery | Yes — `PubSub__ExactlyOnceDelivery=true` (prevents duplicate deliveries at Pub/Sub layer) |
+| KMS encryption | Yes — `PubSub__KmsKeyName` |
+| Message retention | Yes — configurable via `PubSub__MessageRetention` |
+| Automatic redelivery | Yes — via acknowledgment deadline (`AckDeadlinePeriod`) |
+
+## Limitations
+
+- **No priority queues.** Pub/Sub has no native priority routing. All partitions use a single subscription.
+- **MessageOrdering serializes delivery.** Enabling `MessageOrdering=true` prevents concurrent pulls from a single subscription, which reduces throughput. Use only when task ordering within a partition is strictly required.
+- **ExactlyOnceDelivery overhead.** This feature requires acknowledgment tracking on the Pub/Sub side and increases latency. Enable only when duplicate task execution is unacceptable.
+- **GCP authentication required in production.** The emulator does not require credentials; real GCP does. Ensure Application Default Credentials or a service account key is configured before deploying.
+- **Topic/subscription naming:** ArmoniK prepends `a` to the prefix to avoid names starting with `goog` (reserved by GCP). Keep `Prefix` short to stay within GCP's 255-character name limit.
+
+## Health check
+
+The emulator exposes an HTTP endpoint. The Terraform module waits for:
+
+```shell
+curl -fsSL localhost:8085
+```

--- a/.docs/content/1.concepts/14.pubsub.md
+++ b/.docs/content/1.concepts/14.pubsub.md
@@ -21,9 +21,9 @@ ArmoniK creates one **topic** and one **subscription** per partition. Topics and
 Naming pattern: `a{Prefix}-{partitionId}` (topic) and `a{Prefix}-{partitionId}-ak-sub` (subscription).
 
 ```
-subscription:partition-0-ak-sub ──pull── PollingAgent[0]
+subscription:a{Prefix}-partition-0-ak-sub ──pull── PollingAgent[0]
         │
-        topic:partition-0  ──── Submitter (push)
+        topic:a{Prefix}-partition-0  ──── Submitter (push)
 ```
 
 ## Configuration
@@ -35,7 +35,7 @@ subscription:partition-0-ak-sub ──pull── PollingAgent[0]
 | `PubSub__MessageRetention` | `1 day` | How long undelivered messages are retained on the topic |
 | `PubSub__AckDeadlinePeriod` | `120` | Acknowledgment deadline (seconds); message redelivered if not acked within this window |
 | `PubSub__AckExtendDeadlineStep` | `60` | Interval (seconds) between deadline modifications for long-running tasks |
-| `PubSub__MessageOrdering` | `false` | Enable message ordering on subscriptions (disables parallel pulls within a subscription) |
+| `PubSub__MessageOrdering` | `false` | Set `EnableMessageOrdering` on subscriptions (note: has no effect on delivery order — the adapter does not set `OrderingKey` when publishing) |
 | `PubSub__ExactlyOnceDelivery` | `false` | Enable exactly-once delivery semantics (adds processing overhead) |
 | `PubSub__KmsKeyName` | `""` | KMS key for message encryption at rest |
 | `PUBSUB_EMULATOR_HOST` | — | Emulator endpoint for local testing, e.g. `localhost:8085` (set by Terraform automatically) |
@@ -45,7 +45,7 @@ subscription:partition-0-ak-sub ──pull── PollingAgent[0]
 | Feature | Supported |
 |---------|-----------|
 | Task priorities | No — single subscription per partition, no priority routing |
-| Message ordering | Yes — `PubSub__MessageOrdering=true` (serializes delivery within a subscription) |
+| Message ordering | No — `PubSub__MessageOrdering` sets a subscription flag but the adapter does not set `OrderingKey` on published messages; Pub/Sub ordering guarantees do not apply |
 | Exactly-once delivery | Yes — `PubSub__ExactlyOnceDelivery=true` (prevents duplicate deliveries at Pub/Sub layer) |
 | KMS encryption | Yes — `PubSub__KmsKeyName` |
 | Message retention | Yes — configurable via `PubSub__MessageRetention` |
@@ -54,7 +54,7 @@ subscription:partition-0-ak-sub ──pull── PollingAgent[0]
 ## Limitations
 
 - **No priority queues.** Pub/Sub has no native priority routing. All partitions use a single subscription.
-- **MessageOrdering serializes delivery.** Enabling `MessageOrdering=true` prevents concurrent pulls from a single subscription, which reduces throughput. Use only when task ordering within a partition is strictly required.
+- **MessageOrdering has no effect.** `PubSub__MessageOrdering=true` sets `EnableMessageOrdering` on the subscription, but Pub/Sub only orders messages that carry an `OrderingKey`. The adapter does not set an `OrderingKey` when publishing, so delivery order is not guaranteed regardless of this setting.
 - **ExactlyOnceDelivery overhead.** This feature requires acknowledgment tracking on the Pub/Sub side and increases latency. Enable only when duplicate task execution is unacceptable.
 - **GCP authentication required in production.** The emulator does not require credentials; real GCP does. Ensure Application Default Credentials or a service account key is configured before deploying.
 - **Topic/subscription naming:** ArmoniK prepends `a` to the prefix to avoid names starting with `goog` (reserved by GCP). Keep `Prefix` short to stay within GCP's 255-character name limit.

--- a/.docs/content/1.concepts/4.adaptors.md
+++ b/.docs/content/1.concepts/4.adaptors.md
@@ -38,13 +38,13 @@ It allows using any AMQP server such as ActiveMQ, ActiveMQ Artemis, RabbitMQ or 
 - `ArmoniK.Core.Adapters.RabbitMQ` provides a dedicated adaptor for RabbitMQ.
 It uses RabbitMQ native client that supports priorities better than the AMQ protocol in our AMQP adaptor.
 
-- `ArmoniK.Core.Adapters.Nats` provides an Nats Jets Stream connector for ArmoniK. It allows using a Nats server.
+- `ArmoniK.Core.Adapters.Nats` provides a [NATS JetStream](./12.nats.md) connector for ArmoniK. It allows using a NATS server.
 
 Other adaptors for queue may also be available:
 
-- `ArmoniK.Core.Adapters.SQS` AmazonSQS (supports priority)
+- `ArmoniK.Core.Adapters.SQS` — [Amazon SQS](./13.sqs.md) (supports priority-based queue splitting)
 
-- `ArmoniK.Core.Adapters.PubSub` GCP Pub/Sub
+- `ArmoniK.Core.Adapters.PubSub` — [Google Cloud Pub/Sub](./14.pubsub.md)
 
 ## Object Storage Adaptors
 


### PR DESCRIPTION
# Motivation

RabbitMQ has a dedicated concept page (`5.rabbitmq.md`) covering architecture, limitations, configuration, and TLS setup. NATS, SQS, and Pub/Sub — three actively supported queue adapters — have no equivalent documentation. Users who choose these backends must read the source code to find configuration variables and understand limitations.

# Description

Three new pages under `1.concepts/`:

- **`12.nats.md`** — NATS JetStream adapter:
  - Stream/consumer architecture (one stream `armonik-stream`, one consumer per partition)
  - All `Nats__*` configuration variables with defaults and descriptions
  - Supported features: durable subscriptions, automatic redelivery, deadline extension
  - Limitations: no priority queues, fixed stream name
  - Health check endpoint

- **`13.sqs.md`** — Amazon SQS adapter:
  - Priority-based queue splitting (one queue per partition per priority level)
  - All `SQS__*` configuration variables with defaults and descriptions
  - Supported features: batch operations, long polling, FIFO ordering, KMS encryption
  - Limitations: 256 KB message size, 12h max visibility timeout
  - ElasticMQ local emulator for development

- **`14.pubsub.md`** — Google Cloud Pub/Sub adapter:
  - Topic/subscription model (one topic + one subscription per partition)
  - All `PubSub__*` configuration variables with defaults and descriptions
  - Supported features: message ordering, exactly-once delivery, KMS encryption, message retention
  - Limitations: no priority queues, ordering serializes delivery
  - Pub/Sub emulator for local development

Update `4.adaptors.md` to link to the three new pages.

# Testing

- Read each new page — content renders correctly
- Verify documented env vars against the Options classes in the source:
  - `Adaptors/Nats/src/Nats.cs`
  - `Adaptors/SQS/src/Options/SQS.cs`
  - `Adaptors/PubSub/src/PubSub.cs`
- Deploy with `just queue=nats build-deploy` and `just queue=sqs build-deploy` to confirm the variables work as documented

# Impact

Documentation only. No code changes. Users of NATS, SQS, and Pub/Sub now have a reference page equivalent to RabbitMQ's.

# Additional Information

Content was derived from the adapter source files, test configurations, and Terraform modules. Limitations reflect actual code behaviour (e.g. `MaxPriority` returning `int.MaxValue` for NATS and Pub/Sub indicates no priority routing is implemented).

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.