### PR TITLE
refactor(grpc): centralize exception-to-RpcException mapping in ExceptionInterceptor

### DIFF
--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -20,6 +20,8 @@ using System.Threading.Tasks;
 
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Base.Exceptions;
+using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.Utils;
 
 using Grpc.Core;
@@ -169,41 +171,87 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
   private ValueTask HandleException(Exception         e,
                                     ServerCallContext context)
   {
-    _ = context;
-    if (e is RpcException rpcException)
+    switch (e)
     {
-      switch (rpcException.Status.StatusCode)
-      {
-        case StatusCode.OK:
-        case StatusCode.Cancelled:
-        case StatusCode.InvalidArgument:
-        case StatusCode.NotFound:
-        case StatusCode.AlreadyExists:
-        case StatusCode.PermissionDenied:
-        case StatusCode.Unauthenticated:
-        case StatusCode.FailedPrecondition:
-        case StatusCode.OutOfRange:
-          logger_.LogDebug(e,
-                           "An exception has been thrown during handling of request due to client error");
-          return ValueTask.CompletedTask;
-        case StatusCode.Unknown:
-        case StatusCode.DeadlineExceeded:
-        case StatusCode.ResourceExhausted:
-        case StatusCode.Aborted:
-        case StatusCode.Unimplemented:
-        case StatusCode.Internal:
-        case StatusCode.Unavailable:
-        case StatusCode.DataLoss:
-        default:
-          break;
-      }
+      case OperationCanceledException:
+        if (context.CancellationToken.IsCancellationRequested)
+        {
+          logger_.LogWarning(e,
+                             "Client has cancelled the request");
+        }
+        else
+        {
+          exceptionManager_.RecordError(logger_,
+                                        e,
+                                        "Request has been canceled by internal means");
+        }
+
+        break;
+      case ObjectDataNotFoundException:
+      case PartitionNotFoundException:
+      case ResultNotFoundException:
+      case SessionNotFoundException:
+      case TaskNotFoundException:
+        logger_.LogWarning(e,
+                           e.Message);
+        return ValueTask.FromException(new RpcException(new Status(StatusCode.NotFound,
+                                                                   e.Message)));
+      case InvalidSessionTransitionException:
+      case ResultInvalidStatusException:
+      case SubmissionClosedException:
+        logger_.LogWarning(e,
+                           e.Message);
+        return ValueTask.FromException(new RpcException(new Status(StatusCode.FailedPrecondition,
+                                                                   e.Message)));
+      case ArmoniKException:
+        exceptionManager_.RecordError(logger_,
+                                      e,
+                                      e.Message);
+        return ValueTask.FromException(new RpcException(new Status(StatusCode.Internal,
+                                                                   e.Message)));
+
+      case RpcException rpcException:
+
+        switch (rpcException.Status.StatusCode)
+        {
+          case StatusCode.OK:
+          case StatusCode.Cancelled:
+          case StatusCode.InvalidArgument:
+          case StatusCode.NotFound:
+          case StatusCode.AlreadyExists:
+          case StatusCode.PermissionDenied:
+          case StatusCode.Unauthenticated:
+          case StatusCode.FailedPrecondition:
+          case StatusCode.OutOfRange:
+            logger_.LogError(e,
+                             "An exception has been thrown during handling of request due to client error");
+            break;
+          case StatusCode.Unknown:
+          case StatusCode.DeadlineExceeded:
+          case StatusCode.ResourceExhausted:
+          case StatusCode.Aborted:
+          case StatusCode.Unimplemented:
+          case StatusCode.Internal:
+          case StatusCode.Unavailable:
+          case StatusCode.DataLoss:
+          default:
+            exceptionManager_.RecordError(logger_,
+                                          e,
+                                          "An exception has been thrown during handling of request");
+            break;
+        }
+
+        break;
+      default:
+        exceptionManager_.RecordError(logger_,
+                                      e,
+                                      "An unknown exception has been thrown during handling of request");
+
+        throw new RpcException(new Status(StatusCode.Unknown,
+                                          "Unknown Exception, see application logs"));
     }
 
-    exceptionManager_.RecordError(logger_,
-                                  e,
-                                  "An exception has been thrown during handling of request");
-
-    return ValueTask.CompletedTask;
+    return ValueTask.FromException(e);
   }
 
   private ValueTask HandleSuccess(ServerCallContext context)

--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -77,14 +77,11 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
     }
     catch (Exception e)
     {
-      await HandleException(e,
-                            context)
-        .ConfigureAwait(false);
-      throw;
+      throw HandleException(e,
+                            context);
     }
 
-    await HandleSuccess(context)
-      .ConfigureAwait(false);
+    HandleSuccess(context);
 
     return response;
   }
@@ -104,14 +101,11 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
     }
     catch (Exception e)
     {
-      await HandleException(e,
-                            context)
-        .ConfigureAwait(false);
-      throw;
+      throw HandleException(e,
+                            context);
     }
 
-    await HandleSuccess(context)
-      .ConfigureAwait(false);
+    HandleSuccess(context);
 
     return response;
   }
@@ -132,14 +126,11 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
     }
     catch (Exception e)
     {
-      await HandleException(e,
-                            context)
-        .ConfigureAwait(false);
-      throw;
+      throw HandleException(e,
+                            context);
     }
 
-    await HandleSuccess(context)
-      .ConfigureAwait(false);
+    HandleSuccess(context);
   }
 
   /// <inheritdoc />
@@ -158,108 +149,186 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
     }
     catch (Exception e)
     {
-      await HandleException(e,
-                            context)
-        .ConfigureAwait(false);
-      throw;
+      throw HandleException(e,
+                            context);
     }
 
-    await HandleSuccess(context)
-      .ConfigureAwait(false);
+    HandleSuccess(context);
   }
 
-  private ValueTask HandleException(Exception         e,
-                                    ServerCallContext context)
-  {
-    switch (e)
-    {
-      case OperationCanceledException:
-        if (context.CancellationToken.IsCancellationRequested)
-        {
-          logger_.LogWarning(e,
-                             "Client has cancelled the request");
-        }
-        else
-        {
-          exceptionManager_.RecordError(logger_,
-                                        e,
-                                        "Request has been canceled by internal means");
-        }
+  /// <summary>
+  ///   Handle the exception that was thrown by the RPC
+  /// </summary>
+  /// <param name="e">Exception thrown by the RPC</param>
+  /// <param name="context">Context of the RPC</param>
+  /// <returns>RpcException that is returned to the client</returns>
+  private RpcException HandleException(Exception         e,
+                                       ServerCallContext context)
+    => e switch
+       {
+         OperationCanceledException when context.CancellationToken.IsCancellationRequested => ProcessException(ExceptionAction.Warning,
+                                                                                                               e,
+                                                                                                               context,
+                                                                                                               StatusCode.Cancelled,
+                                                                                                               "Cancelled by client"),
+         OperationCanceledException => ProcessException(ExceptionAction.Record,
+                                                        e,
+                                                        context,
+                                                        StatusCode.Cancelled,
+                                                        "Canceled by internal means"),
+         ObjectDataNotFoundException => ProcessException(ExceptionAction.Warning,
+                                                         e,
+                                                         context,
+                                                         StatusCode.NotFound,
+                                                         "Result data was not found"),
+         PartitionNotFoundException => ProcessException(ExceptionAction.Warning,
+                                                        e,
+                                                        context,
+                                                        StatusCode.NotFound,
+                                                        "Partition was not found"),
+         ResultNotFoundException => ProcessException(ExceptionAction.Warning,
+                                                     e,
+                                                     context,
+                                                     StatusCode.NotFound,
+                                                     "Result was not found"),
+         SessionNotFoundException => ProcessException(ExceptionAction.Warning,
+                                                      e,
+                                                      context,
+                                                      StatusCode.NotFound,
+                                                      "Session was not found"),
+         TaskNotFoundException => ProcessException(ExceptionAction.Warning,
+                                                   e,
+                                                   context,
+                                                   StatusCode.NotFound,
+                                                   "Task was not found"),
+         InvalidSessionTransitionException => ProcessException(ExceptionAction.Warning,
+                                                               e,
+                                                               context,
+                                                               StatusCode.FailedPrecondition,
+                                                               "The session transition is invalid"),
+         ResultInvalidStatusException => ProcessException(ExceptionAction.Warning,
+                                                          e,
+                                                          context,
+                                                          StatusCode.FailedPrecondition,
+                                                          "Result status is invalid"),
+         SubmissionClosedException => ProcessException(ExceptionAction.Warning,
+                                                       e,
+                                                       context,
+                                                       StatusCode.FailedPrecondition,
+                                                       "Submission for the session is closed"),
+         ArmoniKException => ProcessException(ExceptionAction.Warning,
+                                              e,
+                                              context,
+                                              StatusCode.Internal,
+                                              "Internal error, see ArmoniK logs",
+                                              true),
+         RpcException
+         {
+           StatusCode: StatusCode.OK or StatusCode.Cancelled or StatusCode.InvalidArgument or StatusCode.NotFound or StatusCode.AlreadyExists or
+                       StatusCode.PermissionDenied or StatusCode.Unauthenticated or StatusCode.FailedPrecondition or StatusCode.OutOfRange,
+         } r => ProcessException(ExceptionAction.Warning,
+                                 e,
+                                 context,
+                                 r.StatusCode,
+                                 r.Status.Detail,
+                                 true),
+         RpcException r => ProcessException(ExceptionAction.Record,
+                                            e,
+                                            context,
+                                            r.StatusCode,
+                                            r.Status.Detail,
+                                            true),
+         _ => ProcessException(ExceptionAction.Record,
+                               e,
+                               context,
+                               StatusCode.Unknown,
+                               "Unknown exception, see ArmoniK logs",
+                               true),
+       };
 
-        break;
-      case ObjectDataNotFoundException:
-      case PartitionNotFoundException:
-      case ResultNotFoundException:
-      case SessionNotFoundException:
-      case TaskNotFoundException:
-        logger_.LogWarning(e,
-                           e.Message);
-        return ValueTask.FromException(new RpcException(new Status(StatusCode.NotFound,
-                                                                   e.Message)));
-      case InvalidSessionTransitionException:
-      case ResultInvalidStatusException:
-      case SubmissionClosedException:
-        logger_.LogWarning(e,
-                           e.Message);
-        return ValueTask.FromException(new RpcException(new Status(StatusCode.FailedPrecondition,
-                                                                   e.Message)));
-      case ArmoniKException:
-        exceptionManager_.RecordError(logger_,
-                                      e,
-                                      e.Message);
-        return ValueTask.FromException(new RpcException(new Status(StatusCode.Internal,
-                                                                   e.Message)));
-
-      case RpcException rpcException:
-
-        switch (rpcException.Status.StatusCode)
-        {
-          case StatusCode.OK:
-          case StatusCode.Cancelled:
-          case StatusCode.InvalidArgument:
-          case StatusCode.NotFound:
-          case StatusCode.AlreadyExists:
-          case StatusCode.PermissionDenied:
-          case StatusCode.Unauthenticated:
-          case StatusCode.FailedPrecondition:
-          case StatusCode.OutOfRange:
-            logger_.LogError(e,
-                             "An exception has been thrown during handling of request due to client error");
-            break;
-          case StatusCode.Unknown:
-          case StatusCode.DeadlineExceeded:
-          case StatusCode.ResourceExhausted:
-          case StatusCode.Aborted:
-          case StatusCode.Unimplemented:
-          case StatusCode.Internal:
-          case StatusCode.Unavailable:
-          case StatusCode.DataLoss:
-          default:
-            exceptionManager_.RecordError(logger_,
-                                          e,
-                                          "An exception has been thrown during handling of request");
-            break;
-        }
-
-        break;
-      default:
-        exceptionManager_.RecordError(logger_,
-                                      e,
-                                      "An unknown exception has been thrown during handling of request");
-
-        throw new RpcException(new Status(StatusCode.Unknown,
-                                          "Unknown Exception, see application logs"));
-    }
-
-    return ValueTask.FromException(e);
-  }
-
-  private ValueTask HandleSuccess(ServerCallContext context)
+  /// <summary>
+  ///   Records the success of an RPC
+  /// </summary>
+  /// <param name="context">Context of the RPC</param>
+  private void HandleSuccess(ServerCallContext context)
   {
     _ = context;
 
     exceptionManager_.RecordSuccess(logger_);
+  }
 
-    return ValueTask.CompletedTask;
+  /// <summary>
+  ///   Converts an exception into a <see cref="RpcException" />
+  /// </summary>
+  /// <param name="action">Action to do: either log warning, log error, or record error</param>
+  /// <param name="e">Exception that was thrown by the RPC</param>
+  /// <param name="context">Context of the RPC</param>
+  /// <param name="statusCode">Response status code</param>
+  /// <param name="details">Details for the status</param>
+  /// <param name="skipMessageInRpc">
+  ///   If true, the message of the exception is not added to the details in the response to the
+  ///   client
+  /// </param>
+  /// <returns>The <see cref="RpcException" /> sent to the client</returns>
+  private RpcException ProcessException(ExceptionAction   action,
+                                        Exception         e,
+                                        ServerCallContext context,
+                                        StatusCode        statusCode,
+                                        string            details,
+                                        bool              skipMessageInRpc = false)
+  {
+    switch (action)
+    {
+      case ExceptionAction.Warning:
+        logger_.LogWarning(e,
+                           "Error while processing the request {RequestPath} with status {ErrorStatus}: {ErrorDetails}: {ErrorMessage}",
+                           context.Method,
+                           statusCode,
+                           details,
+                           e.Message);
+        break;
+      case ExceptionAction.Error:
+        logger_.LogError(e,
+                         "Error while processing the request {RequestPath} with status {ErrorStatus}: {ErrorDetails}: {ErrorMessage}",
+                         context.Method,
+                         statusCode,
+                         details,
+                         e.Message);
+        break;
+      case ExceptionAction.Record:
+      default:
+        exceptionManager_.RecordError(logger_,
+                                      e,
+                                      "Error while processing the request {RequestPath} with status {ErrorStatus}: {ErrorDetails}: {ErrorMessage}",
+                                      context.Method,
+                                      statusCode,
+                                      details,
+                                      e.Message);
+        break;
+    }
+
+    if (!skipMessageInRpc && !string.IsNullOrEmpty(details) && details != e.Message)
+    {
+      details = $"{details}: {e.Message}";
+    }
+
+    return new RpcException(new Status(statusCode,
+                                       details),
+                            e.Message);
+  }
+
+  /// <summary>
+  ///   Action to perform on the exception
+  /// </summary>
+  private enum ExceptionAction
+  {
+    /// <summary>Log with warning level</summary>
+    Warning,
+
+    /// <summary>Log with error level</summary>
+    Error,
+
+    /// <summary>Record the exception (and log with error level)</summary>
+    Record,
   }
 }

