### PR TITLE
refactor(grpc): bind ExceptionInterceptor to ExceptionManager

### DIFF
--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -1,5 +1,5 @@
 // This file is part of the ArmoniK project
-// 
+//
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -16,12 +16,11 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Concurrent;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
-using ArmoniK.Core.Common.Injection.Options;
+using ArmoniK.Core.Common.Utils;
 
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -37,48 +36,42 @@ namespace ArmoniK.Core.Common.gRPC;
 /// </summary>
 public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
 {
-  private readonly ConcurrentQueue<Exception> errors_;
-  private readonly ILogger                    logger_;
-  private readonly int                        maxAllowedErrors_;
+  private readonly ExceptionManager exceptionManager_;
+  private readonly ILogger          logger_;
 
   /// <summary>
   ///   Construct the interceptor
   /// </summary>
-  /// <param name="submitterOptions">Map containing the submitter options, and especially `Options.Submitter.MaxErrorAllowed`</param>
+  /// <param name="exceptionManager">Component that record errors and success</param>
   /// <param name="logger">Logger to be used by the interceptor</param>
-  public ExceptionInterceptor(Submitter                     submitterOptions,
+  public ExceptionInterceptor(ExceptionManager              exceptionManager,
                               ILogger<ExceptionInterceptor> logger)
   {
-    maxAllowedErrors_ = submitterOptions.MaxErrorAllowed;
-    errors_           = new ConcurrentQueue<Exception>();
+    exceptionManager_ = exceptionManager;
     logger_           = logger;
-    logger_.LogDebug("Interceptor created with {maxAllowedErrors_} maximum errors",
-                     maxAllowedErrors_);
   }
 
   /// <inheritdoc />
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
-  {
-    _ = tag;
-    logger_.LogDebug("Interceptor HealthCheck: errors {nbErrors}/{maxAllowedErrors}",
-                     errors_.Count,
-                     maxAllowedErrors_);
-    return Task.FromResult(maxAllowedErrors_ < 0 || errors_.Count <= maxAllowedErrors_
-                             ? HealthCheckResult.Healthy()
-                             : HealthCheckResult.Unhealthy("Too many errors recorded",
-                                                           new AggregateException(errors_)));
-  }
+    => Task.FromResult((tag, exceptionManager_.Failed) switch
+                       {
+                         // If there is too many errors, the pod is marked as not ready to avoid Kubernetes sending new requests to the controller.
+                         // Liveness Unhealthy is not needed as the pod is killing itself, without the intervention of Kubernetes.
+                         (HealthCheckTag.Readiness, true) => HealthCheckResult.Unhealthy("Too many error recorded, application is shutting down"),
+                         _                                => HealthCheckResult.Healthy(),
+                       });
 
   /// <inheritdoc />
   public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest                               request,
                                                                                 ServerCallContext                      context,
                                                                                 UnaryServerMethod<TRequest, TResponse> continuation)
   {
+    TResponse response;
     try
     {
-      return await continuation(request,
-                                context)
-               .ConfigureAwait(false);
+      response = await continuation(request,
+                                    context)
+                   .ConfigureAwait(false);
     }
     catch (Exception e)
     {
@@ -87,6 +80,11 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
         .ConfigureAwait(false);
       throw;
     }
+
+    await HandleSuccess(context)
+      .ConfigureAwait(false);
+
+    return response;
   }
 
   /// <inheritdoc />
@@ -94,12 +92,13 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                                                                                           ServerCallContext                                context,
                                                                                           ClientStreamingServerMethod<TRequest, TResponse> continuation)
   {
+    TResponse response;
     try
     {
-      return await base.ClientStreamingServerHandler(requestStream,
-                                                     context,
-                                                     continuation)
-                       .ConfigureAwait(false);
+      response = await base.ClientStreamingServerHandler(requestStream,
+                                                         context,
+                                                         continuation)
+                           .ConfigureAwait(false);
     }
     catch (Exception e)
     {
@@ -108,6 +107,11 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
         .ConfigureAwait(false);
       throw;
     }
+
+    await HandleSuccess(context)
+      .ConfigureAwait(false);
+
+    return response;
   }
 
   /// <inheritdoc />
