### PR TITLE
ci: HtcMock client as self-contained single-file binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -893,6 +893,36 @@ jobs:
             -e GrpcClient__Endpoint=http://armonik.control.submitter:1080 `
             dockerhubaneo/armonik_core_htcmock_test_client:$env:VERSION
 
+      - name: Build HtcMock win-x64 binary
+        shell: bash
+        run: just tag=$VERSION publishHtcmockClient win-x64
+
+      - name: Run HtcMock binary test 100 tasks 1 level
+        timeout-minutes: 3
+        shell: powershell
+        run: |
+          $env:HtcMock__NTasks = "100"
+          $env:HtcMock__TotalCalculationTime = "00:00:00.100"
+          $env:HtcMock__DataSize = "1"
+          $env:HtcMock__MemorySize = "1"
+          $env:HtcMock__SubTasksLevels = "1"
+          $env:HtcMock__Partition = "TestPartition0"
+          $env:GrpcClient__Endpoint = "http://localhost:5001"
+          .\publish\htcmock-client-win-x64\ArmoniK.Samples.HtcMock.Client.exe
+
+      - name: Run HtcMock binary test 100 tasks 4 levels
+        timeout-minutes: 3
+        shell: powershell
+        run: |
+          $env:HtcMock__NTasks = "100"
+          $env:HtcMock__TotalCalculationTime = "00:00:00.100"
+          $env:HtcMock__DataSize = "1"
+          $env:HtcMock__MemorySize = "1"
+          $env:HtcMock__SubTasksLevels = "4"
+          $env:HtcMock__Partition = "TestPartition0"
+          $env:GrpcClient__Endpoint = "http://localhost:5001"
+          .\publish\htcmock-client-win-x64\ArmoniK.Samples.HtcMock.Client.exe
+
       - name: Collect docker container logs
         if: ${{ always() }}
         uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
@@ -923,8 +953,16 @@ jobs:
       - images
     env:
       VERSION: ${{ needs.versionning.outputs.version }}
-    runs-on: ubuntu-latest
-    name: HtcMock self-contained binary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-x64
+            runner: ubuntu-latest
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    name: HtcMock self-contained binary (${{ matrix.arch }})
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -956,13 +994,13 @@ jobs:
         run: |
           tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=htcmock build-all
 
-      - name: Build self-contained client binaries
-        run: just tag=${VERSION} publishHtcmockClientAll
+      - name: Build self-contained client binary
+        run: just tag=${VERSION} publishHtcmockClient ${{ matrix.arch }}
 
-      - name: Upload self-contained binaries
+      - name: Upload self-contained binary
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: htcmock-client-${{ needs.versionning.outputs.version }}
+          name: htcmock-client-${{ needs.versionning.outputs.version }}-${{ matrix.arch }}
           path: ./publish/
           retention-days: 5
 
@@ -987,7 +1025,7 @@ jobs:
           export HtcMock__SubTasksLevels=1
           export HtcMock__Partition=TestPartition0
           export GrpcClient__Endpoint=http://localhost:5001
-          ./publish/htcmock-client-linux-x64/ArmoniK.Samples.HtcMock.Client
+          ./publish/htcmock-client-${{ matrix.arch }}/ArmoniK.Samples.HtcMock.Client
 
       - name: Run HtcMock test 100 tasks 4 levels
         timeout-minutes: 3
@@ -999,7 +1037,7 @@ jobs:
           export HtcMock__SubTasksLevels=4
           export HtcMock__Partition=TestPartition0
           export GrpcClient__Endpoint=http://localhost:5001
-          ./publish/htcmock-client-linux-x64/ArmoniK.Samples.HtcMock.Client
+          ./publish/htcmock-client-${{ matrix.arch }}/ArmoniK.Samples.HtcMock.Client
 
       - name: Show logs
         if: ${{ always() && env.REPOSITORY != github.repository }}
@@ -1011,8 +1049,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: |
-          docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary.json.gz"
-          tar -czf - monitor/ | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-monitor.tar.gz"
+          docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-${{ matrix.arch }}.json.gz"
+          tar -czf - monitor/ | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-${{ matrix.arch }}-monitor.tar.gz"
 
       - name: Collect docker container logs
         if: ${{ always() }}
