### PR TITLE
fix(storage): validate task dependencies before finalization

### DIFF
--- a/Common/src/Exceptions/ResultInvalidStatusException.cs
+++ b/Common/src/Exceptions/ResultInvalidStatusException.cs
@@ -1,0 +1,63 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using ArmoniK.Core.Base.Exceptions;
+
+namespace ArmoniK.Core.Common.Exceptions;
+
+/// <summary>
+///   Exception thrown when one or more task dependencies are in a terminal invalid status (e.g. Aborted or DeletedData)
+///   and can therefore never transition to Completed.
+/// </summary>
+[Serializable]
+public class ResultInvalidStatusException : ArmoniKException
+{
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ResultInvalidStatusException" /> class.
+  /// </summary>
+  public ResultInvalidStatusException()
+  {
+  }
+
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ResultInvalidStatusException" /> class with a specified error
+  ///   message.
+  /// </summary>
+  /// <param name="message">The message that describes the error.</param>
+  public ResultInvalidStatusException(string message)
+    : base(message)
+  {
+  }
+
+  /// <summary>
+  ///   Initializes a new instance of the <see cref="ResultInvalidStatusException" /> class with a specified error
+  ///   message and a reference to the inner exception that is the cause of this exception.
+  /// </summary>
+  /// <param name="message">The error message that explains the reason for the exception.</param>
+  /// <param name="innerException">
+  ///   The exception that is the cause of the current exception, or a null reference if no inner
+  ///   exception is specified.
+  /// </param>
+  public ResultInvalidStatusException(string    message,
+                                      Exception innerException)
+    : base(message,
+           innerException)
+  {
+  }
+}

--- a/Common/src/Storage/TaskLifeCycleHelper.cs
+++ b/Common/src/Storage/TaskLifeCycleHelper.cs
@@ -329,6 +329,7 @@ public static class TaskLifeCycleHelper
 
     var allDependencies       = new HashSet<string>();
     var completedDependencies = new List<string>();
+    var invalidDependencies   = new List<string>();
 
     // Get all the results that are a dependency of at least one task
     foreach (var request in taskRequests)
@@ -340,14 +341,57 @@ public static class TaskLifeCycleHelper
     logger.LogDebug("Check Result status for results {@ResultIds}",
                     allDependencies);
 
-    // Get the dependencies that are already completed to avoid tracking already completed results
-    await foreach (var resultId in resultTable.GetResults(result => allDependencies.Contains(result.ResultId) && result.Status == ResultStatus.Completed,
-                                                          result => result.ResultId,
-                                                          cancellationToken)
-                                              .ConfigureAwait(false))
+    // Fetch all dependencies in a single query so we can validate existence and status before tracking
+    var results = await resultTable.GetResults(result => allDependencies.Contains(result.ResultId),
+                                               result => new
+                                                         {
+                                                           result.ResultId,
+                                                           result.Status,
+                                                         },
+                                               cancellationToken)
+                                   .ToListAsync(cancellationToken)
+                                   .ConfigureAwait(false);
+
+    // A missing result means the caller referenced a result that was never created; fail fast rather than
+    // leaving tasks permanently stuck waiting for a dependency that will never appear
+    if (results.Count != allDependencies.Count)
     {
-      allDependencies.Remove(resultId);
-      completedDependencies.Add(resultId);
+      var existingResultIds = results.Select(r => r.ResultId)
+                                     .ToHashSet();
+      var missingResultIds = allDependencies.Where(id => !existingResultIds.Contains(id));
+      logger.LogError("The following dependencies do not exist in the ResultTable: {@ResultIds}",
+                      missingResultIds);
+      throw new ResultNotFoundException($"Some dependencies do not exist in the ResultTable: {string.Join(", ", missingResultIds)}");
+    }
+
+    // Check the status of the dependencies. Completed dependencies can be removed from the tasks right away,
+    // while Aborted or DeletedData dependencies should mark the task as invalid
+    foreach (var result in results)
+    {
+      switch (result.Status)
+      {
+        case ResultStatus.Completed:
+          allDependencies.Remove(result.ResultId);
+          completedDependencies.Add(result.ResultId);
+          break;
+        case ResultStatus.Created:
+          break;
+        case ResultStatus.Aborted:
+        case ResultStatus.DeletedData:
+        case ResultStatus.Unspecified:
+        default:
+          invalidDependencies.Add(result.ResultId);
+          break;
+      }
+    }
+
+    // Aborted and DeletedData are terminal states: a result in these states can never become Completed,
+    // so any task depending on them would block forever
+    if (invalidDependencies.Any())
+    {
+      logger.LogError("The following dependencies have invalid status: {@InvalidResults}",
+                      invalidDependencies);
+      throw new ResultInvalidStatusException($"Some dependencies have invalid status: {string.Join(", ", invalidDependencies)}");
     }
 
     // Build the mapping between tasks and their dependencies