--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -30,6 +30,8 @@ using Grpc.Core.Interceptors;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Logging;
 
+using TaskCanceledException = ArmoniK.Core.Common.Exceptions.TaskCanceledException;
+
 namespace ArmoniK.Core.Common.gRPC;
 
 /// <summary>
@@ -216,6 +218,21 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                                                        context,
                                                        StatusCode.FailedPrecondition,
                                                        "Submission for the session is closed"),
+         TaskAlreadyInFinalStateException => ProcessException(ExceptionAction.Warning,
+                                                              e,
+                                                              context,
+                                                              StatusCode.FailedPrecondition,
+                                                              "Task is already in a final state"),
+         TaskCanceledException => ProcessException(ExceptionAction.Warning,
+                                                   e,
+                                                   context,
+                                                   StatusCode.FailedPrecondition,
+                                                   "Task is canceled"),
+         TaskPausedException => ProcessException(ExceptionAction.Warning,
+                                                 e,
+                                                 context,
+                                                 StatusCode.FailedPrecondition,
+                                                 "Task is paused"),
          ArmoniKException => ProcessException(ExceptionAction.Warning,
                                               e,
                                               context,

--- a/Common/src/gRPC/Services/GrpcEventsService.cs
+++ b/Common/src/gRPC/Services/GrpcEventsService.cs
@@ -97,8 +97,8 @@ public class GrpcEventsService : Events.EventsBase
     }
     catch (OperationCanceledException e)
     {
-      logger_.LogWarning(e,
-                         "Subscription cancelled, no more messages will be sent.");
+      logger_.LogDebug(e,
+                       "Subscription cancelled, no more messages will be sent.");
     }
   }
 }

--- a/Common/src/gRPC/Services/GrpcResultsService.cs
+++ b/Common/src/gRPC/Services/GrpcResultsService.cs
@@ -29,10 +29,8 @@ using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.SortDirection;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
-using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
-using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Convertors;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Storage;
@@ -285,51 +283,35 @@ public class GrpcResultsService : Results.ResultsBase
                                                                           ServerCallContext        context)
   {
     using var measure = meter_.CountAndTime();
-    try
+
+    await foreach (var ids in resultTable_.GetResults(result => request.ResultId.Contains(result.ResultId) && !result.ManualDeletion,
+                                                      result => result.OpaqueId,
+                                                      context.CancellationToken)
+                                          .ToChunksAsync(500,
+                                                         Timeout.InfiniteTimeSpan,
+                                                         context.CancellationToken)
+                                          .ConfigureAwait(false))
     {
-      await foreach (var ids in resultTable_.GetResults(result => request.ResultId.Contains(result.ResultId) && !result.ManualDeletion,
-                                                        result => result.OpaqueId,
-                                                        context.CancellationToken)
-                                            .ToChunksAsync(500,
-                                                           Timeout.InfiniteTimeSpan,
-                                                           context.CancellationToken)
-                                            .ConfigureAwait(false))
-      {
-        await objectStorage_.TryDeleteAsync(ids,
-                                            context.CancellationToken)
-                            .ConfigureAwait(false);
-      }
+      await objectStorage_.TryDeleteAsync(ids,
+                                          context.CancellationToken)
+                          .ConfigureAwait(false);
+    }
 
-      await resultTable_.UpdateManyResults(result => request.ResultId.Contains(result.ResultId) && !result.ManualDeletion,
-                                           new UpdateDefinition<Result>().Set(result => result.Status,
-                                                                              ResultStatus.DeletedData)
-                                                                         .Set(result => result.OpaqueId,
-                                                                              Array.Empty<byte>()),
-                                           context.CancellationToken)
-                        .ConfigureAwait(false);
+    await resultTable_.UpdateManyResults(result => request.ResultId.Contains(result.ResultId) && !result.ManualDeletion,
+                                         new UpdateDefinition<Result>().Set(result => result.Status,
+                                                                            ResultStatus.DeletedData)
+                                                                       .Set(result => result.OpaqueId,
+                                                                            Array.Empty<byte>()),
+                                         context.CancellationToken)
+                      .ConfigureAwait(false);
 
-      return new DeleteResultsDataResponse
+    return new DeleteResultsDataResponse
+           {
+             ResultId =
              {
-               ResultId =
-               {
-                 request.ResultId,
-               },
-             };
-    }
-    catch (ObjectDataNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while deleting results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result data not found"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while deleting results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result data not found"));
-    }
+               request.ResultId,
+             },
+           };
   }
 
   /// <inheritdoc />
@@ -340,35 +322,19 @@ public class GrpcResultsService : Results.ResultsBase
                                                 ServerCallContext                               context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      var id = (await resultTable_.GetResult(request.ResultId)
-                                  .ConfigureAwait(false)).OpaqueId;
 
-      await foreach (var chunk in objectStorage_.GetValuesAsync(id,
-                                                                context.CancellationToken)
-                                                .ConfigureAwait(false))
-      {
-        await responseStream.WriteAsync(new DownloadResultDataResponse
-                                        {
-                                          DataChunk = UnsafeByteOperations.UnsafeWrap(chunk),
-                                        })
-                            .ConfigureAwait(false);
-      }
-    }
-    catch (ObjectDataNotFoundException e)
+    var id = (await resultTable_.GetResult(request.ResultId)
+                                .ConfigureAwait(false)).OpaqueId;
+
+    await foreach (var chunk in objectStorage_.GetValuesAsync(id,
+                                                              context.CancellationToken)
+                                              .ConfigureAwait(false))
     {
-      logger_.LogWarning(e,
-                         "Error while downloading results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result data not found"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while downloading results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result data not found"));
+      await responseStream.WriteAsync(new DownloadResultDataResponse
+                                      {
+                                        DataChunk = UnsafeByteOperations.UnsafeWrap(chunk),
+                                      })
+                          .ConfigureAwait(false);
     }
   }
 
@@ -425,49 +391,32 @@ public class GrpcResultsService : Results.ResultsBase
                                                                  context.CancellationToken)
                                                .ConfigureAwait(false);
 
-    try
-    {
-      var sessionData = await sessionTask.ConfigureAwait(false);
+    var sessionData = await sessionTask.ConfigureAwait(false);
 
-      var resultData = await resultTable_.CompleteResult(id.SessionId,
-                                                         id.ResultId,
-                                                         size,
-                                                         opaqueId,
-                                                         context.CancellationToken)
-                                         .ConfigureAwait(false);
+    var resultData = await resultTable_.CompleteResult(id.SessionId,
+                                                       id.ResultId,
+                                                       size,
+                                                       opaqueId,
+                                                       context.CancellationToken)
+                                       .ConfigureAwait(false);
 
-      await TaskLifeCycleHelper.ResolveDependencies(taskTable_,
-                                                    resultTable_,
-                                                    pushQueueStorage_,
-                                                    sessionData,
-                                                    new[]
-                                                    {
-                                                      id.ResultId,
-                                                    },
-                                                    logger_,
-                                                    context.CancellationToken)
-                               .ConfigureAwait(false);
+    await TaskLifeCycleHelper.ResolveDependencies(taskTable_,
+                                                  resultTable_,
+                                                  pushQueueStorage_,
+                                                  sessionData,
+                                                  new[]
+                                                  {
+                                                    id.ResultId,
+                                                  },
+                                                  logger_,
+                                                  context.CancellationToken)
+                             .ConfigureAwait(false);
 
 
-      return new UploadResultDataResponse
-             {
-               Result = resultData.ToGrpcResultRaw(),
-             };
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while downloading results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result data not found"));
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while downloading results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session associated to the result was not found"));
-    }
+    return new UploadResultDataResponse
+           {
+             Result = resultData.ToGrpcResultRaw(),
+           };
   }
 
   /// <inheritdoc />

--- a/Common/src/gRPC/Services/GrpcSessionsService.cs
+++ b/Common/src/gRPC/Services/GrpcSessionsService.cs
@@ -25,10 +25,8 @@ using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.SortDirection;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
-using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
-using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Convertors;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Storage;
@@ -101,84 +99,54 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                   ServerCallContext    context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      var session = await sessionTable_.CancelSessionAsync(request.SessionId,
-                                                           context.CancellationToken)
-                                       .ConfigureAwait(false);
 
-      // Notify agents to stop running tasks for this session
-      await taskTable_.FindTasksAsync(data => data.SessionId == request.SessionId && (data.Status == TaskStatus.Dispatched || data.Status == TaskStatus.Processing),
-                                      data => data.OwnerPodId,
-                                      context.CancellationToken)
-                      .Distinct()
-                      .ParallelForEach(new ParallelTaskOptions(submitterOptions_.DegreeOfParallelism),
-                                       async podId =>
+    var session = await sessionTable_.CancelSessionAsync(request.SessionId,
+                                                         context.CancellationToken)
+                                     .ConfigureAwait(false);
+
+    // Notify agents to stop running tasks for this session
+    await taskTable_.FindTasksAsync(data => data.SessionId == request.SessionId && (data.Status == TaskStatus.Dispatched || data.Status == TaskStatus.Processing),
+                                    data => data.OwnerPodId,
+                                    context.CancellationToken)
+                    .Distinct()
+                    .ParallelForEach(new ParallelTaskOptions(submitterOptions_.DegreeOfParallelism),
+                                     async podId =>
+                                     {
+                                       try
                                        {
-                                         try
-                                         {
-                                           logger_.LogInformation("Notifying agent {OwnerPodId} to stop tasks for session {SessionId}",
-                                                                  podId,
-                                                                  request.SessionId);
-                                           await httpClient_.GetAsync("http://" + podId + ":1080/stopcancelledtask")
-                                                            .ConfigureAwait(false);
-                                         }
-                                         catch (HttpRequestException e) when (e is
-                                                                              {
-                                                                                InnerException: SocketException
-                                                                                                {
-                                                                                                  SocketErrorCode: SocketError.ConnectionRefused,
-                                                                                                },
-                                                                              })
-                                         {
-                                           logger_.LogError(e,
-                                                            "The agent with {OwnerPodId} was not reached successfully",
-                                                            podId);
-                                         }
-                                       })
-                      .ConfigureAwait(false);
+                                         logger_.LogInformation("Notifying agent {OwnerPodId} to stop tasks for session {SessionId}",
+                                                                podId,
+                                                                request.SessionId);
+                                         await httpClient_.GetAsync("http://" + podId + ":1080/stopcancelledtask")
+                                                          .ConfigureAwait(false);
+                                       }
+                                       catch (HttpRequestException e) when (e is
+                                                                            {
+                                                                              InnerException: SocketException
+                                                                                              {
+                                                                                                SocketErrorCode: SocketError.ConnectionRefused,
+                                                                                              },
+                                                                            })
+                                       {
+                                         logger_.LogError(e,
+                                                          "The agent with {OwnerPodId} was not reached successfully",
+                                                          podId);
+                                       }
+                                     })
+                    .ConfigureAwait(false);
 
-      var results = resultTable_.AbortSessionResults(request.SessionId,
-                                                     context.CancellationToken);
-      await taskTable_.CancelSessionAsync(request.SessionId,
-                                          context.CancellationToken)
-                      .ConfigureAwait(false);
+    var results = resultTable_.AbortSessionResults(request.SessionId,
+                                                   context.CancellationToken);
+    await taskTable_.CancelSessionAsync(request.SessionId,
+                                        context.CancellationToken)
+                    .ConfigureAwait(false);
 
-      await results.ConfigureAwait(false);
+    await results.ConfigureAwait(false);
 
-      return new CancelSessionResponse
-             {
-               Session = session.ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while cancelling session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (InvalidSessionTransitionException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while cancelling session");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session is in a state that cannot be cancelled"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while cancelling session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while cancelling session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+    return new CancelSessionResponse
+           {
+             Session = session.ToGrpcSessionRaw(),
+           };
   }
 
   /// <inheritdoc />
@@ -188,36 +156,13 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                             ServerCallContext context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      return new GetSessionResponse
-             {
-               Session = (await sessionTable_.GetSessionAsync(request.SessionId,
-                                                              context.CancellationToken)
-                                             .ConfigureAwait(false)).ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+
+    return new GetSessionResponse
+           {
+             Session = (await sessionTable_.GetSessionAsync(request.SessionId,
+                                                            context.CancellationToken)
+                                           .ConfigureAwait(false)).ToGrpcSessionRaw(),
+           };
   }
 
   /// <inheritdoc />
@@ -232,45 +177,28 @@ public class GrpcSessionsService : Sessions.SessionsBase
                          ? sessionTable_.Secondary
                          : sessionTable_;
 
-    try
-    {
-      var (sessions, totalCount) = await sessionTable.ListSessionsAsync(request.Filters is null
-                                                                          ? data => true
-                                                                          : request.Filters.ToSessionDataFilter(),
-                                                                        request.Sort is null
-                                                                          ? data => data.SessionId
-                                                                          : request.Sort.ToField(),
-                                                                        request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                                        request.Page,
-                                                                        request.PageSize,
-                                                                        context.CancellationToken)
-                                                     .ConfigureAwait(false);
+    var (sessions, totalCount) = await sessionTable.ListSessionsAsync(request.Filters is null
+                                                                        ? data => true
+                                                                        : request.Filters.ToSessionDataFilter(),
+                                                                      request.Sort is null
+                                                                        ? data => data.SessionId
+                                                                        : request.Sort.ToField(),
+                                                                      request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                                      request.Page,
+                                                                      request.PageSize,
+                                                                      context.CancellationToken)
+                                                   .ConfigureAwait(false);
 
-      return new ListSessionsResponse
+    return new ListSessionsResponse
+           {
+             Page     = request.Page,
+             PageSize = request.PageSize,
+             Sessions =
              {
-               Page     = request.Page,
-               PageSize = request.PageSize,
-               Sessions =
-               {
-                 sessions.Select(data => data.ToGrpcSessionRaw()),
-               },
-               Total = (int)totalCount,
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing sessions");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing sessions");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+               sessions.Select(data => data.ToGrpcSessionRaw()),
+             },
+             Total = (int)totalCount,
+           };
   }
 
   /// <inheritdoc />