@@ -1029,7 +1067,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: |
-          tar -cvf - ./container-logs | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-container-logs.tar.gz"
+          tar -cvf - ./container-logs | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-${{ matrix.arch }}-container-logs.tar.gz"
       - name: Export and upload database
         if: ${{ always() && env.REPOSITORY == github.repository }}
         env:
@@ -1038,7 +1076,7 @@ jobs:
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: |
           bash tools/export_mongodb.sh
-          tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-database.tar.gz"
+          tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-${{ matrix.arch }}-database.tar.gz"
 
   testBenchBinary:
     needs:
@@ -1046,8 +1084,16 @@ jobs:
       - images
     env:
       VERSION: ${{ needs.versionning.outputs.version }}
-    runs-on: ubuntu-latest
-    name: Bench self-contained binary
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: linux-x64
+            runner: ubuntu-latest
+          - arch: linux-arm64
+            runner: ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
+    name: Bench self-contained binary (${{ matrix.arch }})
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -1079,13 +1125,13 @@ jobs:
         run: |
           tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=bench build-all
 
-      - name: Build self-contained client binaries
-        run: just tag=${VERSION} publishBenchClientAll
+      - name: Build self-contained client binary
+        run: just tag=${VERSION} publishBenchClient ${{ matrix.arch }}
 
-      - name: Upload self-contained binaries
+      - name: Upload self-contained binary
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
         with:
-          name: bench-client-${{ needs.versionning.outputs.version }}
+          name: bench-client-${{ needs.versionning.outputs.version }}-${{ matrix.arch }}
           path: ./publish/
           retention-days: 5
 
@@ -1110,7 +1156,7 @@ jobs:
           export BenchOptions__BatchSize=100
           export BenchOptions__Partition=TestPartition0
           export GrpcClient__Endpoint=http://localhost:5001
-          ./publish/bench-client-linux-x64/ArmoniK.Samples.Bench.Client
+          ./publish/bench-client-${{ matrix.arch }}/ArmoniK.Samples.Bench.Client
 
       - name: Show logs
         if: ${{ always() && env.REPOSITORY != github.repository }}
@@ -1122,8 +1168,8 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: |
-          docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary.json.gz"
-          tar -czf - monitor/ | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-monitor.tar.gz"
+          docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-${{ matrix.arch }}.json.gz"
+          tar -czf - monitor/ | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-${{ matrix.arch }}-monitor.tar.gz"
 
       - name: Collect docker container logs
         if: ${{ always() }}
@@ -1140,7 +1186,7 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: |
-          tar -cvf - ./container-logs | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-container-logs.tar.gz"
+          tar -cvf - ./container-logs | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-${{ matrix.arch }}-container-logs.tar.gz"
       - name: Export and upload database
         if: ${{ always() && env.REPOSITORY == github.repository }}
         env:
@@ -1149,7 +1195,7 @@ jobs:
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: |
           bash tools/export_mongodb.sh
-          tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-database.tar.gz"
+          tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-${{ matrix.arch }}-database.tar.gz"
 
   testConnectivity:
     needs:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -917,6 +917,129 @@ jobs:
           AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
         run: docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - s3://$env:AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/docker-windows-armonik-logs.json.gz
 