--- a/Common/src/gRPC/Services/GrpcSubmitterService.cs
+++ b/Common/src/gRPC/Services/GrpcSubmitterService.cs
@@ -308,6 +308,20 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
                                         "Session not found"));
     }
+    catch (ResultInvalidStatusException e)
+    {
+      logger_.LogWarning(e,
+                         "Error while submitting tasks due to invalid dependency status");
+      throw new RpcException(new Status(StatusCode.FailedPrecondition,
+                                        "One or more dependencies have an invalid status"));
+    }
+    catch (ResultNotFoundException e)
+    {
+      logger_.LogWarning(e,
+                         "Error while submitting tasks due to dependency that does not exist");
+      throw new RpcException(new Status(StatusCode.NotFound,
+                                        "One or more dependencies do not exist"));
+    }
     catch (ArmoniKException e)
     {
       logger_.LogWarning(e,
@@ -400,6 +414,20 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
                          "Error while creating tasks");
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
                                         "Session not found"));
+    }
+    catch (ResultInvalidStatusException e)
+    {
+      logger_.LogWarning(e,
+                         "Error while submitting tasks due to invalid dependency status");
+      throw new RpcException(new Status(StatusCode.FailedPrecondition,
+                                        "One or more dependencies have an invalid status"));
+    }
+    catch (ResultNotFoundException e)
+    {
+      logger_.LogWarning(e,
+                         "Error while submitting tasks due to dependency that does not exist");
+      throw new RpcException(new Status(StatusCode.NotFound,
+                                        "One or more dependencies do not exist"));
     }
     catch (ArmoniKException e)
     {

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -571,5 +571,19 @@ public class GrpcTasksService : Task.TasksBase
       throw new RpcException(new Status(StatusCode.FailedPrecondition,
                                         "Client submission is closed, no tasks can be submitted"));
     }
+    catch (ResultInvalidStatusException e)
+    {
+      logger_.LogWarning(e,
+                         "Error while submitting tasks due to invalid dependency status");
+      throw new RpcException(new Status(StatusCode.FailedPrecondition,
+                                        "One or more dependencies have an invalid status"));
+    }
+    catch (ResultNotFoundException e)
+    {
+      logger_.LogWarning(e,
+                         "Error while submitting tasks due to dependency that does not exist");
+      throw new RpcException(new Status(StatusCode.NotFound,
+                                        "One or more dependencies do not exist"));
+    }
   }
 }

--- a/Common/tests/TaskLifeCycleHelperTest.cs
+++ b/Common/tests/TaskLifeCycleHelperTest.cs
@@ -26,6 +26,7 @@ using System.Threading.Tasks;
 
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Core.Base;
+using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Convertors;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Storage;
@@ -43,6 +44,7 @@ using ResultStatus = ArmoniK.Core.Common.Storage.ResultStatus;
 using SessionStatus = ArmoniK.Core.Common.Storage.SessionStatus;
 using TaskRequest = ArmoniK.Core.Common.gRPC.Services.TaskRequest;
 using TaskStatus = ArmoniK.Core.Common.Storage.TaskStatus;
+using Type = System.Type;
 
 namespace ArmoniK.Core.Common.Tests;
 
@@ -1496,5 +1498,107 @@ public class TaskLifeCycleHelperTest
                                                       : "A")
                                      .And.No.Member("root"));
                     });
