### PR TITLE
docs: add deployment topology diagram to components page

### DIFF
--- a/.docs/content/1.concepts/1.components.md
+++ b/.docs/content/1.concepts/1.components.md
@@ -14,7 +14,7 @@ The following diagram shows a full local deployment (`just build-deploy`). Optio
 graph TB
     Client(["External Client<br/>(gRPC)"])
 
-    subgraph Ingress ["Ingress (optional — ingress=true)"]
+    subgraph Ingress ["Ingress<br/>(optional — ingress=true)"]
         nginx_http["nginx :5201 (HTTP)"]
         nginx_tls["nginx :5202 (TLS)"]
         nginx_mtls["nginx :5203 (mTLS)"]

--- a/.docs/content/1.concepts/1.components.md
+++ b/.docs/content/1.concepts/1.components.md
@@ -21,29 +21,29 @@ graph TB
     end
 
     subgraph Control ["Control Plane"]
-        submitter["Submitter<br/>armonik.control.submitter<br/>:5001 gRPC | :5011 metrics"]
-        metrics["Metrics Exporter<br/>armonik.control.metrics<br/>:1080"]
+        submitter["Submitter<br/>armonik.control.submitter<br/>1080→5001 gRPC | 1081→5011 metrics"]
+        metrics["Metrics Exporter<br/>armonik.control.metrics<br/>1080→5002"]
     end
 
     subgraph Compute ["Compute Plane (× replicas)"]
-        pa["PollingAgent<br/>armonik.compute.pollingagentN<br/>:998N health"]
-        worker["Worker<br/>armonik.compute.workerN<br/>:108N"]
+        pa["PollingAgent<br/>armonik.compute.pollingagentN<br/>1080→998N health"]
+        worker["Worker<br/>armonik.compute.workerN<br/>1080→108N"]
         pa <-->|"Unix socket / TCP"| worker
     end
 
     subgraph Storage ["Storage"]
-        queue[("Queue\nActiveMQ / RabbitMQ\nNATS / SQS / Pub/Sub")]
-        db[("MongoDB\n:27017")]
-        obj[("Object Storage\nRedis / MinIO / GCS\n/ Local / Embed")]
+        queue[("Queue<br/>ActiveMQ / RabbitMQ<br/>NATS / SQS / Pub/Sub")]
+        db[("MongoDB<br/>:27017")]
+        obj[("Object Storage<br/>Redis / MinIO / GCS<br/>/ Local / Embed")]
     end
 
     subgraph Monitoring ["Monitoring"]
-        fluent["Fluent Bit\n:24224 (always)"]
-        seq["Seq :9080\n(seq=true)"]
-        prom["Prometheus :9090\n(prometheus=true)"]
-        grafana["Grafana :3000\n(grafana=true)"]
-        otel["OpenTelemetry Collector\n:4317 (tracing optional)"]
-        zipkin["Zipkin :9411\n(tracing optional)"]
+        fluent["Fluent Bit<br/>:24224 (always)"]
+        seq["Seq :4080<br/>(seq=true)"]
+        prom["Prometheus :9090<br/>(prometheus=true)"]
+        grafana["Grafana :3000<br/>(grafana=true)"]
+        otel["OpenTelemetry Collector<br/>:4317 (tracing optional)"]
+        zipkin["Zipkin :9411<br/>(tracing optional)"]
     end
 
     Client --> Ingress