@@ -280,40 +208,17 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                ServerCallContext    context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      return new CreateSessionReply
-             {
-               SessionId = await SessionLifeCycleHelper.CreateSession(sessionTable_,
-                                                                      partitionTable_,
-                                                                      request.PartitionIds,
-                                                                      request.DefaultTaskOption.ToTaskOptions(),
-                                                                      submitterOptions_.DefaultPartition,
-                                                                      context.CancellationToken)
-                                                       .ConfigureAwait(false),
-             };
-    }
-    catch (PartitionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Partition not found while creating session");
-      throw new RpcException(new Status(StatusCode.InvalidArgument,
-                                        "Partition not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal ArmoniK Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
+
+    return new CreateSessionReply
+           {
+             SessionId = await SessionLifeCycleHelper.CreateSession(sessionTable_,
+                                                                    partitionTable_,
+                                                                    request.PartitionIds,
+                                                                    request.DefaultTaskOption.ToTaskOptions(),
+                                                                    submitterOptions_.DefaultPartition,
+                                                                    context.CancellationToken)
+                                                     .ConfigureAwait(false),
+           };
   }
 
   /// <inheritdoc />
@@ -323,47 +228,17 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                 ServerCallContext   context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      var session = await TaskLifeCycleHelper.PauseAsync(taskTable_,
-                                                         sessionTable_,
-                                                         request.SessionId,
-                                                         context.CancellationToken)
-                                             .ConfigureAwait(false);
 
-      return new PauseSessionResponse
-             {
-               Session = session.ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while pausing session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (InvalidSessionTransitionException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while pausing session");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session is in a state that cannot be paused"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while pausing session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while pausing session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+    var session = await TaskLifeCycleHelper.PauseAsync(taskTable_,
+                                                       sessionTable_,
+                                                       request.SessionId,
+                                                       context.CancellationToken)
+                                           .ConfigureAwait(false);
+
+    return new PauseSessionResponse
+           {
+             Session = session.ToGrpcSessionRaw(),
+           };
   }
 
 
@@ -374,53 +249,23 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                 ServerCallContext   context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      var session = await sessionTable_.GetSessionAsync(request.SessionId,
-                                                        context.CancellationToken)
-                                       .ConfigureAwait(false);
 
-      session = await sessionTable_.CloseSessionAsync(request.SessionId,
-                                                      session.CreationDate,
+    var session = await sessionTable_.GetSessionAsync(request.SessionId,
                                                       context.CancellationToken)
-                                   .ConfigureAwait(false);
+                                     .ConfigureAwait(false);
 
-      logger_.LogInformation("Closed {sessionId}",
-                             session);
+    session = await sessionTable_.CloseSessionAsync(request.SessionId,
+                                                    session.CreationDate,
+                                                    context.CancellationToken)
+                                 .ConfigureAwait(false);
 
-      return new CloseSessionResponse
-             {
-               Session = session.ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while closing session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (InvalidSessionTransitionException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while closing session");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session is in a state that cannot be closed"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while closing session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while closing session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+    logger_.LogInformation("Closed {sessionId}",
+                           session);
+
+    return new CloseSessionResponse
+           {
+             Session = session.ToGrpcSessionRaw(),
+           };
   }
 
   /// <inheritdoc />
@@ -430,57 +275,27 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                 ServerCallContext   context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      var session = await sessionTable_.GetSessionAsync(request.SessionId,
-                                                        context.CancellationToken)
-                                       .ConfigureAwait(false);
 
-      await ResultLifeCycleHelper.PurgeResultsAsync(resultTable_,
-                                                    objectStorage_,
-                                                    request.SessionId,
-                                                    context.CancellationToken)
-                                 .ConfigureAwait(false);
+    var session = await sessionTable_.GetSessionAsync(request.SessionId,
+                                                      context.CancellationToken)
+                                     .ConfigureAwait(false);
 
-      logger_.LogInformation("Purged data for {sessionId}",
-                             session);
+    await ResultLifeCycleHelper.PurgeResultsAsync(resultTable_,
+                                                  objectStorage_,
+                                                  request.SessionId,
+                                                  context.CancellationToken)
+                               .ConfigureAwait(false);
 
-      return new PurgeSessionResponse
-             {
-               Session = (await sessionTable_.PurgeSessionAsync(request.SessionId,
-                                                                session.CreationDate,
-                                                                context.CancellationToken)
-                                             .ConfigureAwait(false)).ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while purging session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (InvalidSessionTransitionException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while purging session");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session is in a state that cannot be purged"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while purging session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while purging session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+    logger_.LogInformation("Purged data for {sessionId}",
+                           session);
+
+    return new PurgeSessionResponse
+           {
+             Session = (await sessionTable_.PurgeSessionAsync(request.SessionId,
+                                                              session.CreationDate,
+                                                              context.CancellationToken)
+                                           .ConfigureAwait(false)).ToGrpcSessionRaw(),
+           };
   }
 
   /// <inheritdoc />
@@ -490,75 +305,45 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                   ServerCallContext    context)
   {
     using var measure = meter_.CountAndTime();
+
+    var session = new SessionData(request.SessionId,
+                                  SessionStatus.Deleted,
+                                  Array.Empty<string>(),
+                                  new TaskOptions());
+
     try
     {
-      var session = new SessionData(request.SessionId,
-                                    SessionStatus.Deleted,
-                                    Array.Empty<string>(),
-                                    new TaskOptions());
-
-      try
-      {
-        session = await sessionTable_.GetSessionAsync(request.SessionId,
-                                                      context.CancellationToken)
-                                     .ConfigureAwait(false);
-      }
-      catch (Exception)
-      {
-        // Session may not exist or be already deleted
-        logger_.LogDebug("Session {sessionId} not found; returning an empty one",
-                         request.SessionId);
-      }
-
-      await Task.WhenAll(taskTable_.DeleteTasksAsync(request.SessionId,
-                                                     context.CancellationToken),
-                         resultTable_.DeleteResults(request.SessionId,
-                                                    context.CancellationToken))
-                .ConfigureAwait(false);
-
-      await sessionTable_.DeleteSessionAsync(request.SessionId,
-                                             context.CancellationToken)
-                         .ConfigureAwait(false);
-
-      session = session with
-                {
-                  Status = SessionStatus.Deleted,
-                  DeletionDate = DateTime.UtcNow,
-                };
-
-      return new DeleteSessionResponse
-             {
-               Session = session.ToGrpcSessionRaw(),
-             };
+      session = await sessionTable_.GetSessionAsync(request.SessionId,
+                                                    context.CancellationToken)
+                                   .ConfigureAwait(false);
     }
-    catch (SessionNotFoundException e)
+    catch (Exception)
     {
-      logger_.LogWarning(e,
-                         "Error while deleting session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
+      // Session may not exist or be already deleted
+      logger_.LogDebug("Session {sessionId} not found; returning an empty one",
+                       request.SessionId);
     }
-    catch (InvalidSessionTransitionException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while deleting session");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session is in a state that cannot be deleted"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while deleting session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while deleting session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+
+    await Task.WhenAll(taskTable_.DeleteTasksAsync(request.SessionId,
+                                                   context.CancellationToken),
+                       resultTable_.DeleteResults(request.SessionId,
+                                                  context.CancellationToken))
+              .ConfigureAwait(false);
+
+    await sessionTable_.DeleteSessionAsync(request.SessionId,
+                                           context.CancellationToken)
+                       .ConfigureAwait(false);
+
+    session = session with
+              {
+                Status = SessionStatus.Deleted,
+                DeletionDate = DateTime.UtcNow,
+              };
+
+    return new DeleteSessionResponse
+           {
+             Session = session.ToGrpcSessionRaw(),
+           };
   }
 
   /// <inheritdoc />
@@ -568,48 +353,18 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                   ServerCallContext    context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      var session = await TaskLifeCycleHelper.ResumeAsync(taskTable_,
-                                                          sessionTable_,
-                                                          pushQueueStorage_,
-                                                          request.SessionId,
-                                                          context.CancellationToken)
-                                             .ConfigureAwait(false);
 
-      return new ResumeSessionResponse
-             {
-               Session = session.ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while resuming session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (InvalidSessionTransitionException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while resuming session");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session is in a state that cannot be cancelled"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while resuming session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while resuming session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+    var session = await TaskLifeCycleHelper.ResumeAsync(taskTable_,
+                                                        sessionTable_,
+                                                        pushQueueStorage_,
+                                                        request.SessionId,
+                                                        context.CancellationToken)
+                                           .ConfigureAwait(false);
+
+    return new ResumeSessionResponse
+           {
+             Session = session.ToGrpcSessionRaw(),
+           };
   }
 
   /// <inheritdoc />
@@ -619,37 +374,14 @@ public class GrpcSessionsService : Sessions.SessionsBase
                                                                     ServerCallContext     context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      return new StopSubmissionResponse
-             {
-               Session = (await sessionTable_.StopSubmissionAsync(request.SessionId,
-                                                                  request.Client,
-                                                                  request.Worker,
-                                                                  context.CancellationToken)
-                                             .ConfigureAwait(false)).ToGrpcSessionRaw(),
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+
+    return new StopSubmissionResponse
+           {
+             Session = (await sessionTable_.StopSubmissionAsync(request.SessionId,
+                                                                request.Client,
+                                                                request.Worker,
+                                                                context.CancellationToken)
+                                           .ConfigureAwait(false)).ToGrpcSessionRaw(),
+           };
   }
 }

--- a/Common/src/gRPC/Services/GrpcSubmitterService.cs
+++ b/Common/src/gRPC/Services/GrpcSubmitterService.cs
@@ -23,10 +23,8 @@ using System.Threading.Tasks;
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Base;
-using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
-using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Convertors;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Utils;
@@ -82,28 +80,9 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<Configuration> GetServiceConfiguration(Empty             request,
                                                                     ServerCallContext context)
-  {
-    try
-    {
-      return await submitter_.GetServiceConfiguration(request,
-                                                      context.CancellationToken)
-                             .ConfigureAwait(false);
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting service configuration");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting service configuration");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => await submitter_.GetServiceConfiguration(request,
+                                                context.CancellationToken)
+                       .ConfigureAwait(false);
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -112,34 +91,10 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   public override async Task<Empty> CancelSession(Session           request,
                                                   ServerCallContext context)
   {
-    try
-    {
-      await submitter_.CancelSession(request.Id,
-                                     context.CancellationToken)
-                      .ConfigureAwait(false);
-      return new Empty();
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while canceling session");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while canceling session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while canceling session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
+    await submitter_.CancelSession(request.Id,
+                                   context.CancellationToken)
+                    .ConfigureAwait(false);
+    return new Empty();
   }
 
   /// <inheritdoc />
@@ -149,31 +104,14 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   public override async Task<Empty> CancelTasks(TaskFilter        request,
                                                 ServerCallContext context)
   {
-    try
-    {
-      logger_.LogTrace("request received {request}",
-                       request);
-      await taskTable_.CancelTasks(request,
-                                   context.CancellationToken)
-                      .ConfigureAwait(false);
+    logger_.LogTrace("request received {request}",
+                     request);
+    await taskTable_.CancelTasks(request,
+                                 context.CancellationToken)
+                    .ConfigureAwait(false);
 
 
-      return new Empty();
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while canceling tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while canceling tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
+    return new Empty();
   }
 
   /// <inheritdoc />
@@ -182,36 +120,10 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<CreateSessionReply> CreateSession(CreateSessionRequest request,
                                                                ServerCallContext    context)
-  {
-    try
-    {
-      return await submitter_.CreateSession(request.PartitionIds,
-                                            request.DefaultTaskOption.ToTaskOptions(),
-                                            context.CancellationToken)
-                             .ConfigureAwait(false);
-    }
-    catch (PartitionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Partition not found while creating session");
-      throw new RpcException(new Status(StatusCode.InvalidArgument,
-                                        "Partition not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating session");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating session");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => await submitter_.CreateSession(request.PartitionIds,
+                                      request.DefaultTaskOption.ToTaskOptions(),
+                                      context.CancellationToken)
+                       .ConfigureAwait(false);
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -220,165 +132,29 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   public override async Task<CreateTaskReply> CreateSmallTasks(CreateSmallTaskRequest request,
                                                                ServerCallContext      context)
   {
+    var sessionTask = sessionTable_.GetSessionAsync(request.SessionId);
+
+    var requests = await submitter_.CreateTasks(request.SessionId,
+                                                request.SessionId,
+                                                request.TaskOptions.ToTaskOptions(),
+                                                request.TaskRequests.ToAsyncEnumerable()
+                                                       .Select(taskRequest => new TaskRequest(taskRequest.ExpectedOutputKeys,
+                                                                                              taskRequest.DataDependencies,
+                                                                                              new[]
+                                                                                              {
+                                                                                                taskRequest.Payload.Memory,
+                                                                                              }.ToAsyncEnumerable())),
+                                                context.CancellationToken)
+                                   .ConfigureAwait(false);
+
+
+    var sessionData = await sessionTask.ConfigureAwait(false);
+
     try
     {
-      var sessionTask = sessionTable_.GetSessionAsync(request.SessionId);
-
-      var requests = await submitter_.CreateTasks(request.SessionId,
-                                                  request.SessionId,
-                                                  request.TaskOptions.ToTaskOptions(),
-                                                  request.TaskRequests.ToAsyncEnumerable()
-                                                         .Select(taskRequest => new TaskRequest(taskRequest.ExpectedOutputKeys,
-                                                                                                taskRequest.DataDependencies,
-                                                                                                new[]
-                                                                                                {
-                                                                                                  taskRequest.Payload.Memory,
-                                                                                                }.ToAsyncEnumerable())),
-                                                  context.CancellationToken)
-                                     .ConfigureAwait(false);
-
-
-      var sessionData = await sessionTask.ConfigureAwait(false);
-
-      try
-      {
-        await submitter_.FinalizeTaskCreation(requests,
-                                              sessionData,
-                                              request.SessionId,
-                                              context.CancellationToken)
-                        .ConfigureAwait(false);
-
-        return new CreateTaskReply
-               {
-                 CreationStatusList = new CreateTaskReply.Types.CreationStatusList
-                                      {
-                                        CreationStatuses =
-                                        {
-                                          requests.Select(taskRequest => new CreateTaskReply.Types.CreationStatus
-                                                                         {
-                                                                           TaskInfo = new CreateTaskReply.Types.TaskInfo
-                                                                                      {
-                                                                                        TaskId = taskRequest.TaskId,
-                                                                                      },
-                                                                         }),
-                                        },
-                                      },
-               };
-      }
-      catch (Exception e)
-      {
-        await TaskLifeCycleHelper.DeleteTasksAsync(taskTable_,
-                                                   resultTable_,
-                                                   requests,
-                                                   CancellationToken.None)
-                                 .ConfigureAwait(false);
-        var payloads = requests.Select(creationRequest => creationRequest.PayloadId)
-                               .AsICollection();
-        var outputs = requests.SelectMany(creationRequest => creationRequest.ExpectedOutputKeys)
-                              .ToList();
-        outputs.AddRange(payloads);
-        await resultTable_.GetResults(result => payloads.Contains(result.ResultId),
-                                      result => result.OpaqueId,
-                                      CancellationToken.None)
-                          .ParallelForEach(opaqueId =>
-                                           {
-                                             Task.Factory.StartNew(async () =>
-                                                                   {
-                                                                     await objectStorage_.TryDeleteAsync(new[]
-                                                                                                         {
-                                                                                                           opaqueId,
-                                                                                                         },
-                                                                                                         CancellationToken.None)
-                                                                                         .ConfigureAwait(false);
-                                                                   },
-                                                                   CancellationToken.None);
-                                             return Task.CompletedTask;
-                                           })
-                          .ConfigureAwait(false);
-        await resultTable_.DeleteResults(outputs,
-                                         CancellationToken.None)
-                          .ConfigureAwait(false);
-        throw;
-      }
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session not found"));
-    }
-    catch (ResultInvalidStatusException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks due to invalid dependency status");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "One or more dependencies have an invalid status"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks due to dependency that does not exist");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "One or more dependencies do not exist"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
-
-
-  /// <inheritdoc />
-  [RequiresPermission(typeof(GrpcSubmitterService),
-                      nameof(CreateLargeTasks))]
-  [Obsolete]
-  public override async Task<CreateTaskReply> CreateLargeTasks(IAsyncStreamReader<CreateLargeTaskRequest> requestStream,
-                                                               ServerCallContext                          context)
-  {
-    try
-    {
-      await using var enumerator = requestStream.ReadAllAsync(context.CancellationToken)
-                                                .GetAsyncEnumerator(context.CancellationToken);
-
-      if (!await enumerator.MoveNextAsync()
-                           .ConfigureAwait(false))
-      {
-        throw new RpcException(new Status(StatusCode.InvalidArgument,
-                                          "stream contained no message"));
-      }
-
-      var first = enumerator.Current;
-
-      if (first.TypeCase != CreateLargeTaskRequest.TypeOneofCase.InitRequest)
-      {
-        throw new RpcException(new Status(StatusCode.InvalidArgument,
-                                          "First message in stream must be of type InitRequest"),
-                               "First message in stream must be of type InitRequest");
-      }
-
-      var sessionTask = sessionTable_.GetSessionAsync(first.InitRequest.SessionId);
-      var requests = await submitter_.CreateTasks(first.InitRequest.SessionId,
-                                                  first.InitRequest.SessionId,
-                                                  first.InitRequest.TaskOptions.ToNullableTaskOptions(),
-                                                  enumerator.BuildRequests(context.CancellationToken),
-                                                  context.CancellationToken)
-                                     .ConfigureAwait(false);
-
-      var sessionData = await sessionTask.ConfigureAwait(false);
       await submitter_.FinalizeTaskCreation(requests,
                                             sessionData,
-                                            first.InitRequest.SessionId,
+                                            request.SessionId,
                                             context.CancellationToken)
                       .ConfigureAwait(false);
 
@@ -393,62 +169,116 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
                                                                          TaskInfo = new CreateTaskReply.Types.TaskInfo
                                                                                     {
                                                                                       TaskId = taskRequest.TaskId,
-                                                                                      DataDependencies =
-                                                                                      {
-                                                                                        taskRequest.DataDependencies,
-                                                                                      },
-                                                                                      ExpectedOutputKeys =
-                                                                                      {
-                                                                                        taskRequest.ExpectedOutputKeys,
-                                                                                      },
-                                                                                      PayloadId = taskRequest.PayloadId,
                                                                                     },
                                                                        }),
                                       },
                                     },
              };
     }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Session not found"));
-    }
-    catch (ResultInvalidStatusException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks due to invalid dependency status");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "One or more dependencies have an invalid status"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks due to dependency that does not exist");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "One or more dependencies do not exist"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (RpcException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw;
-    }
     catch (Exception e)
     {
-      logger_.LogWarning(e,
-                         "Error while creating tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
+      await TaskLifeCycleHelper.DeleteTasksAsync(taskTable_,
+                                                 resultTable_,
+                                                 requests,
+                                                 CancellationToken.None)
+                               .ConfigureAwait(false);
+      var payloads = requests.Select(creationRequest => creationRequest.PayloadId)
+                             .AsICollection();
+      var outputs = requests.SelectMany(creationRequest => creationRequest.ExpectedOutputKeys)
+                            .ToList();
+      outputs.AddRange(payloads);
+      await resultTable_.GetResults(result => payloads.Contains(result.ResultId),
+                                    result => result.OpaqueId,
+                                    CancellationToken.None)
+                        .ParallelForEach(opaqueId =>
+                                         {
+                                           Task.Factory.StartNew(async () =>
+                                                                 {
+                                                                   await objectStorage_.TryDeleteAsync(new[]
+                                                                                                       {
+                                                                                                         opaqueId,
+                                                                                                       },
+                                                                                                       CancellationToken.None)
+                                                                                       .ConfigureAwait(false);
+                                                                 },
+                                                                 CancellationToken.None);
+                                           return Task.CompletedTask;
+                                         })
+                        .ConfigureAwait(false);
+      await resultTable_.DeleteResults(outputs,
+                                       CancellationToken.None)
+                        .ConfigureAwait(false);
+      throw;
     }
+  }
+
+
+  /// <inheritdoc />
+  [RequiresPermission(typeof(GrpcSubmitterService),
+                      nameof(CreateLargeTasks))]
+  [Obsolete]
+  public override async Task<CreateTaskReply> CreateLargeTasks(IAsyncStreamReader<CreateLargeTaskRequest> requestStream,
+                                                               ServerCallContext                          context)
+  {
+    await using var enumerator = requestStream.ReadAllAsync(context.CancellationToken)
+                                              .GetAsyncEnumerator(context.CancellationToken);
+
+    if (!await enumerator.MoveNextAsync()
+                         .ConfigureAwait(false))
+    {
+      throw new RpcException(new Status(StatusCode.InvalidArgument,
+                                        "stream contained no message"));
+    }
+
+    var first = enumerator.Current;
+
+    if (first.TypeCase != CreateLargeTaskRequest.TypeOneofCase.InitRequest)
+    {
+      throw new RpcException(new Status(StatusCode.InvalidArgument,
+                                        "First message in stream must be of type InitRequest"),
+                             "First message in stream must be of type InitRequest");
+    }
+
+    var sessionTask = sessionTable_.GetSessionAsync(first.InitRequest.SessionId);
+    var requests = await submitter_.CreateTasks(first.InitRequest.SessionId,
+                                                first.InitRequest.SessionId,
+                                                first.InitRequest.TaskOptions.ToNullableTaskOptions(),
+                                                enumerator.BuildRequests(context.CancellationToken),
+                                                context.CancellationToken)
+                                   .ConfigureAwait(false);
+
+    var sessionData = await sessionTask.ConfigureAwait(false);
+    await submitter_.FinalizeTaskCreation(requests,
+                                          sessionData,
+                                          first.InitRequest.SessionId,
+                                          context.CancellationToken)
+                    .ConfigureAwait(false);
+
+    return new CreateTaskReply
+           {
+             CreationStatusList = new CreateTaskReply.Types.CreationStatusList
+                                  {
+                                    CreationStatuses =
+                                    {
+                                      requests.Select(taskRequest => new CreateTaskReply.Types.CreationStatus
+                                                                     {
+                                                                       TaskInfo = new CreateTaskReply.Types.TaskInfo
+                                                                                  {
+                                                                                    TaskId = taskRequest.TaskId,
+                                                                                    DataDependencies =
+                                                                                    {
+                                                                                      taskRequest.DataDependencies,
+                                                                                    },
+                                                                                    ExpectedOutputKeys =
+                                                                                    {
+                                                                                      taskRequest.ExpectedOutputKeys,
+                                                                                    },
+                                                                                    PayloadId = taskRequest.PayloadId,
+                                                                                  },
+                                                                     }),
+                                    },
+                                  },
+           };
   }
 
   /// <inheritdoc />
@@ -457,34 +287,15 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<Count> CountTasks(TaskFilter        request,
                                                ServerCallContext context)
-  {
-    try
-    {
-      return new Count
-             {
-               Values =
-               {
-                 (await taskTable_.Secondary.CountTasksAsync(request,
-                                                             context.CancellationToken)
-                                  .ConfigureAwait(false)).Select(count => count.ToGrpcStatusCount()),
-               },
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while counting tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while counting tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => new()
+       {
+         Values =
+         {
+           (await taskTable_.Secondary.CountTasksAsync(request,
+                                                       context.CancellationToken)
+                            .ConfigureAwait(false)).Select(count => count.ToGrpcStatusCount()),
+         },
+       };
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -493,50 +304,10 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   public override async Task TryGetResultStream(ResultRequest                    request,
                                                 IServerStreamWriter<ResultReply> responseStream,
                                                 ServerCallContext                context)
-  {
-    try
-    {
-      await submitter_.TryGetResult(request,
-                                    responseStream,
-                                    context.CancellationToken)
-                      .ConfigureAwait(false);
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result not found"));
-    }
-    catch (ObjectDataNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result data not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => await submitter_.TryGetResult(request,
+                                     responseStream,
+                                     context.CancellationToken)
+                       .ConfigureAwait(false);
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -544,35 +315,9 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<Count> WaitForCompletion(WaitRequest       request,
                                                       ServerCallContext context)
-  {
-    try
-    {
-      return await submitter_.WaitForCompletion(request,
-                                                context.CancellationToken)
-                             .ConfigureAwait(false);
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for completion");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for completion");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for completion");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => await submitter_.WaitForCompletion(request,
+                                          context.CancellationToken)
+                       .ConfigureAwait(false);
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -580,42 +325,9 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<Output> TryGetTaskOutput(TaskOutputRequest request,
                                                       ServerCallContext context)
-  {
-    try
-    {
-      return (await taskTable_.GetTaskOutput(request.TaskId,
-                                             context.CancellationToken)
-                              .ConfigureAwait(false)).ToGrpcOutput();
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting output");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting output");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting output");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting output");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => (await taskTable_.GetTaskOutput(request.TaskId,
+                                       context.CancellationToken)
+                        .ConfigureAwait(false)).ToGrpcOutput();
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -623,42 +335,9 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete($"{nameof(ISubmitter.WaitForAvailabilityAsync)} is obsolete")]
   public override async Task<AvailabilityReply> WaitForAvailability(ResultRequest     request,
                                                                     ServerCallContext context)
-  {
-    try
-    {
-      return await submitter_.WaitForAvailabilityAsync(request,
-                                                       context.CancellationToken)
-                             .ConfigureAwait(false);
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for availability");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for availability");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for availability");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while waiting for availability");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => await submitter_.WaitForAvailabilityAsync(request,
+                                                 context.CancellationToken)
+                       .ConfigureAwait(false);
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -666,46 +345,20 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override Task<GetTaskStatusReply> GetTaskStatus(GetTaskStatusRequest request,
                                                          ServerCallContext    context)
-  {
-    try
-    {
-      return Task.FromResult(new GetTaskStatusReply
-                             {
-                               IdStatuses =
-                               {
-                                 taskTable_.GetTaskStatus(request.TaskIds,
-                                                          context.CancellationToken)
-                                           .Select(status => new GetTaskStatusReply.Types.IdStatus
-                                                             {
-                                                               Status = status.Status.ToGrpcStatus(),
-                                                               TaskId = status.TaskId,
-                                                             })
-                                           .ToBlockingEnumerable(),
-                               },
-                             });
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting status");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting status");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting status");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => Task.FromResult(new GetTaskStatusReply
+                       {
+                         IdStatuses =
+                         {
+                           taskTable_.GetTaskStatus(request.TaskIds,
+                                                    context.CancellationToken)
+                                     .Select(status => new GetTaskStatusReply.Types.IdStatus
+                                                       {
+                                                         Status = status.Status.ToGrpcStatus(),
+                                                         TaskId = status.TaskId,
+                                                       })
+                                     .ToBlockingEnumerable(),
+                         },
+                       });
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -713,46 +366,20 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete($"{nameof(Api.gRPC.V1.Submitter.Submitter.SubmitterBase.GetResultStatus)} is obsolete")]
   public override async Task<GetResultStatusReply> GetResultStatus(GetResultStatusRequest request,
                                                                    ServerCallContext      context)
-  {
-    try
-    {
-      return new GetResultStatusReply
-             {
-               IdStatuses =
-               {
-                 (await resultTable_.GetResultStatus(request.ResultIds,
-                                                     request.SessionId,
-                                                     context.CancellationToken)
-                                    .ConfigureAwait(false)).Select(status => new GetResultStatusReply.Types.IdStatus
-                                                                             {
-                                                                               ResultId = status.ResultId,
-                                                                               Status   = status.Status.ToGrpcStatus(),
-                                                                             }),
-               },
-             };
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting status");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Result not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting status");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting status");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => new()
+       {
+         IdStatuses =
+         {
+           (await resultTable_.GetResultStatus(request.ResultIds,
+                                               request.SessionId,
+                                               context.CancellationToken)
+                              .ConfigureAwait(false)).Select(status => new GetResultStatusReply.Types.IdStatus
+                                                                       {
+                                                                         ResultId = status.ResultId,
+                                                                         Status   = status.Status.ToGrpcStatus(),
+                                                                       }),
+         },
+       };
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -760,42 +387,16 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<TaskIdList> ListTasks(TaskFilter        request,
                                                    ServerCallContext context)
-  {
-    try
-    {
-      return new TaskIdList
-             {
-               TaskIds =
-               {
-                 await taskTable_.ListTasksAsync(request,
-                                                 context.CancellationToken)
-                                 .ToListAsync()
-                                 .ConfigureAwait(false),
-               },
-             };
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => new()
+       {
+         TaskIds =
+         {
+           await taskTable_.ListTasksAsync(request,
+                                           context.CancellationToken)
+                           .ToListAsync()
+                           .ConfigureAwait(false),
+         },
+       };
 
   /// <inheritdoc />
   [RequiresPermission(typeof(GrpcSubmitterService),
@@ -803,40 +404,14 @@ public class GrpcSubmitterService : Api.gRPC.V1.Submitter.Submitter.SubmitterBas
   [Obsolete]
   public override async Task<SessionIdList> ListSessions(SessionFilter     request,
                                                          ServerCallContext context)
-  {
-    try
-    {
-      return new SessionIdList
-             {
-               SessionIds =
-               {
-                 await sessionTable_.ListSessionsAsync(request,
-                                                       context.CancellationToken)
-                                    .ToListAsync()
-                                    .ConfigureAwait(false),
-               },
-             };
-    }
-    catch (SessionNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing sessions");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Session not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing sessions");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see Submitter logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing sessions");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see Submitter logs"));
-    }
-  }
+    => new()
+       {
+         SessionIds =
+         {
+           await sessionTable_.ListSessionsAsync(request,
+                                                 context.CancellationToken)
+                              .ToListAsync()
+                              .ConfigureAwait(false),
+         },
+       };
 }

--- a/Common/src/gRPC/Services/GrpcTasksService.cs
+++ b/Common/src/gRPC/Services/GrpcTasksService.cs
@@ -27,10 +27,8 @@ using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.SortDirection;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
-using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
-using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC.Convertors;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Storage;
@@ -161,37 +159,14 @@ public class GrpcTasksService : Task.TasksBase
                                                       ServerCallContext context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      return new GetTaskResponse
-             {
-               Task = (await taskTable_.ReadTaskAsync(request.TaskId,
-                                                      taskDetailedMask_.GetProjection(),
-                                                      context.CancellationToken)
-                                       .ConfigureAwait(false)).ToTaskDetailed(),
-             };
-    }
-    catch (TaskNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting task");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "Task not found"));
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting task");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting task");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+
+    return new GetTaskResponse
+           {
+             Task = (await taskTable_.ReadTaskAsync(request.TaskId,
+                                                    taskDetailedMask_.GetProjection(),
+                                                    context.CancellationToken)
+                                     .ConfigureAwait(false)).ToTaskDetailed(),
+           };
   }
 
   /// <inheritdoc />
@@ -206,52 +181,35 @@ public class GrpcTasksService : Task.TasksBase
                       ? taskTable_.Secondary
                       : taskTable_;
 
-    try
+    if (request.Sort is not null && request.Sort.Field.FieldCase == TaskField.FieldOneofCase.TaskOptionGenericField)
     {
-      if (request.Sort is not null && request.Sort.Field.FieldCase == TaskField.FieldOneofCase.TaskOptionGenericField)
-      {
-        logger_.LogWarning("Sorting on the field {field} is not advised because this field is not part of ArmoniK data schema.",
-                           request.Sort.Field.TaskOptionGenericField.Field);
-      }
+      logger_.LogWarning("Sorting on the field {field} is not advised because this field is not part of ArmoniK data schema.",
+                         request.Sort.Field.TaskOptionGenericField.Field);
+    }
 
-      var (tasks, totalCount) = await taskTable.ListTasksAsync(request.Filters is null
-                                                                 ? data => true
-                                                                 : request.Filters.ToTaskDataFilter(),
-                                                               request.Sort is null
-                                                                 ? data => data.TaskId
-                                                                 : request.Sort.ToField(),
-                                                               taskSummaryMask_.GetProjection(),
-                                                               request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                               request.Page,
-                                                               request.PageSize,
-                                                               context.CancellationToken)
-                                               .ConfigureAwait(false);
+    var (tasks, totalCount) = await taskTable.ListTasksAsync(request.Filters is null
+                                                               ? data => true
+                                                               : request.Filters.ToTaskDataFilter(),
+                                                             request.Sort is null
+                                                               ? data => data.TaskId
+                                                               : request.Sort.ToField(),
+                                                             taskSummaryMask_.GetProjection(),
+                                                             request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                             request.Page,
+                                                             request.PageSize,
+                                                             context.CancellationToken)
+                                             .ConfigureAwait(false);
 
-      return new ListTasksResponse
+    return new ListTasksResponse
+           {
+             Page     = request.Page,
+             PageSize = request.PageSize,
+             Tasks =
              {
-               Page     = request.Page,
-               PageSize = request.PageSize,
-               Tasks =
-               {
-                 tasks.Select(data => data.ToTaskSummary()),
-               },
-               Total = (int)totalCount,
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+               tasks.Select(data => data.ToTaskSummary()),
+             },
+             Total = (int)totalCount,
+           };
   }
 
   /// <inheritdoc />
@@ -261,41 +219,25 @@ public class GrpcTasksService : Task.TasksBase
                                                                 ServerCallContext   context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      return new GetResultIdsResponse
+
+    return new GetResultIdsResponse
+           {
+             TaskResults =
              {
-               TaskResults =
-               {
-                 await taskTable_.GetTasksExpectedOutputKeys(request.TaskId,
-                                                             context.CancellationToken)
-                                 .Select(r => new GetResultIdsResponse.Types.MapTaskResult
+               await taskTable_.GetTasksExpectedOutputKeys(request.TaskId,
+                                                           context.CancellationToken)
+                               .Select(r => new GetResultIdsResponse.Types.MapTaskResult
+                                            {
+                                              TaskId = r.taskId,
+                                              ResultIds =
                                               {
-                                                TaskId = r.taskId,
-                                                ResultIds =
-                                                {
-                                                  r.expectedOutputKeys,
-                                                },
-                                              })
-                                 .ToListAsync(context.CancellationToken)
-                                 .ConfigureAwait(false),
-               },
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results ids from tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while getting results ids from tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+                                                r.expectedOutputKeys,
+                                              },
+                                            })
+                               .ToListAsync(context.CancellationToken)
+                               .ConfigureAwait(false),
+             },
+           };
   }
 
   /// <inheritdoc />
@@ -305,82 +247,66 @@ public class GrpcTasksService : Task.TasksBase
                                                               ServerCallContext  context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      await taskTable_.CancelTaskAsync(request.TaskIds,
-                                       context.CancellationToken)
-                      .ConfigureAwait(false);
-      var ownerPodIds = await taskTable_.FindTasksAsync(data => request.TaskIds.Contains(data.TaskId),
-                                                        data => new
-                                                                {
-                                                                  data.OwnerPodId,
-                                                                  data.TaskId,
-                                                                })
-                                        .ToListAsync()
-                                        .ConfigureAwait(false);
 
-      await ownerPodIds.ParallelForEach(new ParallelTaskOptions(options_.DegreeOfParallelism),
-                                        async t =>
+    await taskTable_.CancelTaskAsync(request.TaskIds,
+                                     context.CancellationToken)
+                    .ConfigureAwait(false);
+    var ownerPodIds = await taskTable_.FindTasksAsync(data => request.TaskIds.Contains(data.TaskId),
+                                                      data => new
+                                                              {
+                                                                data.OwnerPodId,
+                                                                data.TaskId,
+                                                              })
+                                      .ToListAsync()
+                                      .ConfigureAwait(false);
+
+    await ownerPodIds.ParallelForEach(new ParallelTaskOptions(options_.DegreeOfParallelism),
+                                      async t =>
+                                      {
+                                        try
                                         {
-                                          try
-                                          {
-                                            logger_.LogInformation("Cancel task {TaskId} on {OwnerPodId}",
-                                                                   t.TaskId,
-                                                                   t.OwnerPodId);
+                                          logger_.LogInformation("Cancel task {TaskId} on {OwnerPodId}",
+                                                                 t.TaskId,
+                                                                 t.OwnerPodId);
 
-                                            await (string.IsNullOrEmpty(t.OwnerPodId)
-                                                     ? System.Threading.Tasks.Task.CompletedTask
-                                                     : httpClient_.GetAsync("http://" + t.OwnerPodId + ":1080/stopcancelledtask")).ConfigureAwait(false);
-                                          }
-                                          // Ignore unreachable agents
-                                          catch (HttpRequestException e) when (e is
-                                                                               {
-                                                                                 InnerException: SocketException
-                                                                                                 {
-                                                                                                   SocketErrorCode: SocketError.ConnectionRefused,
-                                                                                                 },
-                                                                               })
-                                          {
-                                            logger_.LogError(e,
-                                                             "The agent with {OwnerPodId} was not reached successfully",
-                                                             t.OwnerPodId);
-                                          }
-                                        })
-                       .ConfigureAwait(false);
+                                          await (string.IsNullOrEmpty(t.OwnerPodId)
+                                                   ? System.Threading.Tasks.Task.CompletedTask
+                                                   : httpClient_.GetAsync("http://" + t.OwnerPodId + ":1080/stopcancelledtask")).ConfigureAwait(false);
+                                        }
+                                        // Ignore unreachable agents
+                                        catch (HttpRequestException e) when (e is
+                                                                             {
+                                                                               InnerException: SocketException
+                                                                                               {
+                                                                                                 SocketErrorCode: SocketError.ConnectionRefused,
+                                                                                               },
+                                                                             })
+                                        {
+                                          logger_.LogError(e,
+                                                           "The agent with {OwnerPodId} was not reached successfully",
+                                                           t.OwnerPodId);
+                                        }
+                                      })
+                     .ConfigureAwait(false);
 
-      await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
-                                                           resultTable_,
-                                                           request.TaskIds,
-                                                           reason: $"Client requested cancellation of tasks {string.Join(", ", request.TaskIds)}",
-                                                           cancellationToken: context.CancellationToken)
-                                 .ConfigureAwait(false);
+    await ResultLifeCycleHelper.TerminateTasksAndResults(taskTable_,
+                                                         resultTable_,
+                                                         request.TaskIds,
+                                                         reason: $"Client requested cancellation of tasks {string.Join(", ", request.TaskIds)}",
+                                                         cancellationToken: context.CancellationToken)
+                               .ConfigureAwait(false);
 
-      return new CancelTasksResponse
+    return new CancelTasksResponse
+           {
+             Tasks =
              {
-               Tasks =
-               {
-                 (await taskTable_.FindTasksAsync(data => request.TaskIds.Contains(data.TaskId),
-                                                  taskSummaryMask_.GetProjection(),
-                                                  context.CancellationToken)
-                                  .ToListAsync(context.CancellationToken)
-                                  .ConfigureAwait(false)).Select(data => data.ToTaskSummary()),
-               },
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while cancelling tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while cancelling tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+               (await taskTable_.FindTasksAsync(data => request.TaskIds.Contains(data.TaskId),
+                                                taskSummaryMask_.GetProjection(),
+                                                context.CancellationToken)
+                                .ToListAsync(context.CancellationToken)
+                                .ConfigureAwait(false)).Select(data => data.ToTaskSummary()),
+             },
+           };
   }
 
   /// <inheritdoc />
@@ -390,38 +316,22 @@ public class GrpcTasksService : Task.TasksBase
                                                                             ServerCallContext         context)
   {
     using var measure = meter_.CountAndTime();
-    try
-    {
-      return new CountTasksByStatusResponse
+
+    return new CountTasksByStatusResponse
+           {
+             Status =
              {
-               Status =
-               {
-                 (await taskTable_.Secondary.CountTasksAsync(request.Filters is null
-                                                               ? data => true
-                                                               : request.Filters.ToTaskDataFilter(),
-                                                             context.CancellationToken)
-                                  .ConfigureAwait(false)).Select(count => new StatusCount
-                                                                          {
-                                                                            Status = count.Status.ToGrpcStatus(),
-                                                                            Count  = count.Count,
-                                                                          }),
-               },
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while counting tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while counting tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+               (await taskTable_.Secondary.CountTasksAsync(request.Filters is null
+                                                             ? data => true
+                                                             : request.Filters.ToTaskDataFilter(),
+                                                           context.CancellationToken)
+                                .ConfigureAwait(false)).Select(count => new StatusCount
+                                                                        {
+                                                                          Status = count.Status.ToGrpcStatus(),
+                                                                          Count  = count.Count,
+                                                                        }),
+             },
+           };
   }
 
   /// <inheritdoc />
@@ -436,52 +346,35 @@ public class GrpcTasksService : Task.TasksBase
                       ? taskTable_.Secondary
                       : taskTable_;
 
-    try
+    if (request.Sort is not null && request.Sort.Field.FieldCase == TaskField.FieldOneofCase.TaskOptionGenericField)
     {
-      if (request.Sort is not null && request.Sort.Field.FieldCase == TaskField.FieldOneofCase.TaskOptionGenericField)
-      {
-        logger_.LogWarning("Sorting on the field {field} is not advised because this field is not part of ArmoniK data schema.",
-                           request.Sort.Field.TaskOptionGenericField.Field);
-      }
+      logger_.LogWarning("Sorting on the field {field} is not advised because this field is not part of ArmoniK data schema.",
+                         request.Sort.Field.TaskOptionGenericField.Field);
+    }
 
-      var (tasks, totalCount) = await taskTable.ListTasksAsync(request.Filters is null
-                                                                 ? data => true
-                                                                 : request.Filters.ToTaskDataFilter(),
-                                                               request.Sort is null
-                                                                 ? data => data.TaskId
-                                                                 : request.Sort.ToField(),
-                                                               taskDetailedMask_.GetProjection(),
-                                                               request.Sort is null || request.Sort.Direction == SortDirection.Asc,
-                                                               request.Page,
-                                                               request.PageSize,
-                                                               context.CancellationToken)
-                                               .ConfigureAwait(false);
+    var (tasks, totalCount) = await taskTable.ListTasksAsync(request.Filters is null
+                                                               ? data => true
+                                                               : request.Filters.ToTaskDataFilter(),
+                                                             request.Sort is null
+                                                               ? data => data.TaskId
+                                                               : request.Sort.ToField(),
+                                                             taskDetailedMask_.GetProjection(),
+                                                             request.Sort is null || request.Sort.Direction == SortDirection.Asc,
+                                                             request.Page,
+                                                             request.PageSize,
+                                                             context.CancellationToken)
+                                             .ConfigureAwait(false);
 
-      return new ListTasksDetailedResponse
+    return new ListTasksDetailedResponse
+           {
+             Page     = request.Page,
+             PageSize = request.PageSize,
+             Tasks =
              {
-               Page     = request.Page,
-               PageSize = request.PageSize,
-               Tasks =
-               {
-                 tasks.Select(data => data.ToTaskDetailed()),
-               },
-               Total = (int)totalCount,
-             };
-    }
-    catch (ArmoniKException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.Internal,
-                                        "Internal Armonik Exception, see application logs"));
-    }
-    catch (Exception e)
-    {
-      logger_.LogWarning(e,
-                         "Error while listing tasks");
-      throw new RpcException(new Status(StatusCode.Unknown,
-                                        "Unknown Exception, see application logs"));
-    }
+               tasks.Select(data => data.ToTaskDetailed()),
+             },
+             Total = (int)totalCount,
+           };
   }
 
   /// <inheritdoc />