+  }
+
+  [TestCase(null,
+            typeof(ResultNotFoundException))]
+  [TestCase(ResultStatus.Aborted,
+            typeof(ResultInvalidStatusException))]
+  [TestCase(ResultStatus.DeletedData,
+            typeof(ResultInvalidStatusException))]
+  public async Task TaskCreationWithInvalidDependencyShouldThrow(ResultStatus? dependencyStatus,
+                                                                 Type          expectedException)
+  {
+    using var holder = new Holder();
+
+    var sessionId = await SessionLifeCycleHelper.CreateSession(holder.SessionTable,
+                                                               holder.PartitionTable,
+                                                               new List<string>
+                                                               {
+                                                                 Holder.Partition,
+                                                               },
+                                                               holder.Options.ToTaskOptions(),
+                                                               Holder.Partition)
+                                                .ConfigureAwait(false);
+
+    var sessionData = await holder.SessionTable.GetSessionAsync(sessionId)
+                                  .ConfigureAwait(false);
+
+    var payloadId = Guid.NewGuid()
+                        .ToString();
+    var dependencyId = Guid.NewGuid()
+                           .ToString();
+
+    var resultsToCreate = new List<Result>
+                          {
+                            new(sessionId,
+                                payloadId,
+                                "Payload",
+                                "",
+                                "",
+                                "",
+                                ResultStatus.Completed,
+                                new List<string>(),
+                                DateTime.UtcNow,
+                                DateTime.UtcNow,
+                                0,
+                                Array.Empty<byte>(),
+                                false),
+                          };
+
+    // When dependencyStatus is null the dependency result is never inserted, simulating a missing result
+    if (dependencyStatus is not null)
+    {
+      resultsToCreate.Add(new Result(sessionId,
+                                     dependencyId,
+                                     "Dependency",
+                                     "",
+                                     "",
+                                     "",
+                                     dependencyStatus.Value,
+                                     new List<string>(),
+                                     DateTime.UtcNow,
+                                     null,
+                                     0,
+                                     Array.Empty<byte>(),
+                                     false));
+    }
+
+    await holder.ResultTable.Create(resultsToCreate)
+                .ConfigureAwait(false);
+
+    var tasks = new List<TaskCreationRequest>
+                {
+                  new(Guid.NewGuid()
+                          .ToString(),
+                      payloadId,
+                      holder.Options.ToTaskOptions(),
+                      new List<string>
+                      {
+                        Guid.NewGuid()
+                            .ToString(),
+                      },
+                      new List<string>
+                      {
+                        dependencyId,
+                      }),
+                };
+
+    await TaskLifeCycleHelper.CreateTasks(holder.TaskTable,
+                                          holder.ResultTable,
+                                          sessionId,
+                                          sessionId,
+                                          tasks,
+                                          NullLogger.Instance)
+                             .ConfigureAwait(false);
+
+    Assert.ThrowsAsync(expectedException,
+                       () => TaskLifeCycleHelper.FinalizeTaskCreation(holder.TaskTable,
+                                                                      holder.ResultTable,
+                                                                      holder.PushQueueStorage,
+                                                                      tasks,
+                                                                      sessionData,
+                                                                      sessionId,
+                                                                      NullLogger.Instance));
   }
 }


### PR DESCRIPTION
# Motivation

When a task was submitted with dependencies referencing results that did not exist or that were in a terminal invalid state (`Aborted`, `DeletedData`), the system had no early detection mechanism. Tasks would end up permanently stuck in `Pending` state waiting for a dependency that can never become `Completed`.

# Description

Added two validation checks in `PrepareTaskDependencies` (called by `FinalizeTaskCreation`):

1. **Missing dependency detection** — after fetching all dependency results in a single query, the count is compared against the set of requested dependency IDs. If any are missing, the existing `ResultNotFoundException` is raised immediately with the list of unknown IDs.

2. **Invalid status detection** — a `switch` on each result's status routes `Completed` to the already-resolved set, `Created` to the pending-tracking set, and everything else (`Aborted`, `DeletedData`, `Unspecified`, or any unknown future status) to an invalid list. If the invalid list is non-empty after the loop, the new `ResultInvalidStatusException` is raised.

The two gRPC services that expose task submission (`GrpcSubmitterService`, `GrpcTasksService`) now catch both exception types and convert them to proper gRPC status codes:
- `ResultNotFoundException` → `StatusCode.NotFound`
- `ResultInvalidStatusException` → `StatusCode.FailedPrecondition`

As a side effect, the previous two-pass approach (one streaming query for completed-only, plus an implicit pass-through for everything else) is replaced by a single batched query whose in-memory result is reused for both validation and completed-dependency filtering.

### Files changed
- `Common/src/Exceptions/ResultInvalidStatusException.cs` *(new)* — thrown when a dependency is in a terminal non-completable state
- `Common/src/Storage/TaskLifeCycleHelper.cs` — validation logic using the new and existing exceptions
- `Common/src/gRPC/Services/GrpcSubmitterService.cs` — gRPC error mapping for both new exception paths
- `Common/src/gRPC/Services/GrpcTasksService.cs` — same
- `Common/tests/TaskLifeCycleHelperTest.cs` — test coverage

# Testing

Added a single parameterized NUnit test `TaskCreationWithInvalidDependencyShouldThrow` with three `[TestCase]` entries:

| `dependencyStatus` | Expected exception |
|---|---|
| `null` (result never inserted) | `ResultNotFoundException` |
| `ResultStatus.Aborted` | `ResultInvalidStatusException` |
| `ResultStatus.DeletedData` | `ResultInvalidStatusException` |

All three cases pass locally.

# Impact

- Task submission will now fail fast at `FinalizeTaskCreation` time rather than silently leaving tasks in `Pending` forever when dependencies are missing or in a terminal invalid state.
- Callers receive a typed gRPC error (`NOT_FOUND` or `FAILED_PRECONDITION`) instead of a silent hang.
- No performance regression: two async streaming queries replaced by one batched query with in-memory filtering.

# Additional Information

`ResultInvalidStatusException` also catches `Unspecified` and any unrecognised future status values via the `default` branch of the switch, making the validation forward-compatible.