@@ -131,6 +135,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
         .ConfigureAwait(false);
       throw;
     }
+
+    await HandleSuccess(context)
+      .ConfigureAwait(false);
   }
 
   /// <inheritdoc />
@@ -154,6 +161,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
         .ConfigureAwait(false);
       throw;
     }
+
+    await HandleSuccess(context)
+      .ConfigureAwait(false);
   }
 
   private ValueTask HandleException(Exception         e,
@@ -189,13 +199,18 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
       }
     }
 
-    logger_.LogDebug(e,
-                     "An exception has been thrown during handling of request");
-    // If we have already too many errors, stop recording
-    if (errors_.Count <= maxAllowedErrors_)
-    {
-      errors_.Enqueue(e);
-    }
+    exceptionManager_.RecordError(logger_,
+                                  e,
+                                  "An exception has been thrown during handling of request");
+
+    return ValueTask.CompletedTask;
+  }
+
+  private ValueTask HandleSuccess(ServerCallContext context)
+  {
+    _ = context;
+
+    exceptionManager_.RecordSuccess(logger_);
 
     return ValueTask.CompletedTask;
   }

--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -1,5 +1,5 @@
 // This file is part of the ArmoniK project
-//
+// 
 // Copyright (C) ANEO, 2021-2026. All rights reserved.
 // 
 // This program is free software: you can redistribute it and/or modify
@@ -57,7 +57,7 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                        {
                          // If there is too many errors, the pod is marked as not ready to avoid Kubernetes sending new requests to the controller.
                          // Liveness Unhealthy is not needed as the pod is killing itself, without the intervention of Kubernetes.
-                         (HealthCheckTag.Readiness, true) => HealthCheckResult.Unhealthy("Too many error recorded, application is shutting down"),
+                         (HealthCheckTag.Readiness, true) => HealthCheckResult.Unhealthy("Too many errors recorded, application is shutting down"),
                          _                                => HealthCheckResult.Healthy(),
                        });
 

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -29,6 +29,7 @@ using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Helpers;
+using ArmoniK.Core.Common.Utils;
 
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -37,7 +38,10 @@ using Grpc.Core;
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 using Moq;
 
@@ -58,8 +62,7 @@ internal class ExceptionInterceptorTests
 {
   [SetUp]
   public void SetUp()
-  {
-  }
+    => lifetime_ = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
 
   [OneTimeSetUp]
   public void OneTimeSetUp()
@@ -75,9 +78,21 @@ internal class ExceptionInterceptorTests
                    .ConfigureAwait(false);
       helper_.Dispose();
     }
+
+    lifetime_.StopApplication();
   }
 
   private GrpcSubmitterServiceHelper? helper_;
+  private ApplicationLifetime         lifetime_ = null!;
+
+  private ExceptionManager BuildExceptionManager(int maxError)
+    => new(lifetime_,
+           new OptionsWrapper<ConsoleLifetimeOptions>(new ConsoleLifetimeOptions()),
+           new HostingEnvironment(),
+           new OptionsWrapper<HostOptions>(new HostOptions()),
+           NullLogger<ExceptionManager>.Instance,
+           new ExceptionManager.Options(TimeSpan.Zero,
+                                        maxError));
 
   [Test]
   [Obsolete]
@@ -109,10 +124,8 @@ internal class ExceptionInterceptorTests
                                   ? Task.FromResult(noErrorReply)
                                   : Task.FromException<CreateSessionReply>(ex));
 
-    var interceptor = new ExceptionInterceptor(new Injection.Options.Submitter
-                                               {
-                                                 MaxErrorAllowed = 1,
-                                               },
+    using var exceptionManager = BuildExceptionManager(1);
+    var interceptor = new ExceptionInterceptor(exceptionManager,
                                                NullLogger<ExceptionInterceptor>.Instance);
     helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object,
                                              services => services.AddSingleton(interceptor)
@@ -120,7 +133,7 @@ internal class ExceptionInterceptorTests
     var client = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(await helper_.CreateChannel()
                                                                                   .ConfigureAwait(false));
 
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
 
@@ -131,7 +144,7 @@ internal class ExceptionInterceptorTests
     {
       Assert.That(client.CreateSession(request),
                   Is.EqualTo(noErrorReply));
-      Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+      Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                     .ConfigureAwait(false)).Status,
                   Is.EqualTo(HealthStatus.Healthy));
     }
