### PR TITLE
chore(nats): use class decorator so document extraction tool picks nats options

### DIFF
--- a/Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj
+++ b/Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj
@@ -31,6 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.7.3" />
     <PackageReference Include="NATS.Client" Version="1.1.8" />
     <PackageReference Include="NATS.Client.JetStream" Version="2.7.2" />
     <PackageReference Include="NATS.Net" Version="2.7.2" />

--- a/Adaptors/Nats/src/Nats.cs
+++ b/Adaptors/Nats/src/Nats.cs
@@ -1,17 +1,17 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-//
+// 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-//
+// 
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-//
+// 
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 

--- a/Adaptors/Nats/src/Nats.cs
+++ b/Adaptors/Nats/src/Nats.cs
@@ -1,19 +1,21 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published
 // by the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY, without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 // GNU Affero General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using ArmoniK.Utils.DocAttribute;
 
 namespace ArmoniK.Core.Adapters.Nats;
 
@@ -21,6 +23,7 @@ namespace ArmoniK.Core.Adapters.Nats;
 ///   All Allowed option for Nats queue in ArmoniK.
 ///   Can be set through configuration sources.
 /// </summary>
+[ExtractDocumentation("Options for Nats")]
 internal class Nats
 {
   /// <summary>


### PR DESCRIPTION
 # Motivation

  The NATS adapter's configuration options were not being picked up by the document extraction tool used to generate environment variable documentation. The `Nats` options class was missing the `[ExtractDocumentation]`
  decorator that signals the tool to include the class in its output.

  # Description

  - Added the `ArmoniK.Utils.DocAttribute` package (`0.7.3`) to `Adaptors/Nats/src/ArmoniK.Core.Adapters.Nats.csproj`.
  - Applied the `[ExtractDocumentation("Options for Nats")]` attribute to the `Nats` class in `Adaptors/Nats/src/Nats.cs` so the documentation extraction tool now correctly discovers and documents NATS configuration options
  alongside other adapters.

  # Testing
  
  The change is mechanical (adding a decorator + package reference). Existing unit and integration tests for the NATS adapter cover the runtime behaviour and are unaffected.

  # Impact
  
  No runtime behaviour change. NATS configuration options will now appear in the auto-generated environment variable documentation, consistent with other adapters.

  # Additional Information

  The same `[ExtractDocumentation]` pattern is used by other adapter option classes. This change brings NATS in line with them.

  # Checklist
  
  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [x] I have made corresponding changes to the documentation.
  - [ ] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.
  - [ ] I have assessed the performance impact of my modifications.