@@ -491,99 +384,76 @@ public class GrpcTasksService : Task.TasksBase
                                                               ServerCallContext  context)
   {
     using var measure = meter_.CountAndTime();
+
+    var sessionData = await sessionTable_.GetSessionAsync(request.SessionId,
+                                                          context.CancellationToken)
+                                         .ConfigureAwait(false);
+
+
+    var submissionOptions = TaskLifeCycleHelper.ValidateSession(sessionData,
+                                                                request.TaskOptions.ToNullableTaskOptions(),
+                                                                request.SessionId,
+                                                                pushQueueStorage_.MaxPriority,
+                                                                logger_,
+                                                                context.CancellationToken);
+
+    var creationRequests = request.TaskCreations.Select(creation => new TaskCreationRequest(Guid.NewGuid()
+                                                                                                .ToString(),
+                                                                                            creation.PayloadId,
+                                                                                            TaskOptions.Merge(creation.TaskOptions.ToNullableTaskOptions(),
+                                                                                                              submissionOptions),
+                                                                                            creation.ExpectedOutputKeys,
+                                                                                            creation.DataDependencies))
+                                  .ToList();
     try
     {
-      var sessionData = await sessionTable_.GetSessionAsync(request.SessionId,
-                                                            context.CancellationToken)
-                                           .ConfigureAwait(false);
+      await TaskLifeCycleHelper.CreateTasks(taskTable_,
+                                            resultTable_,
+                                            request.SessionId,
+                                            request.SessionId,
+                                            creationRequests,
+                                            logger_,
+                                            context.CancellationToken)
+                               .ConfigureAwait(false);
 
+      await TaskLifeCycleHelper.FinalizeTaskCreation(taskTable_,
+                                                     resultTable_,
+                                                     pushQueueStorage_,
+                                                     creationRequests,
+                                                     sessionData,
+                                                     request.SessionId,
+                                                     logger_,
+                                                     context.CancellationToken)
+                               .ConfigureAwait(false);
 
-      var submissionOptions = TaskLifeCycleHelper.ValidateSession(sessionData,
-                                                                  request.TaskOptions.ToNullableTaskOptions(),
-                                                                  request.SessionId,
-                                                                  pushQueueStorage_.MaxPriority,
-                                                                  logger_,
-                                                                  context.CancellationToken);
-
-      var creationRequests = request.TaskCreations.Select(creation => new TaskCreationRequest(Guid.NewGuid()
-                                                                                                  .ToString(),
-                                                                                              creation.PayloadId,
-                                                                                              TaskOptions.Merge(creation.TaskOptions.ToNullableTaskOptions(),
-                                                                                                                submissionOptions),
-                                                                                              creation.ExpectedOutputKeys,
-                                                                                              creation.DataDependencies))
-                                    .ToList();
-      try
-      {
-        await TaskLifeCycleHelper.CreateTasks(taskTable_,
-                                              resultTable_,
-                                              request.SessionId,
-                                              request.SessionId,
-                                              creationRequests,
-                                              logger_,
-                                              context.CancellationToken)
-                                 .ConfigureAwait(false);
-
-        await TaskLifeCycleHelper.FinalizeTaskCreation(taskTable_,
-                                                       resultTable_,
-                                                       pushQueueStorage_,
-                                                       creationRequests,
-                                                       sessionData,
-                                                       request.SessionId,
-                                                       logger_,
-                                                       context.CancellationToken)
-                                 .ConfigureAwait(false);
-
-        return new SubmitTasksResponse
+      return new SubmitTasksResponse
+             {
+               TaskInfos =
                {
-                 TaskInfos =
-                 {
-                   creationRequests.Select(creationRequest => new SubmitTasksResponse.Types.TaskInfo
+                 creationRequests.Select(creationRequest => new SubmitTasksResponse.Types.TaskInfo
+                                                            {
+                                                              DataDependencies =
                                                               {
-                                                                DataDependencies =
-                                                                {
-                                                                  creationRequest.DataDependencies,
-                                                                },
-                                                                ExpectedOutputIds =
-                                                                {
-                                                                  creationRequest.ExpectedOutputKeys,
-                                                                },
-                                                                TaskId    = creationRequest.TaskId,
-                                                                PayloadId = creationRequest.PayloadId,
-                                                              }),
-                 },
-               };
-      }
-      catch (Exception)
-      {
-        await TaskLifeCycleHelper.DeleteTasksAsync(taskTable_,
-                                                   resultTable_,
-                                                   creationRequests,
-                                                   CancellationToken.None)
-                                 .ConfigureAwait(false);
-        throw;
-      }
+                                                                creationRequest.DataDependencies,
+                                                              },
+                                                              ExpectedOutputIds =
+                                                              {
+                                                                creationRequest.ExpectedOutputKeys,
+                                                              },
+                                                              TaskId    = creationRequest.TaskId,
+                                                              PayloadId = creationRequest.PayloadId,
+                                                            }),
+               },
+             };
     }