@@ -143,7 +156,7 @@ internal class ExceptionInterceptorTests
     {
       Assert.That(() => client.CreateSession(request),
                   Throws.InstanceOf<RpcException>());
-      Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+      Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                     .ConfigureAwait(false)).Status,
                   Is.EqualTo(HealthStatus.Healthy));
     }
@@ -152,21 +165,21 @@ internal class ExceptionInterceptorTests
     ex = new ApplicationException("server error");
     Assert.That(() => client.CreateSession(request),
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
     // Call #10 with server error
     ex = new ApplicationException("server error");
     Assert.That(() => client.CreateSession(request),
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
     // Call #11 without error
     ex = null;
     Assert.That(client.CreateSession(request),
                 Is.EqualTo(noErrorReply));
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
   }
@@ -233,10 +246,8 @@ internal class ExceptionInterceptorTests
                                    };
                           });
 
-    var interceptor = new ExceptionInterceptor(new Injection.Options.Submitter
-                                               {
-                                                 MaxErrorAllowed = 1,
-                                               },
+    using var exceptionManager = BuildExceptionManager(1);
+    var interceptor = new ExceptionInterceptor(exceptionManager,
                                                NullLogger<ExceptionInterceptor>.Instance);
     helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object,
                                              services => services.AddSingleton(interceptor)
@@ -244,7 +255,7 @@ internal class ExceptionInterceptorTests
     var client = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(await helper_.CreateChannel()
                                                                                   .ConfigureAwait(false));
 
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
 
@@ -350,7 +361,7 @@ internal class ExceptionInterceptorTests
       Assert.That(await CreateLargeTasks(10)
                     .ConfigureAwait(false),
                   Is.EqualTo(noErrorReply));
-      Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+      Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                     .ConfigureAwait(false)).Status,
                   Is.EqualTo(HealthStatus.Healthy));
     }
@@ -365,7 +376,7 @@ internal class ExceptionInterceptorTests
       failAfter = i;
       Assert.That(() => CreateLargeTasks(10),
                   Throws.InstanceOf<RpcException>());
-      Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+      Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                     .ConfigureAwait(false)).Status,
                   Is.EqualTo(HealthStatus.Healthy));
     }
@@ -375,7 +386,7 @@ internal class ExceptionInterceptorTests
     failAfter = 0;
     Assert.That(() => CreateLargeTasks(10),
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
     // Call #10 with server error
@@ -383,7 +394,7 @@ internal class ExceptionInterceptorTests
     failAfter = 1;
     Assert.That(() => CreateLargeTasks(10),
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
   }
@@ -443,10 +454,8 @@ internal class ExceptionInterceptorTests
                             }
                           });
 
-    var interceptor = new ExceptionInterceptor(new Injection.Options.Submitter
-                                               {
-                                                 MaxErrorAllowed = 3,
-                                               },
+    using var exceptionManager = BuildExceptionManager(3);
+    var interceptor = new ExceptionInterceptor(exceptionManager,
                                                NullLogger<ExceptionInterceptor>.Instance);
     helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object,
                                              services => services.AddSingleton(interceptor)
@@ -454,7 +463,7 @@ internal class ExceptionInterceptorTests
     var client = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(await helper_.CreateChannel()
                                                                                   .ConfigureAwait(false));
 
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
 
@@ -479,7 +488,7 @@ internal class ExceptionInterceptorTests
     {
       Assert.That(TryGetResult,
                   Throws.Nothing);
-      Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+      Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                     .ConfigureAwait(false)).Status,
                   Is.EqualTo(HealthStatus.Healthy));
     }
@@ -492,7 +501,7 @@ internal class ExceptionInterceptorTests
       failAfter = i;
       Assert.That(TryGetResult,
                   Throws.InstanceOf<RpcException>());
-      Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+      Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                     .ConfigureAwait(false)).Status,
                   Is.EqualTo(HealthStatus.Healthy));
     }