@@ -63,9 +63,9 @@ graph TB
     otel --> zipkin
 ```
 
-**Container count** for a default deployment (`replicas=3`): ~15 containers (3 PollingAgents + 3 Workers + Submitter + Metrics + MongoDB + Queue + ObjectStorage + FluentBit + Seq + Prometheus + Grafana).
+**Container count** for a default deployment (`replicas=3`): ~16 containers (3 PollingAgents + 3 Workers + Submitter + Metrics + MongoDB + Queue + ObjectStorage + FluentBit + Seq + Prometheus + Grafana + Ingress).
 
-All containers share the `armonik_network` Docker bridge network.
+All containers share the `armonik_network` Docker bridge network (or `nat` on Windows).
 
 ## Common Library
 

--- a/.docs/content/1.concepts/1.components.md
+++ b/.docs/content/1.concepts/1.components.md
@@ -6,6 +6,67 @@ This page intends to describe the different software projects and components use
 - install: [ArmoniK](https://github.com/aneoconsulting/armonik)
 - use: [ArmoniK.Samples](https://github.com/aneoconsulting/ArmoniK.Samples)
 
+## Deployment topology
+
+The following diagram shows a full local deployment (`just build-deploy`). Optional components are annotated; core components are always present.
+
+```{mermaid}
+graph TB
+    Client(["External Client<br/>(gRPC)"])
+
+    subgraph Ingress ["Ingress (optional — ingress=true)"]
+        nginx_http["nginx :5201 (HTTP)"]
+        nginx_tls["nginx :5202 (TLS)"]
+        nginx_mtls["nginx :5203 (mTLS)"]
+    end
+
+    subgraph Control ["Control Plane"]
+        submitter["Submitter<br/>armonik.control.submitter<br/>:5001 gRPC | :5011 metrics"]
+        metrics["Metrics Exporter<br/>armonik.control.metrics<br/>:1080"]
+    end
+
+    subgraph Compute ["Compute Plane (× replicas)"]
+        pa["PollingAgent<br/>armonik.compute.pollingagentN<br/>:998N health"]
+        worker["Worker<br/>armonik.compute.workerN<br/>:108N"]
+        pa <-->|"Unix socket / TCP"| worker
+    end
+
+    subgraph Storage ["Storage"]
+        queue[("Queue\nActiveMQ / RabbitMQ\nNATS / SQS / Pub/Sub")]
+        db[("MongoDB\n:27017")]
+        obj[("Object Storage\nRedis / MinIO / GCS\n/ Local / Embed")]
+    end
+
+    subgraph Monitoring ["Monitoring"]
+        fluent["Fluent Bit\n:24224 (always)"]
+        seq["Seq :9080\n(seq=true)"]
+        prom["Prometheus :9090\n(prometheus=true)"]
+        grafana["Grafana :3000\n(grafana=true)"]
+        otel["OpenTelemetry Collector\n:4317 (tracing optional)"]
+        zipkin["Zipkin :9411\n(tracing optional)"]
+    end
+
+    Client --> Ingress
+    Ingress --> submitter
+    submitter --> queue
+    submitter --> db
+    submitter --> obj
+    pa --> queue
+    pa --> db
+    pa --> obj
+    metrics --> db
+    metrics --> queue
+    prom --> metrics
+    prom --> pa
+    grafana --> prom
+    fluent --> seq
+    otel --> zipkin
+```
+
+**Container count** for a default deployment (`replicas=3`): ~15 containers (3 PollingAgents + 3 Workers + Submitter + Metrics + MongoDB + Queue + ObjectStorage + FluentBit + Seq + Prometheus + Grafana).
+
+All containers share the `armonik_network` Docker bridge network.
+
 ## Common Library
 
 - **ArmoniK.Core.Common** provides the components required by all the other components of ArmoniK.


### PR DESCRIPTION
# Motivation

`1.components.md` lists the software components of ArmoniK but provides no visual overview of how they connect. Understanding the deployment topology (which containers run, which ports they use, which are optional) currently requires reading the Terraform modules under `terraform/modules/`. This is a significant barrier for new contributors and operators.

# Description

Add a Mermaid `graph TB` diagram to `1.components.md` showing a complete local deployment:

- **Core services**: Submitter, PollingAgent × N (connected via Unix socket or TCP to Worker × N), Metrics Exporter
- **Storage layer**: Queue (one of ActiveMQ/RabbitMQ/NATS/SQS/Pub/Sub), MongoDB, Object Storage (Redis/MinIO/GCS/Local/Embed)
- **Monitoring layer**: Fluent Bit (always), Seq, Prometheus, Grafana, OpenTelemetry Collector, Zipkin
- **Ingress**: NGINX (HTTP, TLS, mTLS variants)

Optional components are annotated with the controlling `just` flag (`seq=true`, `prometheus=true`, `grafana=true`, `ingress=true`, tracing). Default container count (replicas=3) is noted below the diagram.

# Testing

- Render the page on ReadTheDocs — Mermaid diagram displays correctly (Sphinx uses `sphinxcontrib.mermaid`)
- Verify all containers in the diagram exist in Terraform modules under `terraform/modules/`
- Verify port numbers match those in `terraform/modules/submitter/`, `terraform/modules/compute_plane/`, and `terraform/modules/monitoring/`

# Impact

Documentation only. No code changes. Gives operators and contributors a single visual reference for the full deployment.

# Additional Information

The diagram uses Mermaid `graph TB` syntax. The `.docs/conf.py` already includes `sphinxcontrib.mermaid` so no build configuration changes are needed.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.