### PR TITLE
feat(submitter): add configurable grace delay

### DIFF
--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+
 using ArmoniK.Utils.DocAttribute;
 
 namespace ArmoniK.Core.Common.Injection.Options;
@@ -61,4 +63,9 @@ public class Submitter
   ///   The value must be less than the limit of gRPC messages accepted by the server.
   /// </remarks>
   public int PreferredMessageSize { get; set; } = 2 * 1024 * 1024;
+
+  /// <summary>
+  ///   Delay between the early and late cancellation tokens in the ExceptionManager
+  /// </summary>
+  public TimeSpan GraceDelay { get; set; } = TimeSpan.FromSeconds(30);
 }

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -86,6 +86,9 @@ public static class Program
     {
       AppDomain.CurrentDomain.AssemblyResolve += new CollocatedAssemblyResolver(logger.GetLogger()).AssemblyResolve;
 
+      var submitterOptions = builder.Configuration.GetSection(Common.Injection.Options.Submitter.SettingSection)
+                                    .Get<Common.Injection.Options.Submitter>() ?? new Common.Injection.Options.Submitter();
+
       builder.Host.UseSerilog(logger.GetSerilogConf());
 
       builder.Services.AddLogging(logger.Configure)
@@ -105,7 +108,7 @@ public static class Program
              .AddInitializedOption<InitServices>(builder.Configuration,
                                                  InitServices.SettingSection)
              .AddSingleton<InitDatabase>()
-             .AddExceptionManager(sp => new ExceptionManager.Options(TimeSpan.Zero,
+             .AddExceptionManager(sp => new ExceptionManager.Options(submitterOptions.GraceDelay,
                                                                      sp.GetRequiredService<Common.Injection.Options.Submitter>()
                                                                        .MaxErrorAllowed))
              .AddGrpcReflection()


### PR DESCRIPTION
# Motivation

The Submitter service was passing `TimeSpan.Zero` as the grace delay to `ExceptionManager`, meaning there was no delay between the early and late cancellation tokens on shutdown. Under load, this can cause in-flight work to be aborted before it completes. Making the delay configurable allows operators to tune shutdown behaviour to their workload.

# Description

- Added a new `GraceDelay` property (default: 30 seconds) to `Common/src/Injection/Options/Submitter.cs`.
- Wired it into `ExceptionManager.Options` in `Control/Submitter/src/Program.cs`, replacing the hardcoded `TimeSpan.Zero`.
- The option is read from the existing `Submitter` configuration section, so no new configuration section is required.

# Testing

No new automated tests added — the change is a straightforward options binding. The default value (30 s) provides a reasonable grace window and the path can be exercised manually by configuring a short delay and observing graceful drain behaviour.

# Impact

- **Configuration**: operators can now set `Submitter:GraceDelay` (e.g. `"00:01:00"`) to tune the window between early and late cancellation on shutdown.
- **Behaviour**: the grace delay changes from the previous hardcoded `TimeSpan.Zero` (no delay) to 30 seconds by default, giving in-flight requests time to complete before the late cancellation fires.
- **Performance**: no impact on steady-state throughput.

# Additional Information

None.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.