@@ -502,7 +511,7 @@ internal class ExceptionInterceptorTests
     failAfter = 0;
     Assert.That(TryGetResult,
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
     // Call #10 with server error
@@ -510,7 +519,7 @@ internal class ExceptionInterceptorTests
     failAfter = 1;
     Assert.That(TryGetResult,
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
     // Call #11 with server error
@@ -518,7 +527,7 @@ internal class ExceptionInterceptorTests
     failAfter = 2;
     Assert.That(TryGetResult,
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.EqualTo(HealthStatus.Healthy));
     // Call #12 with server error
@@ -526,7 +535,7 @@ internal class ExceptionInterceptorTests
     failAfter = 3;
     Assert.That(TryGetResult,
                 Throws.InstanceOf<RpcException>());
-    Assert.That((await interceptor.Check(HealthCheckTag.Liveness)
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
   }


### PR DESCRIPTION
# Motivation

`ExceptionInterceptor` used to maintain its own error queue and `MaxErrorAllowed`
threshold, in parallel with the application-wide `ExceptionManager` that
already tracks errors and drives shutdown. Two independent error-management
systems made it harder to reason about overall service health and duplicated
logic.

# Description

Bind `ExceptionInterceptor` to `ExceptionManager` so there is a single source
of truth for error accounting.

- Constructor now takes an `ExceptionManager` instead of
  `Injection.Options.Submitter`. Errors that survive the client-error
  short-circuit are reported via `ExceptionManager.RecordError`, and
  successful calls are reported via `ExceptionManager.RecordSuccess`.
- The `IHealthCheckProvider.Check` implementation reports `Unhealthy` only
  when `tag == HealthCheckTag.Readiness` **and** the manager is in `Failed`
  state. All other combinations, notably `Liveness`, return `Healthy`,
  matching the readiness-vs-liveness convention used elsewhere.
- The local concurrent error queue and `maxAllowedErrors_` counter are
  removed.
- `ExceptionInterceptorTests` are updated to construct a real
  `ExceptionManager` (via a small `BuildExceptionManager(int maxError)` helper
  modeled on `ExceptionManagerTests`) and to query
  `HealthCheckTag.Readiness` instead of `Liveness`. The test fixture now
  manages an `ApplicationLifetime` in `SetUp`/`TearDown`.

The DI wiring in `Control/Submitter/src/Program.cs` already provides an
`ExceptionManager` (registered via `AddExceptionManager`), so the new
constructor is satisfied without further changes.

# Testing

- `dotnet build Common/tests/ArmoniK.Core.Common.Tests.csproj`: 0 errors.
- `dotnet test ... --filter FullyQualifiedName~ExceptionInterceptorTests`:
  3 passed, 0 failed (Unary, ClientStream, ServerStream variants).

The existing call sequences (4 successes, 4 client errors, then server errors
until the budget is exhausted) still drive the interceptor to Unhealthy at
exactly the same call number as before, because:

- Client errors (RpcException with `NotFound` / `InvalidArgument` /
  `Cancelled` / …) still short-circuit `HandleException` without recording.
- Server errors call `RecordError`; the (n+1)-th flips
  `ExceptionManager.Failed` to true, matching the old
  `errors_.Count > maxAllowedErrors_` trigger point.
- `RecordSuccess` is a no-op when `nbError == 0` or when `Failed` is already
  true, so success-after-failure does not un-fail the manager (matching the
  old non-decrementing queue).

# Impact

- Behaviour change: `ExceptionInterceptor` only reports `Unhealthy` on the
  Readiness health-check tag now (previously, on every tag). Any consumer
  polling Liveness for "too many errors" will no longer see Unhealthy, but
  that signal was conceptually a readiness signal anyway, and Liveness should
  remain Healthy while the process is still running.
- Configuration: the interceptor no longer reads
  `Submitter.MaxErrorAllowed`; the equivalent limit is now configured on the
  shared `ExceptionManager.Options.MaxError` value used by the rest of the
  service.
- No new dependencies. No public-API change beyond the constructor of
  `ExceptionInterceptor`, which is resolved via DI.

# Additional Information

The interceptor's `[Obsolete]` test methods stay obsolete, they still
exercise the obsolete `ISubmitter` surface, unrelated to this change.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.