-    catch (SubmissionClosedException e)
+    catch (Exception)
     {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "Client submission is closed, no tasks can be submitted"));
-    }
-    catch (ResultInvalidStatusException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks due to invalid dependency status");
-      throw new RpcException(new Status(StatusCode.FailedPrecondition,
-                                        "One or more dependencies have an invalid status"));
-    }
-    catch (ResultNotFoundException e)
-    {
-      logger_.LogWarning(e,
-                         "Error while submitting tasks due to dependency that does not exist");
-      throw new RpcException(new Status(StatusCode.NotFound,
-                                        "One or more dependencies do not exist"));
+      await TaskLifeCycleHelper.DeleteTasksAsync(taskTable_,
+                                                 resultTable_,
+                                                 creationRequests,
+                                                 CancellationToken.None)
+                               .ConfigureAwait(false);
+      throw;
     }
   }
 }

--- a/Common/tests/GrpcResultsServiceTests.cs
+++ b/Common/tests/GrpcResultsServiceTests.cs
@@ -27,6 +27,7 @@ using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Convertors;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
@@ -69,7 +70,7 @@ public class GrpcResultsServiceTests
                                                                .AddSingleton<AgentIdentifier>()
                                                                .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                .AddHttpClient()
-                                                               .AddGrpc(),
+                                                               .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                        builder => builder.UseRouting()
                                                          .UseAuthorization(),
                                        builder =>