+  testHtcMockBinary:
+    needs:
+      - versionning
+      - images
+    env:
+      VERSION: ${{ needs.versionning.outputs.version }}
+    runs-on: ubuntu-latest
+    name: HtcMock self-contained binary
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
+
+      - name: Setup just
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
+        with:
+          tool: just
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: latest
+
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=htcmock build-all
+
+      - name: Build self-contained client binaries
+        run: just tag=${VERSION} publishHtcmockClientAll
+
+      - name: Upload self-contained binaries
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        with:
+          name: htcmock-client-${{ needs.versionning.outputs.version }}
+          path: ./publish/
+          retention-days: 5
+
+      - name: Deploy Core
+        run: |
+          MONITOR_PREFIX="monitor/deploy/" tools/retry.sh -w 30 -- tools/monitor.sh \
+            just log_level=Information tag=${VERSION} queue=activemq object=redis socket_type=tcp cinit=true worker=htcmock deploy
+          sleep 10
+
+      - name: Print And Time Metrics
+        run: |
+          set -x
+          time curl localhost:5002/metrics
+
+      - name: Run HtcMock test 100 tasks 1 level
+        timeout-minutes: 3
+        run: |
+          export HtcMock__NTasks=100
+          export HtcMock__TotalCalculationTime=00:00:00.100
+          export HtcMock__DataSize=1
+          export HtcMock__MemorySize=1
+          export HtcMock__SubTasksLevels=1
+          export HtcMock__Partition=TestPartition0
+          export GrpcClient__Endpoint=http://localhost:5001
+          ./publish/htcmock-client-linux-x64/ArmoniK.Samples.HtcMock.Client
+
+      - name: Run HtcMock test 100 tasks 4 levels
+        timeout-minutes: 3
+        run: |
+          export HtcMock__NTasks=100
+          export HtcMock__TotalCalculationTime=00:00:00.100
+          export HtcMock__DataSize=1
+          export HtcMock__MemorySize=1
+          export HtcMock__SubTasksLevels=4
+          export HtcMock__Partition=TestPartition0
+          export GrpcClient__Endpoint=http://localhost:5001
+          ./publish/htcmock-client-linux-x64/ArmoniK.Samples.HtcMock.Client
+
+      - name: Show logs
+        if: ${{ always() && env.REPOSITORY != github.repository }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
+        if: ${{ always() && env.REPOSITORY == github.repository }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
+        run: |
+          docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary.json.gz"
+          tar -czf - monitor/ | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-monitor.tar.gz"
+
+      - name: Collect docker container logs
+        if: ${{ always() }}
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
+        with:
+          dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() && env.REPOSITORY != github.repository }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
+      - name: Upload docker container logs
+        if: ${{ always() && env.REPOSITORY == github.repository }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
+        run: |
+          tar -cvf - ./container-logs | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-container-logs.tar.gz"
+      - name: Export and upload database
+        if: ${{ always() && env.REPOSITORY == github.repository }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
+        run: |
+          bash tools/export_mongodb.sh
+          tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-database.tar.gz"
+
   testConnectivity:
     needs:
       - versionning
@@ -1536,6 +1659,7 @@ jobs:
       - testsQueueProtos
       - testsWinOnly
       - testHtcMockDC
+      - testHtcMockBinary
       - defaultPartitionMock
       - testStreamDC
       - images

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1040,6 +1040,117 @@ jobs:
           bash tools/export_mongodb.sh
           tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/htcmock-binary-database.tar.gz"
 
+  testBenchBinary:
+    needs:
+      - versionning
+      - images
+    env:
+      VERSION: ${{ needs.versionning.outputs.version }}
+    runs-on: ubuntu-latest
+    name: Bench self-contained binary
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          repository: ${{ env.REPOSITORY }}
+          ref: ${{ env.REFERENCE }}
+
+      - name: Setup just
+        uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
+        with:
+          tool: just
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: latest
+
+      - name: Use GCR cache
+        run: |
+          cat <<EOF | sudo tee /etc/docker/daemon.json
+          {
+            "registry-mirrors": ["https://mirror.gcr.io"]
+          }
+          EOF
+          sudo systemctl restart docker
+
+      - name: Build images
+        if: ${{ env.REPOSITORY != github.repository }}
+        run: |
+          tools/retry.sh -w 60 -r 2 -- just tag=${VERSION} worker=bench build-all
+
+      - name: Build self-contained client binaries
+        run: just tag=${VERSION} publishBenchClientAll
+
+      - name: Upload self-contained binaries
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        with:
+          name: bench-client-${{ needs.versionning.outputs.version }}
+          path: ./publish/
+          retention-days: 5
+
+      - name: Deploy Core
+        run: |
+          MONITOR_PREFIX="monitor/deploy/" tools/retry.sh -w 30 -- tools/monitor.sh \
+            just log_level=Information tag=${VERSION} queue=activemq object=redis socket_type=tcp cinit=true worker=bench deploy
+          sleep 10
+
+      - name: Print And Time Metrics
+        run: |
+          set -x
+          time curl localhost:5002/metrics
+
+      - name: Run Bench test 100 tasks
+        timeout-minutes: 3
+        run: |
+          export BenchOptions__NTasks=100
+          export BenchOptions__TaskDurationMs=100
+          export BenchOptions__PayloadSize=1
+          export BenchOptions__ResultSize=1
+          export BenchOptions__BatchSize=100
+          export BenchOptions__Partition=TestPartition0
+          export GrpcClient__Endpoint=http://localhost:5001
+          ./publish/bench-client-linux-x64/ArmoniK.Samples.Bench.Client
+
+      - name: Show logs
+        if: ${{ always() && env.REPOSITORY != github.repository }}
+        run: docker cp fluentd:/armonik-logs.json -
+      - name: Upload logs
+        if: ${{ always() && env.REPOSITORY == github.repository }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
+        run: |
+          docker cp fluentd:/armonik-logs.json - | gzip -c | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary.json.gz"
+          tar -czf - monitor/ | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-monitor.tar.gz"
+
+      - name: Collect docker container logs
+        if: ${{ always() }}
+        uses: jwalton/gh-docker-logs@2741064ab9d7af54b0b1ffb6076cf64c16f0220e # v2
+        with:
+          dest: './container-logs'
+      - name: Show docker container logs
+        if: ${{ always() && env.REPOSITORY != github.repository }}
+        run: find ./container-logs -type f -name "*.log" -exec echo "===== {} =====" \; -exec cat "{}" \;
+      - name: Upload docker container logs
+        if: ${{ always() && env.REPOSITORY == github.repository }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
+        run: |
+          tar -cvf - ./container-logs | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-container-logs.tar.gz"
+      - name: Export and upload database
+        if: ${{ always() && env.REPOSITORY == github.repository }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_LOG_BUCKET_NAME: ${{ secrets.AWS_LOG_BUCKET_NAME }}
+        run: |
+          bash tools/export_mongodb.sh
+          tar -cvf - *.json | aws s3 cp - "s3://$AWS_LOG_BUCKET_NAME/core-pipeline/${{ github.run_number }}/${{ github.run_attempt }}/bench-binary-database.tar.gz"
+
   testConnectivity:
     needs:
       - versionning
@@ -1660,6 +1771,7 @@ jobs:
       - testsWinOnly
       - testHtcMockDC
       - testHtcMockBinary
+      - testBenchBinary
       - defaultPartitionMock
       - testStreamDC
       - images

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -134,6 +134,40 @@ jobs:
           ArmoniK.Samples.HtcMock.Client-win-x64.exe \
           --clobber
 
+  release-bench-binaries:
+    runs-on: ubuntu-latest
+    needs:
+      - versionning
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ github.ref_name }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+    - name: Setup just
+      uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
+      with:
+        tool: just
+
+    - name: Build self-contained client binaries
+      run: just tag=$VERSION publishBenchClientAll
+
+    - name: Upload binaries to GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        cp ./publish/bench-client-linux-x64/ArmoniK.Samples.Bench.Client   ArmoniK.Samples.Bench.Client-linux-x64
+        cp ./publish/bench-client-linux-arm64/ArmoniK.Samples.Bench.Client  ArmoniK.Samples.Bench.Client-linux-arm64
+        cp ./publish/bench-client-win-x64/ArmoniK.Samples.Bench.Client.exe  ArmoniK.Samples.Bench.Client-win-x64.exe
+        gh release create ${{ github.ref_name }} --generate-notes || true
+        gh release upload ${{ github.ref_name }} \
+          ArmoniK.Samples.Bench.Client-linux-x64 \
+          ArmoniK.Samples.Bench.Client-linux-arm64 \
+          ArmoniK.Samples.Bench.Client-win-x64.exe \
+          --clobber
+
   publish-nuget:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -127,7 +127,6 @@ jobs:
         cp ./publish/htcmock-client-linux-x64/ArmoniK.Samples.HtcMock.Client   ArmoniK.Samples.HtcMock.Client-linux-x64
         cp ./publish/htcmock-client-linux-arm64/ArmoniK.Samples.HtcMock.Client  ArmoniK.Samples.HtcMock.Client-linux-arm64
         cp ./publish/htcmock-client-win-x64/ArmoniK.Samples.HtcMock.Client.exe  ArmoniK.Samples.HtcMock.Client-win-x64.exe
-        gh release create ${{ github.ref_name }} --generate-notes || true
         gh release upload ${{ github.ref_name }} \
           ArmoniK.Samples.HtcMock.Client-linux-x64 \
           ArmoniK.Samples.HtcMock.Client-linux-arm64 \
@@ -161,7 +160,6 @@ jobs:
         cp ./publish/bench-client-linux-x64/ArmoniK.Samples.Bench.Client   ArmoniK.Samples.Bench.Client-linux-x64
         cp ./publish/bench-client-linux-arm64/ArmoniK.Samples.Bench.Client  ArmoniK.Samples.Bench.Client-linux-arm64
         cp ./publish/bench-client-win-x64/ArmoniK.Samples.Bench.Client.exe  ArmoniK.Samples.Bench.Client-win-x64.exe
-        gh release create ${{ github.ref_name }} --generate-notes || true
         gh release upload ${{ github.ref_name }} \
           ArmoniK.Samples.Bench.Client-linux-x64 \
           ArmoniK.Samples.Bench.Client-linux-arm64 \

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -100,6 +100,40 @@ jobs:
       run: just tag=$VERSION platform=linux/arm64,linux/amd64,windows/amd64 load=false push=true ${{ matrix.type }}
 
 
+  release-htcmock-binaries:
+    runs-on: ubuntu-latest
+    needs:
+      - versionning
+    permissions:
+      contents: write
+    env:
+      VERSION: ${{ github.ref_name }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+    - name: Setup just
+      uses: taiki-e/install-action@15449e3094499af05d8d964a1c884208e4b8b595 # v2
+      with:
+        tool: just
+
+    - name: Build self-contained client binaries
+      run: just tag=$VERSION publishHtcmockClientAll
+
+    - name: Upload binaries to GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        cp ./publish/htcmock-client-linux-x64/ArmoniK.Samples.HtcMock.Client   ArmoniK.Samples.HtcMock.Client-linux-x64
+        cp ./publish/htcmock-client-linux-arm64/ArmoniK.Samples.HtcMock.Client  ArmoniK.Samples.HtcMock.Client-linux-arm64
+        cp ./publish/htcmock-client-win-x64/ArmoniK.Samples.HtcMock.Client.exe  ArmoniK.Samples.HtcMock.Client-win-x64.exe
+        gh release create ${{ github.ref_name }} --generate-notes || true
+        gh release upload ${{ github.ref_name }} \
+          ArmoniK.Samples.HtcMock.Client-linux-x64 \
+          ArmoniK.Samples.HtcMock.Client-linux-arm64 \
+          ArmoniK.Samples.HtcMock.Client-win-x64.exe \
+          --clobber
+
   publish-nuget:
     runs-on: ubuntu-latest
     needs:

--- a/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
+++ b/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
@@ -21,7 +21,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed Condition="'$(SelfContained)'=='true'">true</PublishTrimmed>
     <DebugType>none</DebugType>
   </PropertyGroup>
 

--- a/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
+++ b/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
@@ -22,6 +22,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
     <PublishTrimmed>true</PublishTrimmed>
+    <DebugType>none</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
+++ b/Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj
@@ -21,6 +21,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
+++ b/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
@@ -22,6 +22,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
+    <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
+++ b/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
@@ -22,7 +22,7 @@
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
-    <PublishTrimmed>true</PublishTrimmed>
+    <PublishTrimmed Condition="'$(SelfContained)'=='true'">true</PublishTrimmed>
     <DebugType>none</DebugType>
   </PropertyGroup>
 

--- a/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
+++ b/Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj
@@ -23,6 +23,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <Optimize>true</Optimize>
     <PublishTrimmed>true</PublishTrimmed>
+    <DebugType>none</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/justfile
+++ b/justfile
@@ -335,6 +335,21 @@ buildPollingAgent: (build ARMONIK_POLLINGAGENT "./Dockerfile" "polling_agent")
 # Build Htcmock Client
 buildHtcmockClient: (build HTCMOCK_CLIENT_IMAGE  "./Tests/HtcMock/Client/src/Dockerfile")
 
+# Publish self-contained single-file HtcMock client binary
+# Supported rid values: linux-x64, linux-arm64, win-x64
+publishHtcmockClient rid="linux-x64":
+  dotnet publish Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj \
+    -r {{rid}} \
+    --self-contained true \
+    -p:PublishSingleFile=true \
+    -p:PublishReadyToRun=true \
+    -p:Version={{tag}} \
+    -c Release \
+    -o ./publish/htcmock-client-{{rid}}
+
+# Publish self-contained HtcMock client for all supported platforms
+publishHtcmockClientAll: (publishHtcmockClient "linux-x64") (publishHtcmockClient "linux-arm64") (publishHtcmockClient "win-x64")
+
 # Build Stream Client
 buildStreamClient: (build STREAM_CLIENT_IMAGE  "./Tests/Stream/Client/Dockerfile")
 

--- a/justfile
+++ b/justfile
@@ -335,20 +335,27 @@ buildPollingAgent: (build ARMONIK_POLLINGAGENT "./Dockerfile" "polling_agent")
 # Build Htcmock Client
 buildHtcmockClient: (build HTCMOCK_CLIENT_IMAGE  "./Tests/HtcMock/Client/src/Dockerfile")
 
-# Publish self-contained single-file HtcMock client binary
+# Publish a self-contained single-file client binary
 # Supported rid values: linux-x64, linux-arm64, win-x64
-publishHtcmockClient rid="linux-x64":
-  dotnet publish Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj \
+_publishClient project name rid:
+  dotnet publish {{project}} \
     -r {{rid}} \
     --self-contained true \
     -p:PublishSingleFile=true \
     -p:PublishReadyToRun=true \
     -p:Version={{tag}} \
     -c Release \
-    -o ./publish/htcmock-client-{{rid}}
+    -o ./publish/{{name}}-{{rid}}
+
+publishHtcmockClient rid="linux-x64": (_publishClient "Tests/HtcMock/Client/src/ArmoniK.Samples.HtcMock.Client.csproj" "htcmock-client" rid)
 
 # Publish self-contained HtcMock client for all supported platforms
 publishHtcmockClientAll: (publishHtcmockClient "linux-x64") (publishHtcmockClient "linux-arm64") (publishHtcmockClient "win-x64")
+
+publishBenchClient rid="linux-x64": (_publishClient "Tests/Bench/Client/src/ArmoniK.Samples.Bench.Client.csproj" "bench-client" rid)
+
+# Publish self-contained Bench client for all supported platforms
+publishBenchClientAll: (publishBenchClient "linux-x64") (publishBenchClient "linux-arm64") (publishBenchClient "win-x64")
 
 # Build Stream Client
 buildStreamClient: (build STREAM_CLIENT_IMAGE  "./Tests/Stream/Client/Dockerfile")


### PR DESCRIPTION
# Motivation

Make it easier to run HtcMock and Bench clients without Docker or a .NET SDK installed, by shipping
  them as self-contained single-file binaries attached to each GitHub release.

# Description

- Added a shared `_publishClient` recipe in the justfile that wraps `dotnet publish` with the common
  flags (`--self-contained`, `PublishSingleFile`, `PublishReadyToRun`).
- Added `publishHtcmockClient [rid]` / `publishHtcmockClientAll` and `publishBenchClient [rid]` /
  `publishBenchClientAll` recipes on top of it, targeting `linux-x64`, `linux-arm64`, and `win-x64`.
- Enabled `<PublishTrimmed>true</PublishTrimmed>` in the Release `PropertyGroup` of both
  `ArmoniK.Samples.HtcMock.Client.csproj` and `ArmoniK.Samples.Bench.Client.csproj`, as recommended by
  the official .NET docs.
- Added `testHtcMockBinary` and `testBenchBinary` CI jobs in `build.yml` that build the binaries,
  deploy a stack, run a smoke test against the published executable, and upload the binaries as workflow
  artifacts.
- Added `release-htcmock-binaries` and `release-bench-binaries` jobs in `make-release.yml` that attach
  all three platform binaries to the GitHub release.

 # Testing

 - The `testHtcMockBinary`  and `testBenchBinary` CI job deploys Core  (activemq + redis), test runs passing.
 - Cross-compilation for `linux-arm64` and `win-x64` is handled natively by the .NET SDK on
  the Linux runner.

 # Impact

 - No change to existing Docker images or build targets.
 - Slightly smaller binaries due to trimming.
 - Three new assets per client attached to each GitHub release (`linux-x64`, `linux-arm64`, `win-x64`).
 - Two new CI jobs added to the pipeline; they run in parallel with existing jobs and are required by
  the finalize gate.

 # Additional Information

The `PublishTrimmed` is set at project level, according to the official doc, this is the recommended way to do it, c.f. https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-publish#msbuild-properties

  # Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [x] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [x] I have thoroughly tested my modifications and added tests when necessary.
  - [ ] Tests pass locally and in the CI.
  - [ ] I have assessed the performance impact of my modifications.