@@ -672,7 +673,7 @@ public class GrpcResultsServiceTests
     var mock = new Mock<IResultTable>();
     mock.Setup(table => table.Create(It.IsAny<ICollection<Result>>(),
                                      It.IsAny<CancellationToken>()))
-        .Throws<OperationCanceledException>();
+        .Throws<Exception>();
 
 
     helper_ = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
@@ -684,7 +685,7 @@ public class GrpcResultsServiceTests
                                                                .AddSingleton<AgentIdentifier>()
                                                                .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                .AddHttpClient()
-                                                               .AddGrpc(),
+                                                               .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                        builder => builder.UseRouting()
                                                          .UseAuthorization(),
                                        builder =>

--- a/Common/tests/GrpcSessionsServiceTests.cs
+++ b/Common/tests/GrpcSessionsServiceTests.cs
@@ -28,6 +28,7 @@ using System.Threading.Tasks;
 using ArmoniK.Api.gRPC.V1.Results;
 using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Core.Base;
+using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -67,7 +68,7 @@ public class GrpcSessionsServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder => builder.MapGrpcService<GrpcSessionsService>(),
@@ -126,7 +127,7 @@ public class GrpcSessionsServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddSingleton(httpClient)
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>
@@ -307,7 +308,7 @@ public class GrpcSessionsServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddSingleton(httpClient)
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>
@@ -419,7 +420,7 @@ public class GrpcSessionsServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>

--- a/Common/tests/GrpcTasksServiceTests.cs
+++ b/Common/tests/GrpcTasksServiceTests.cs
@@ -27,6 +27,7 @@ using ArmoniK.Api.gRPC.V1.Sessions;
 using ArmoniK.Api.gRPC.V1.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
@@ -62,7 +63,7 @@ public class GrpcTasksServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder => builder.MapGrpcService<GrpcTasksService>(),
@@ -116,7 +117,7 @@ public class GrpcTasksServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>
@@ -227,7 +228,7 @@ public class GrpcTasksServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>
@@ -288,7 +289,7 @@ public class GrpcTasksServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>
@@ -360,7 +361,7 @@ public class GrpcTasksServiceTests
     queue.Setup(storage => storage.PushMessagesAsync(It.IsAny<ICollection<MessageData>>(),
                                                      It.IsAny<string>(),
                                                      It.IsAny<CancellationToken>()))
-         .Throws<OperationCanceledException>();
+         .Throws<Exception>();
 
     var helper = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
                                                                   .AddSingleton(queue.Object)
@@ -370,7 +371,7 @@ public class GrpcTasksServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>
@@ -474,7 +475,7 @@ public class GrpcTasksServiceTests
     mock.Setup(table => table.GetResults(It.IsAny<Expression<Func<Result, bool>>>(),
                                          It.IsAny<Expression<Func<Result, Result>>>(),
                                          It.IsAny<CancellationToken>()))
-        .Throws<OperationCanceledException>();
+        .Throws<Exception>();
 
     var helper = new TestDatabaseProvider(collection => collection.AddSingleton<IPullQueueStorage, SimplePullQueueStorage>()
                                                                   .AddSingleton<IPushQueueStorage, SimplePushQueueStorage>()
@@ -485,7 +486,7 @@ public class GrpcTasksServiceTests
                                                                   .AddSingleton<AgentIdentifier>()
                                                                   .AddScoped(typeof(FunctionExecutionMetrics<>))
                                                                   .AddHttpClient()
-                                                                  .AddGrpc(),
+                                                                  .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()),
                                           builder => builder.UseRouting()
                                                             .UseAuthorization(),
                                           builder =>

--- a/Common/tests/Helpers/GrpcSubmitterServiceHelper.cs
+++ b/Common/tests/Helpers/GrpcSubmitterServiceHelper.cs
@@ -24,12 +24,14 @@ using System.Threading.Tasks;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Auth.Authentication;
 using ArmoniK.Core.Common.Auth.Authorization;
+using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Injection;
 using ArmoniK.Core.Common.Meter;
 using ArmoniK.Core.Common.Pollster;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Auth;
+using ArmoniK.Core.Common.Utils;
 using ArmoniK.Utils;
 
 using Grpc.Core;
@@ -91,12 +93,16 @@ public class GrpcSubmitterServiceHelper : IDisposable
     builder.Services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>()
            .AddAuthorization();
 
+    builder.Services.AddSingleton<ExceptionManager>()
+           .AddSingleton(new ExceptionManager.Options())
+           .AddSingleton<ExceptionInterceptor>();
+
     if (validateGrpcRequests)
     {
       builder.Services.ValidateGrpcRequests();
     }
 
-    builder.Services.AddGrpc();
+    builder.Services.AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>());
 
     serviceConfigurator?.Invoke(builder.Services);
 

--- a/Common/tests/Helpers/TestDatabaseProvider.cs
+++ b/Common/tests/Helpers/TestDatabaseProvider.cs
@@ -26,10 +26,12 @@ using ArmoniK.Core.Adapters.MongoDB;
 using ArmoniK.Core.Adapters.MongoDB.Common;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Common.Auth.Authentication;
+using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.Injection;
 using ArmoniK.Core.Common.Injection.Options;
 using ArmoniK.Core.Common.Injection.Options.Database;
 using ArmoniK.Core.Common.Storage;
+using ArmoniK.Core.Common.Utils;
 using ArmoniK.Core.Utils;
 
 using EphemeralMongo;
@@ -155,7 +157,10 @@ public class TestDatabaseProvider : IDisposable
                                                               Injection.Options.Submitter.SettingSection)
            .AddSingleton(loggerProvider.CreateLogger("root"))
            .AddSingleton(ActivitySource)
-           .AddSingleton<IMongoClient>(client);
+           .AddSingleton<IMongoClient>(client)
+           .AddSingleton<ExceptionManager>()
+           .AddSingleton(new ExceptionManager.Options())
+           .AddSingleton<ExceptionInterceptor>();
 
     if (validateGrpcRequests)
     {

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -128,8 +128,7 @@ internal class ExceptionInterceptorTests
     var interceptor = new ExceptionInterceptor(exceptionManager,
                                                NullLogger<ExceptionInterceptor>.Instance);
     helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object,
-                                             services => services.AddSingleton(interceptor)
-                                                                 .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()));
+                                             services => services.AddSingleton(interceptor));
     var client = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(await helper_.CreateChannel()
                                                                                   .ConfigureAwait(false));
 
@@ -250,8 +249,7 @@ internal class ExceptionInterceptorTests
     var interceptor = new ExceptionInterceptor(exceptionManager,
                                                NullLogger<ExceptionInterceptor>.Instance);
     helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object,
-                                             services => services.AddSingleton(interceptor)
-                                                                 .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()));
+                                             services => services.AddSingleton(interceptor));
     var client = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(await helper_.CreateChannel()
                                                                                   .ConfigureAwait(false));
 
@@ -458,8 +456,7 @@ internal class ExceptionInterceptorTests
     var interceptor = new ExceptionInterceptor(exceptionManager,
                                                NullLogger<ExceptionInterceptor>.Instance);
     helper_ = new GrpcSubmitterServiceHelper(mockSubmitter.Object,
-                                             services => services.AddSingleton(interceptor)
-                                                                 .AddGrpc(options => options.Interceptors.Add<ExceptionInterceptor>()));
+                                             services => services.AddSingleton(interceptor));
     var client = new Api.gRPC.V1.Submitter.Submitter.SubmitterClient(await helper_.CreateChannel()
                                                                                   .ConfigureAwait(false));
 

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -24,6 +24,7 @@ using System.Threading.Tasks;
 using ArmoniK.Api.gRPC.V1;
 using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Base.DataStructures;
+using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
@@ -49,6 +50,8 @@ using NUnit.Framework;
 
 using TaskOptions = ArmoniK.Api.gRPC.V1.TaskOptions;
 using TaskRequest = ArmoniK.Core.Common.gRPC.Services.TaskRequest;
+using TimeoutException = ArmoniK.Core.Common.Exceptions.TimeoutException;
+using Type = System.Type;
 
 // ReSharper disable AccessToModifiedClosure
 
@@ -93,6 +96,61 @@ internal class ExceptionInterceptorTests
            NullLogger<ExceptionManager>.Instance,
            new ExceptionManager.Options(TimeSpan.Zero,
                                         maxError));
+
+  /// <summary>
+  ///   All concrete exception types deriving from <see cref="ArmoniKException" />, discovered by reflection across the
+  ///   Base and Common assemblies.
+  /// </summary>
+  private static IEnumerable<Type> ArmoniKExceptionTypes
+    => new[]
+      {
+        typeof(ArmoniKException).Assembly,     // ArmoniK.Core.Base
+        typeof(ExceptionInterceptor).Assembly, // ArmoniK.Core.Common
+      }.SelectMany(assembly => assembly.GetTypes())
+       .Where(type => typeof(ArmoniKException).IsAssignableFrom(type) && !type.IsAbstract)
+       .Distinct();
+
+  /// <summary>
+  ///   Exception types that are intentionally allowed to resolve to the generic <see cref="ArmoniKException" /> ->
+  ///   <see cref="StatusCode.Internal" /> mapping. Any other exception reaching that fallback must be given a dedicated
+  ///   mapping in <see cref="ExceptionInterceptor" /> or added here on purpose.
+  /// </summary>
+  private static readonly HashSet<Type> InternalFallbackWhitelist = new()
+                                                                    {
+                                                                      typeof(ArmoniKException),
+                                                                      typeof(TaskAlreadyExistsException),
+                                                                      typeof(WorkerDownException),
+                                                                      typeof(QueueInsertionFailedException),
+                                                                      typeof(TimeoutException),
+                                                                    };
+
+  [Test]
+  [TestCaseSource(nameof(ArmoniKExceptionTypes))]
+  public void ArmoniKExceptionShouldNeverMapToUnknown(Type exceptionType)
+  {
+    using var exceptionManager = BuildExceptionManager(int.MaxValue / 2);
+    var interceptor = new ExceptionInterceptor(exceptionManager,
+                                               NullLogger<ExceptionInterceptor>.Instance);
+    var exception = (Exception)Activator.CreateInstance(exceptionType)!;
+
+    var rpc = Assert.CatchAsync<RpcException>(async () => await interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                                                               TestServerCallContext.Create(),
+                                                                                                               (_,
+                                                                                                                _) => throw exception)
+                                                                           .ConfigureAwait(false));
+
+    Assert.That(rpc!.StatusCode,
+                Is.Not.EqualTo(StatusCode.Unknown),
+                $"{exceptionType.Name} maps to Unknown; add a mapping in ExceptionInterceptor.HandleException.");
+
+    if (rpc.StatusCode == StatusCode.Internal)
+    {
+      Assert.That(InternalFallbackWhitelist,
+                  Does.Contain(exceptionType),
+                  $"{exceptionType.Name} falls through to the generic ArmoniKException -> Internal mapping. " +
+                  "Add a dedicated arm in ExceptionInterceptor.HandleException, or add it to InternalFallbackWhitelist.");
+    }
+  }
 
   [Test]
   [Obsolete]

--- a/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
+++ b/Common/tests/Submitter/GrpcSubmitterServiceTests.cs
@@ -28,9 +28,11 @@ using ArmoniK.Api.gRPC.V1.Submitter;
 using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Exceptions;
+using ArmoniK.Core.Common.gRPC;
 using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Helpers;
+using ArmoniK.Core.Common.Utils;
 using ArmoniK.Utils;
 
 using Google.Protobuf;
@@ -38,7 +40,10 @@ using Google.Protobuf.WellKnownTypes;
 
 using Grpc.Core;
 
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Hosting.Internal;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 
 using Moq;
 
@@ -66,11 +71,22 @@ public class GrpcSubmitterServiceTests
                      .Returns(mockSessionTable_.Object);
     mockTaskTable_.Setup(taskTable => taskTable.Secondary)
                   .Returns(mockTaskTable_.Object);
+    lifetime_ = new ApplicationLifetime(NullLogger<ApplicationLifetime>.Instance);
+    exceptionManager_ = new ExceptionManager(lifetime_,
+                                             new OptionsWrapper<ConsoleLifetimeOptions>(new ConsoleLifetimeOptions()),
+                                             new HostingEnvironment(),
+                                             new OptionsWrapper<HostOptions>(new HostOptions()),
+                                             NullLogger<ExceptionManager>.Instance,
+                                             new ExceptionManager.Options());
+    interceptor_ = new ExceptionInterceptor(exceptionManager_,
+                                            NullLogger<ExceptionInterceptor>.Instance);
   }
 
   [TearDown]
   public virtual void TearDown()
   {
+    exceptionManager_.Dispose();
+    lifetime_.StopApplication();
   }
 
   private readonly Mock<IResultTable>   mockResultTable_   = new();
@@ -78,6 +94,10 @@ public class GrpcSubmitterServiceTests
   private readonly Mock<ITaskTable>     mockTaskTable_     = new();
   private readonly Mock<ISubmitter>     mockSubmitter_     = new();
   private readonly Mock<IObjectStorage> mockObjectStorage_ = new();
+
+  private ApplicationLifetime  lifetime_         = null!;
+  private ExceptionManager     exceptionManager_ = null!;
+  private ExceptionInterceptor interceptor_      = null!;
 
   private readonly TaskOptions taskOptions_ = new()
                                               {
@@ -148,14 +168,15 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetResultStream(new ResultRequest
-                                       {
-                                         ResultId = "Key",
-                                         Session  = "Session",
-                                       },
-                                       helperServerStreamWriter,
-                                       TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ServerStreamingServerHandler(new ResultRequest
+                                                      {
+                                                        ResultId = "Key",
+                                                        Session  = "Session",
+                                                      },
+                                                      helperServerStreamWriter,
+                                                      TestServerCallContext.Create(),
+                                                      service.TryGetResultStream)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -188,14 +209,15 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetResultStream(new ResultRequest
-                                       {
-                                         ResultId = "Key",
-                                         Session  = "Session",
-                                       },
-                                       helperServerStreamWriter,
-                                       TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ServerStreamingServerHandler(new ResultRequest
+                                                      {
+                                                        ResultId = "Key",
+                                                        Session  = "Session",
+                                                      },
+                                                      helperServerStreamWriter,
+                                                      TestServerCallContext.Create(),
+                                                      service.TryGetResultStream)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -228,14 +250,15 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetResultStream(new ResultRequest
-                                       {
-                                         ResultId = "Key",
-                                         Session  = "Session",
-                                       },
-                                       helperServerStreamWriter,
-                                       TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ServerStreamingServerHandler(new ResultRequest
+                                                      {
+                                                        ResultId = "Key",
+                                                        Session  = "Session",
+                                                      },
+                                                      helperServerStreamWriter,
+                                                      TestServerCallContext.Create(),
+                                                      service.TryGetResultStream)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -268,14 +291,15 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetResultStream(new ResultRequest
-                                       {
-                                         ResultId = "Key",
-                                         Session  = "Session",
-                                       },
-                                       helperServerStreamWriter,
-                                       TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ServerStreamingServerHandler(new ResultRequest
+                                                      {
+                                                        ResultId = "Key",
+                                                        Session  = "Session",
+                                                      },
+                                                      helperServerStreamWriter,
+                                                      TestServerCallContext.Create(),
+                                                      service.TryGetResultStream)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -308,14 +332,15 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetResultStream(new ResultRequest
-                                       {
-                                         ResultId = "Key",
-                                         Session  = "Session",
-                                       },
-                                       helperServerStreamWriter,
-                                       TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ServerStreamingServerHandler(new ResultRequest
+                                                      {
+                                                        ResultId = "Key",
+                                                        Session  = "Session",
+                                                      },
+                                                      helperServerStreamWriter,
+                                                      TestServerCallContext.Create(),
+                                                      service.TryGetResultStream)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -348,14 +373,15 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetResultStream(new ResultRequest
-                                       {
-                                         ResultId = "Key",
-                                         Session  = "Session",
-                                       },
-                                       helperServerStreamWriter,
-                                       TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ServerStreamingServerHandler(new ResultRequest
+                                                      {
+                                                        ResultId = "Key",
+                                                        Session  = "Session",
+                                                      },
+                                                      helperServerStreamWriter,
+                                                      TestServerCallContext.Create(),
+                                                      service.TryGetResultStream)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -384,13 +410,14 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetTaskOutput(new TaskOutputRequest
-                                     {
-                                       TaskId  = "Key",
-                                       Session = "Session",
-                                     },
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new TaskOutputRequest
+                                            {
+                                              TaskId  = "Key",
+                                              Session = "Session",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.TryGetTaskOutput)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -421,13 +448,14 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.TryGetTaskOutput(new TaskOutputRequest
-                                     {
-                                       TaskId  = "Key",
-                                       Session = "Session",
-                                     },
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new TaskOutputRequest
+                                            {
+                                              TaskId  = "Key",
+                                              Session = "Session",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.TryGetTaskOutput)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -519,9 +547,10 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.GetServiceConfiguration(new Empty(),
-                                            TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new Empty(),
+                                            TestServerCallContext.Create(),
+                                            service.GetServiceConfiguration)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -607,12 +636,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CancelSession(new Session
-                                  {
-                                    Id = "Session",
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new Session
+                                            {
+                                              Id = "Session",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CancelSession)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -642,12 +672,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CancelSession(new Session
-                                  {
-                                    Id = "Session",
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new Session
+                                            {
+                                              Id = "Session",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CancelSession)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -677,12 +708,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CancelSession(new Session
-                                  {
-                                    Id = "Session",
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new Session
+                                            {
+                                              Id = "Session",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CancelSession)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -745,18 +777,19 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CancelTasks(new TaskFilter
-                                {
-                                  Session = new TaskFilter.Types.IdsRequest
+      await interceptor_.UnaryServerHandler(new TaskFilter
                                             {
-                                              Ids =
-                                              {
-                                                "Session",
-                                              },
+                                              Session = new TaskFilter.Types.IdsRequest
+                                                        {
+                                                          Ids =
+                                                          {
+                                                            "Session",
+                                                          },
+                                                        },
                                             },
-                                },
-                                TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+                                            TestServerCallContext.Create(),
+                                            service.CancelTasks)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -785,18 +818,19 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CancelTasks(new TaskFilter
-                                {
-                                  Session = new TaskFilter.Types.IdsRequest
+      await interceptor_.UnaryServerHandler(new TaskFilter
                                             {
-                                              Ids =
-                                              {
-                                                "Session",
-                                              },
+                                              Session = new TaskFilter.Types.IdsRequest
+                                                        {
+                                                          Ids =
+                                                          {
+                                                            "Session",
+                                                          },
+                                                        },
                                             },
-                                },
-                                TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+                                            TestServerCallContext.Create(),
+                                            service.CancelTasks)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -862,15 +896,16 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateSession(new CreateSessionRequest
-                                  {
-                                    DefaultTaskOption = new TaskOptions
-                                                        {
-                                                          MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(1)),
-                                                        },
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new CreateSessionRequest
+                                            {
+                                              DefaultTaskOption = new TaskOptions
+                                                                  {
+                                                                    MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(1)),
+                                                                  },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CreateSession)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -901,21 +936,22 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateSession(new CreateSessionRequest
-                                  {
-                                    PartitionIds =
-                                    {
-                                      "part1",
-                                      "part2",
-                                    },
-                                    DefaultTaskOption = new TaskOptions
-                                                        {
-                                                          PartitionId = "part1",
-                                                          MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(1)),
-                                                        },
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new CreateSessionRequest
+                                            {
+                                              PartitionIds =
+                                              {
+                                                "part1",
+                                                "part2",
+                                              },
+                                              DefaultTaskOption = new TaskOptions
+                                                                  {
+                                                                    PartitionId = "part1",
+                                                                    MaxDuration = Duration.FromTimeSpan(TimeSpan.FromSeconds(1)),
+                                                                  },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CreateSession)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1008,28 +1044,29 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateSmallTasks(new CreateSmallTaskRequest
-                                     {
-                                       SessionId   = "SessionId",
-                                       TaskOptions = taskOptions_,
-                                       TaskRequests =
-                                       {
-                                         new Api.gRPC.V1.TaskRequest
-                                         {
-                                           Payload = ByteString.Empty,
-                                           DataDependencies =
-                                           {
-                                             "dep",
-                                           },
-                                           ExpectedOutputKeys =
-                                           {
-                                             "out",
-                                           },
-                                         },
-                                       },
-                                     },
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new CreateSmallTaskRequest
+                                            {
+                                              SessionId   = "SessionId",
+                                              TaskOptions = taskOptions_,
+                                              TaskRequests =
+                                              {
+                                                new Api.gRPC.V1.TaskRequest
+                                                {
+                                                  Payload = ByteString.Empty,
+                                                  DataDependencies =
+                                                  {
+                                                    "dep",
+                                                  },
+                                                  ExpectedOutputKeys =
+                                                  {
+                                                    "out",
+                                                  },
+                                                },
+                                              },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CreateSmallTasks)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1062,28 +1099,29 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateSmallTasks(new CreateSmallTaskRequest
-                                     {
-                                       SessionId   = "SessionId",
-                                       TaskOptions = taskOptions_,
-                                       TaskRequests =
-                                       {
-                                         new Api.gRPC.V1.TaskRequest
-                                         {
-                                           Payload = ByteString.Empty,
-                                           DataDependencies =
-                                           {
-                                             "dep",
-                                           },
-                                           ExpectedOutputKeys =
-                                           {
-                                             "out",
-                                           },
-                                         },
-                                       },
-                                     },
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new CreateSmallTaskRequest
+                                            {
+                                              SessionId   = "SessionId",
+                                              TaskOptions = taskOptions_,
+                                              TaskRequests =
+                                              {
+                                                new Api.gRPC.V1.TaskRequest
+                                                {
+                                                  Payload = ByteString.Empty,
+                                                  DataDependencies =
+                                                  {
+                                                    "dep",
+                                                  },
+                                                  ExpectedOutputKeys =
+                                                  {
+                                                    "out",
+                                                  },
+                                                },
+                                              },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.CreateSmallTasks)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1173,9 +1211,10 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateLargeTasks(helper,
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ClientStreamingServerHandler(helper,
+                                                      TestServerCallContext.Create(),
+                                                      service.CreateLargeTasks)
+                        .ConfigureAwait(false);
 
       Assert.Fail();
     }
@@ -1222,9 +1261,10 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateLargeTasks(helper,
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ClientStreamingServerHandler(helper,
+                                                      TestServerCallContext.Create(),
+                                                      service.CreateLargeTasks)
+                        .ConfigureAwait(false);
 
       Assert.Fail();
     }
@@ -1271,9 +1311,10 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.CreateLargeTasks(helper,
-                                     TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.ClientStreamingServerHandler(helper,
+                                                      TestServerCallContext.Create(),
+                                                      service.CreateLargeTasks)
+                        .ConfigureAwait(false);
 
       Assert.Fail();
     }
@@ -1355,21 +1396,22 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.WaitForCompletion(new WaitRequest
-                                      {
-                                        Filter = new TaskFilter
-                                                 {
-                                                   Task = new TaskFilter.Types.IdsRequest
-                                                          {
-                                                            Ids =
-                                                            {
-                                                              "TaskId",
-                                                            },
-                                                          },
-                                                 },
-                                      },
-                                      TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new WaitRequest
+                                            {
+                                              Filter = new TaskFilter
+                                                       {
+                                                         Task = new TaskFilter.Types.IdsRequest
+                                                                {
+                                                                  Ids =
+                                                                  {
+                                                                    "TaskId",
+                                                                  },
+                                                                },
+                                                       },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.WaitForCompletion)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1399,21 +1441,22 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.WaitForCompletion(new WaitRequest
-                                      {
-                                        Filter = new TaskFilter
-                                                 {
-                                                   Task = new TaskFilter.Types.IdsRequest
-                                                          {
-                                                            Ids =
-                                                            {
-                                                              "TaskId",
-                                                            },
-                                                          },
-                                                 },
-                                      },
-                                      TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new WaitRequest
+                                            {
+                                              Filter = new TaskFilter
+                                                       {
+                                                         Task = new TaskFilter.Types.IdsRequest
+                                                                {
+                                                                  Ids =
+                                                                  {
+                                                                    "TaskId",
+                                                                  },
+                                                                },
+                                                       },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.WaitForCompletion)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1476,12 +1519,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.WaitForAvailability(new ResultRequest
-                                        {
-                                          ResultId = "Key",
-                                        },
-                                        TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new ResultRequest
+                                            {
+                                              ResultId = "Key",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.WaitForAvailability)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1512,12 +1556,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.WaitForAvailability(new ResultRequest
-                                        {
-                                          ResultId = "Key",
-                                        },
-                                        TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new ResultRequest
+                                            {
+                                              ResultId = "Key",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.WaitForAvailability)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1548,12 +1593,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.WaitForAvailability(new ResultRequest
-                                        {
-                                          ResultId = "Key",
-                                        },
-                                        TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new ResultRequest
+                                            {
+                                              ResultId = "Key",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.WaitForAvailability)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1584,12 +1630,13 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.WaitForAvailability(new ResultRequest
-                                        {
-                                          ResultId = "Key",
-                                        },
-                                        TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new ResultRequest
+                                            {
+                                              ResultId = "Key",
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.WaitForAvailability)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1657,15 +1704,16 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.GetTaskStatus(new GetTaskStatusRequest
-                                  {
-                                    TaskIds =
-                                    {
-                                      "TaskId",
-                                    },
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new GetTaskStatusRequest
+                                            {
+                                              TaskIds =
+                                              {
+                                                "TaskId",
+                                              },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.GetTaskStatus)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1696,15 +1744,16 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.GetTaskStatus(new GetTaskStatusRequest
-                                  {
-                                    TaskIds =
-                                    {
-                                      "TaskId",
-                                    },
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new GetTaskStatusRequest
+                                            {
+                                              TaskIds =
+                                              {
+                                                "TaskId",
+                                              },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.GetTaskStatus)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1733,15 +1782,16 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.GetTaskStatus(new GetTaskStatusRequest
-                                  {
-                                    TaskIds =
-                                    {
-                                      "TaskId",
-                                    },
-                                  },
-                                  TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new GetTaskStatusRequest
+                                            {
+                                              TaskIds =
+                                              {
+                                                "TaskId",
+                                              },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.GetTaskStatus)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1811,18 +1861,19 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.ListTasks(new TaskFilter
-                              {
-                                Task = new TaskFilter.Types.IdsRequest
-                                       {
-                                         Ids =
-                                         {
-                                           "TaskId",
-                                         },
-                                       },
-                              },
-                              TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new TaskFilter
+                                            {
+                                              Task = new TaskFilter.Types.IdsRequest
+                                                     {
+                                                       Ids =
+                                                       {
+                                                         "TaskId",
+                                                       },
+                                                     },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.ListTasks)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1853,18 +1904,19 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.ListTasks(new TaskFilter
-                              {
-                                Task = new TaskFilter.Types.IdsRequest
-                                       {
-                                         Ids =
-                                         {
-                                           "TaskId",
-                                         },
-                                       },
-                              },
-                              TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new TaskFilter
+                                            {
+                                              Task = new TaskFilter.Types.IdsRequest
+                                                     {
+                                                       Ids =
+                                                       {
+                                                         "TaskId",
+                                                       },
+                                                     },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.ListTasks)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
@@ -1896,23 +1948,24 @@ public class GrpcSubmitterServiceTests
 
     try
     {
-      await service.GetResultStatus(new GetResultStatusRequest
-                                    {
-                                      SessionId = "sessionId",
-                                      ResultIds =
-                                      {
-                                        "Result",
-                                      },
-                                    },
-                                    TestServerCallContext.Create())
-                   .ConfigureAwait(false);
+      await interceptor_.UnaryServerHandler(new GetResultStatusRequest
+                                            {
+                                              SessionId = "sessionId",
+                                              ResultIds =
+                                              {
+                                                "Result",
+                                              },
+                                            },
+                                            TestServerCallContext.Create(),
+                                            service.GetResultStatus)
+                        .ConfigureAwait(false);
       Assert.Fail();
     }
     catch (RpcException e)
     {
       Console.WriteLine(e);
       Assert.That(e.StatusCode,
-                  Is.EqualTo(StatusCode.Internal));
+                  Is.EqualTo(StatusCode.NotFound));
     }
   }
 

--- a/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
+++ b/Common/tests/Submitter/IntegrationGrpcSubmitterServiceTest.cs
@@ -798,8 +798,8 @@ internal class IntegrationGrpcSubmitterServiceTest
   {
     get
     {
-      yield return new TestCaseData(new ThrowExceptionSubmitter<TaskNotFoundException>()).Returns(StatusCode.Internal);
-      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<TaskNotFoundException>()).Returns(StatusCode.Internal);
+      yield return new TestCaseData(new ThrowExceptionSubmitter<TaskNotFoundException>()).Returns(StatusCode.NotFound);
+      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<TaskNotFoundException>()).Returns(StatusCode.NotFound);
     }
   }
 
@@ -807,8 +807,8 @@ internal class IntegrationGrpcSubmitterServiceTest
   {
     get
     {
-      yield return new TestCaseData(new ThrowExceptionSubmitter<ResultNotFoundException>()).Returns(StatusCode.Internal);
-      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<ResultNotFoundException>()).Returns(StatusCode.Internal);
+      yield return new TestCaseData(new ThrowExceptionSubmitter<ResultNotFoundException>()).Returns(StatusCode.NotFound);
+      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<ResultNotFoundException>()).Returns(StatusCode.NotFound);
     }
   }
 
@@ -816,8 +816,8 @@ internal class IntegrationGrpcSubmitterServiceTest
   {
     get
     {
-      yield return new TestCaseData(new ThrowExceptionSubmitter<SessionNotFoundException>()).Returns(StatusCode.Internal);
-      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<SessionNotFoundException>()).Returns(StatusCode.Internal);
+      yield return new TestCaseData(new ThrowExceptionSubmitter<SessionNotFoundException>()).Returns(StatusCode.NotFound);
+      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<SessionNotFoundException>()).Returns(StatusCode.NotFound);
     }
   }
 
@@ -825,8 +825,8 @@ internal class IntegrationGrpcSubmitterServiceTest
   {
     get
     {
-      yield return new TestCaseData(new ThrowExceptionSubmitter<ObjectDataNotFoundException>()).Returns(StatusCode.Internal);
-      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<ObjectDataNotFoundException>()).Returns(StatusCode.Internal);
+      yield return new TestCaseData(new ThrowExceptionSubmitter<ObjectDataNotFoundException>()).Returns(StatusCode.NotFound);
+      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<ObjectDataNotFoundException>()).Returns(StatusCode.NotFound);
     }
   }
 
@@ -834,8 +834,8 @@ internal class IntegrationGrpcSubmitterServiceTest
   {
     get
     {
-      yield return new TestCaseData(new ThrowExceptionSubmitter<PartitionNotFoundException>()).Returns(StatusCode.InvalidArgument);
-      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<PartitionNotFoundException>()).Returns(StatusCode.InvalidArgument);
+      yield return new TestCaseData(new ThrowExceptionSubmitter<PartitionNotFoundException>()).Returns(StatusCode.NotFound);
+      yield return new TestCaseData(new AsyncThrowExceptionSubmitter<PartitionNotFoundException>()).Returns(StatusCode.NotFound);
     }
   }
 
@@ -939,7 +939,7 @@ internal class IntegrationGrpcSubmitterServiceTest
   {
     get
     {
-      yield return new TestCaseData(new ThrowExceptionTaskTable<TaskNotFoundException>()).Returns(StatusCode.Internal);
+      yield return new TestCaseData(new ThrowExceptionTaskTable<TaskNotFoundException>()).Returns(StatusCode.NotFound);
       yield return new TestCaseData(new ThrowExceptionTaskTable<Exception>()).Returns(StatusCode.Unknown);
     }
   }
@@ -962,7 +962,7 @@ internal class IntegrationGrpcSubmitterServiceTest
     {
       foreach (var (exception, statusCode) in new[]
                                               {
-                                                (new TaskNotFoundException(), StatusCode.Internal),
+                                                (new TaskNotFoundException(), StatusCode.NotFound),
                                                 (new ResultNotFoundException(), StatusCode.NotFound),
                                                 (new Exception(), StatusCode.Unknown),
                                               })


### PR DESCRIPTION
# Motivation

Exception handling in the gRPC layer was duplicated across every service method. Each RPC in `GrpcSubmitterService`, `GrpcSessionsService`, `GrpcTasksService`, and `GrpcResultsService` wrapped its body in `try/catch` blocks that translated domain exceptions (e.g. `ResultNotFoundException`, `SessionNotFoundException`, `ObjectDataNotFoundException`) into `RpcException`s. This led to:

- Massive boilerplate (the same catch blocks copy-pasted dozens of times).
- Inconsistent status codes and log messages for the same exception type across methods.
- Easy-to-miss cases where a method forgot to translate an exception, leaking an unmapped `Internal` error to the client.

# Description

Centralizes all exception-to-`RpcException` translation in `ExceptionInterceptor`, removing the per-method `try/catch` boilerplate from the gRPC services, and adds a reflection-based guard so no ArmoniK exception can silently fall through to `Unknown`.

**`ExceptionInterceptor` revamp:**
- `HandleException` is now a single `switch` expression mapping each domain/infrastructure exception type to a `StatusCode`, a human-readable detail string, and an `ExceptionAction`.
- New private `ExceptionAction` enum drives behaviour: `Warning` (log warning), `Error` (log error), `Record` (record on the `ExceptionManager` and log error).
- Mapping highlights:
  - `OperationCanceledException` with a client-cancelled token -> `Cancelled` (Warning); otherwise -> `Cancelled` (Record, internal cancellation).
  - Not-found domain exceptions (`ObjectDataNotFoundException`, `PartitionNotFoundException`, `ResultNotFoundException`, `SessionNotFoundException`, `TaskNotFoundException`) -> `NotFound` (Warning).
  - Precondition exceptions (`InvalidSessionTransitionException`, `ResultInvalidStatusException`, `SubmissionClosedException`, `TaskAlreadyInFinalStateException`, `TaskCanceledException`, `TaskPausedException`) -> `FailedPrecondition` (Warning).
  - Generic `ArmoniKException` (and the intentionally-generic `TaskAlreadyExistsException`, `WorkerDownException`, `QueueInsertionFailedException`, `TimeoutException`) -> `Internal` (Warning).
  - Pass-through `RpcException`s: client-error status codes are logged as warnings, server-error codes are recorded.
  - Anything else -> `Unknown` (Record).
- `HandleException`/`HandleSuccess` are now synchronous; `HandleException` returns the `RpcException` to `throw` rather than awaiting and relying on a separate `throw`, simplifying the interceptor call sites.
- New `ProcessException` helper performs the logging/recording and builds the `RpcException`, optionally appending the original exception message to the status detail (`skipMessageInRpc`).

**Service factorization:**
- Removed the now-redundant `try/catch` blocks from `GrpcSubmitterService`, `GrpcSessionsService`, `GrpcTasksService`, and `GrpcResultsService`, along with their now-unused exception `using` imports.

<img width="1304" height="601" alt="image" src="https://github.com/user-attachments/assets/27f654c2-8680-4729-8f28-64e4176f7e38" />

# Testing

- **Wired the interceptor into the test harnesses.** Since translation no longer happens inside the services, the unit tests had to run through the interceptor to observe `RpcException`s. The shared helpers (`TestDatabaseProvider`, `GrpcSubmitterServiceHelper`) now register `ExceptionManager` + `ExceptionInterceptor` and add it to the gRPC pipeline by default; `GrpcResultsServiceTests`, `GrpcSessionsServiceTests`, and `GrpcTasksServiceTests` add the interceptor to their `AddGrpc(...)`. The direct-call tests in `GrpcSubmitterServiceTests` now invoke the matching `ExceptionInterceptor` handler (`UnaryServerHandler` / `ServerStreamingServerHandler` / `ClientStreamingServerHandler`) so they still assert `RpcException` + `StatusCode`.
- **Updated expectations changed by the now-uniform mapping** in `IntegrationGrpcSubmitterServiceTest` and `GrpcSubmitterServiceTests` (e.g. context-specific `Internal` variants and `PartitionNotFound -> InvalidArgument` are now the uniform per-type codes).
- **New reflection guard test** `ArmoniKExceptionShouldNeverMapToUnknown` (`ExceptionInterceptorTests`): discovers every concrete `ArmoniKException` subtype across the Base and Common assemblies, drives each through the interceptor, and asserts the resulting `StatusCode != Unknown`. Any exception that resolves to the generic `ArmoniKException -> Internal` fallback must be in an explicit `InternalFallbackWhitelist`, so a newly-added exception either gets a dedicated mapping or is consciously whitelisted instead of silently drifting into the generic bucket.
- All affected suites pass locally (`ExceptionInterceptorTests`, `IntegrationGrpcSubmitterServiceTest`, `GrpcSubmitterServiceTests`, `GrpcResultsServiceTests`, `GrpcSessionsServiceTests`, `GrpcTasksServiceTests`).

# Impact

- **Behaviour**: Status codes and log levels for thrown exceptions are now consistent across all RPCs. Several exceptions are tightened from a generic `Internal` to dedicated codes: precondition/state violations -> `FailedPrecondition`. Clients relying on the previous (less specific) codes for these cases will observe the new codes.
- **Maintainability**: A single place to add or adjust exception mappings; new RPC methods no longer need bespoke catch blocks, and the guard test enforces that new exceptions are handled.
- **Logging**: Error messages now include the request path, status code, detail, and original exception message via a structured template.
- No new dependencies, no configuration changes.

# Additional Information

This builds on the prior work binding `ExceptionInterceptor` to the `ExceptionManager` (#1244), which is already merged into `main`. The exceptions intentionally left on the generic `Internal` mapping (`TaskAlreadyExistsException`, `WorkerDownException`, `QueueInsertionFailedException`, `TimeoutException`) were reviewed explicitly; `TimeoutException` in particular should never reach the client, so it deliberately uses the generic fallback. `TaskAlreadyExistsException` could later move to `AlreadyExists` if desired.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.