### PR TITLE
feat(grpc): gracefully drain in-flight RPCs on control-plane shutdown

### DIFF
--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using System;
+
 using ArmoniK.Utils.DocAttribute;
 
 namespace ArmoniK.Core.Common.Injection.Options;
@@ -61,4 +63,9 @@ public class Submitter
   ///   The value must be less than the limit of gRPC messages accepted by the server.
   /// </remarks>
   public int PreferredMessageSize { get; set; } = 2 * 1024 * 1024;
+
+  /// <summary>
+  ///   Grace delay before the control plane aborts all on-going RPCs when shutting down
+  /// </summary>
+  public TimeSpan GraceDelay { get; set; } = TimeSpan.FromSeconds(15);
 }

--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -16,6 +16,7 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 using ArmoniK.Core.Base;
@@ -23,6 +24,7 @@ using ArmoniK.Core.Base.DataStructures;
 using ArmoniK.Core.Base.Exceptions;
 using ArmoniK.Core.Common.Exceptions;
 using ArmoniK.Core.Common.Utils;
+using ArmoniK.Utils;
 
 using Grpc.Core;
 using Grpc.Core.Interceptors;
@@ -35,13 +37,17 @@ using TaskCanceledException = ArmoniK.Core.Common.Exceptions.TaskCanceledExcepti
 namespace ArmoniK.Core.Common.gRPC;
 
 /// <summary>
-///   Interceptor that counts all the exceptions thrown by the gRPC services
-///   It is then marked Unhealthy if number of errors is higher than a threshold
+///   Interceptor that maps exceptions thrown by the gRPC services to <see cref="RpcException" /> and records them on the
+///   <see cref="ExceptionManager" />. It is marked Unhealthy (readiness) once the number of errors exceeds the threshold.
+///   It also participates in graceful shutdown: it tracks in-flight requests, rejects new ones with
+///   <see cref="StatusCode.Unavailable" /> while the control plane is shutting down, and signals the
+///   <see cref="ExceptionManager" /> to stop the application once all in-flight requests have drained.
 /// </summary>
 public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
 {
   private readonly ExceptionManager exceptionManager_;
   private readonly ILogger          logger_;
+  private          int              requestCounter_;
 
   /// <summary>
   ///   Construct the interceptor
@@ -53,6 +59,10 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
   {
     exceptionManager_ = exceptionManager;
     logger_           = logger;
+    requestCounter_   = 0;
+
+    exceptionManager.Register();
+    exceptionManager.EarlyCancellationToken.Register(StopRequest);
   }
 
   /// <inheritdoc />
@@ -70,6 +80,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                                                                                 ServerCallContext                      context,
                                                                                 UnaryServerMethod<TRequest, TResponse> continuation)
   {
+    StartRequest();
+    await using var stop = new Deferrer(StopRequest);
+
     TResponse response;
     try
     {
@@ -93,6 +106,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                                                                                           ServerCallContext                                context,
                                                                                           ClientStreamingServerMethod<TRequest, TResponse> continuation)
   {
+    StartRequest();
+    await using var stop = new Deferrer(StopRequest);
+
     TResponse response;
     try
     {
@@ -118,6 +134,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                                                                                ServerCallContext                                context,
                                                                                ServerStreamingServerMethod<TRequest, TResponse> continuation)
   {
+    StartRequest();
+    await using var stop = new Deferrer(StopRequest);
+
     try
     {
       await base.ServerStreamingServerHandler(request,
@@ -141,6 +160,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
                                                                                ServerCallContext                                context,
                                                                                DuplexStreamingServerMethod<TRequest, TResponse> continuation)
   {
+    StartRequest();
+    await using var stop = new Deferrer(StopRequest);
+
     try
     {
       await base.DuplexStreamingServerHandler(requestStream,
@@ -332,6 +354,56 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
     return new RpcException(new Status(statusCode,
                                        details),
                             e.Message);
+  }
+
+  /// <summary>
+  ///   Check if the application is shutting down and increment the request counter.
+  /// </summary>
+  /// <exception cref="RpcException">If application is shutting down, throw a RPC unavailable</exception>
+  private void StartRequest()
+  {
+    var previousCounter = requestCounter_;
+    int counter;
+
+    // CAS loop: atomically check the shutdown state and increment the in-flight counter.
+    // Keeping the check and the increment in a single attempt is what makes the gate race-free:
+    // a request can never slip past a shutdown that started between the check and the increment.
+    do
+    {
+      counter = previousCounter;
+
+      // A negative counter means StopRequest has already driven the counter below zero (shutdown
+      // is in progress); the token check covers the window before that has happened yet. Either way,
+      // refuse the request without incrementing so we do not revive a draining/stopped control plane.
+      if (counter < 0 || exceptionManager_.EarlyCancellationToken.IsCancellationRequested)
+      {
+        throw new RpcException(new Status(StatusCode.Unavailable,
+                                          "Control plane is shutting down"));
+      }
+
+      // CompareExchange returns the value that was in the field before the call:
+      //   - equal to counter  => our swap won, the counter was incremented, exit the loop.
+      //   - different         => another thread moved the counter; retry against the fresh value
+      //                          so the shutdown check above is re-evaluated before we increment.
+      previousCounter = Interlocked.CompareExchange(ref requestCounter_,
+                                                    counter + 1,
+                                                    counter);
+    } while (counter != previousCounter);
+  }
+
+  /// <summary>
+  ///   Decrement the counter and notifies the application that all requests have been processed if it is shutting down and
+  ///   there are no remaining RPC
+  /// </summary>
+  private void StopRequest()
+  {
+    var counter = Interlocked.Decrement(ref requestCounter_);
+
+    if (counter < 0)
+    {
+      exceptionManager_.UnregisterAndStop(logger_,
+                                          "Cancellation is requested and all requests have been fully processed");
+    }
   }
 
   /// <summary>

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -31,6 +31,7 @@ using ArmoniK.Core.Common.gRPC.Services;
 using ArmoniK.Core.Common.Storage;
 using ArmoniK.Core.Common.Tests.Helpers;
 using ArmoniK.Core.Common.Utils;
+using ArmoniK.Utils;
 
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
@@ -88,12 +89,17 @@ internal class ExceptionInterceptorTests
   private ApplicationLifetime         lifetime_ = null!;
 
   private ExceptionManager BuildExceptionManager(int maxError)
+    => BuildExceptionManager(maxError,
+                             TimeSpan.Zero);
+
+  private ExceptionManager BuildExceptionManager(int      maxError,
+                                                 TimeSpan graceDelay)
     => new(lifetime_,
            new OptionsWrapper<ConsoleLifetimeOptions>(new ConsoleLifetimeOptions()),
            new HostingEnvironment(),
            new OptionsWrapper<HostOptions>(new HostOptions()),
            NullLogger<ExceptionManager>.Instance,
-           new ExceptionManager.Options(TimeSpan.Zero,
+           new ExceptionManager.Options(graceDelay,
                                         maxError));
 
   /// <summary>
@@ -230,10 +236,13 @@ internal class ExceptionInterceptorTests
     Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
-    // Call #11 without error
+    // Call #11 without error: the error threshold has been exceeded, so the control plane is shutting
+    // down and the interceptor rejects any new request with Unavailable before it reaches the service.
     ex = null;
-    Assert.That(client.CreateSession(request),
-                Is.EqualTo(noErrorReply));
+    Assert.That(() => client.CreateSession(request),
+                Throws.InstanceOf<RpcException>()
+                      .With.Property(nameof(RpcException.StatusCode))
+                      .EqualTo(StatusCode.Unavailable));
     Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
@@ -451,6 +460,16 @@ internal class ExceptionInterceptorTests
     Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
+    // Call #11 without error: the threshold has been exceeded, so the interceptor rejects new requests
+    // with Unavailable before they reach the service.
+    ex = null;
+    Assert.That(() => CreateLargeTasks(10),
+                Throws.InstanceOf<RpcException>()
+                      .With.Property(nameof(RpcException.StatusCode))
+                      .EqualTo(StatusCode.Unavailable));
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
+                                  .ConfigureAwait(false)).Status,
+                Is.Not.EqualTo(HealthStatus.Healthy));
   }
 
   [Test]
@@ -591,5 +610,158 @@ internal class ExceptionInterceptorTests
     Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
                                   .ConfigureAwait(false)).Status,
                 Is.Not.EqualTo(HealthStatus.Healthy));
+    // Call #13 without error: the threshold has been exceeded, so the interceptor rejects new requests
+    // with Unavailable before they reach the service.
+    ex = null;
+    Assert.That(TryGetResult,
+                Throws.InstanceOf<RpcException>()
+                      .With.Property(nameof(RpcException.StatusCode))
+                      .EqualTo(StatusCode.Unavailable));
+    Assert.That((await interceptor.Check(HealthCheckTag.Readiness)
+                                  .ConfigureAwait(false)).Status,
+                Is.Not.EqualTo(HealthStatus.Healthy));
   }
+
+  [Test]
+  [Timeout(10000)]
+  public void RequestDuringShutdownIsRejected()
+  {
+    // A large grace delay guarantees that the late cancellation token can only be triggered by the
+    // request-draining path, never by the grace timer, during the lifetime of the test.
+    using var exceptionManager = BuildExceptionManager(int.MaxValue / 2,
+                                                       TimeSpan.FromMinutes(10));
+    var interceptor = new ExceptionInterceptor(exceptionManager,
+                                               NullLogger<ExceptionInterceptor>.Instance);
+
+    // Model an external shutdown (SIGTERM): cancels the EarlyCancellationToken.
+    lifetime_.StopApplication();
+
+    var rpc = Assert.CatchAsync<RpcException>(async () => await interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                                                               TestServerCallContext.Create(),
+                                                                                                               (_,
+                                                                                                                _) => Task.FromResult(new object()))
+                                                                           .ConfigureAwait(false));
+
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(rpc!.StatusCode,
+                                  Is.EqualTo(StatusCode.Unavailable));
+                      Assert.That(rpc.Status.Detail,
+                                  Does.Contain("Control plane is shutting down"));
+                    });
+  }
+
+  [Test]
+  [Timeout(10000)]
+  public async Task DrainingLastInFlightRequestStopsApplication()
+  {
+    using var exceptionManager = BuildExceptionManager(int.MaxValue / 2,
+                                                       TimeSpan.FromMinutes(10));
+    // The interceptor registers itself with the ExceptionManager in its constructor, so it is the
+    // only registered component: draining its last in-flight request must stop the application.
+    var interceptor = new ExceptionInterceptor(exceptionManager,
+                                               NullLogger<ExceptionInterceptor>.Instance);
+
+    // Hold one request in-flight until we release it. StartRequest runs synchronously at the top of
+    // the handler, so the in-flight counter is already incremented to 1 once the call is launched.
+    var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+    var inFlight = interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                  TestServerCallContext.Create(),
+                                                                  async (_,
+                                                                         _) =>
+                                                                  {
+                                                                    await release.Task.ConfigureAwait(false);
+                                                                    return new object();
+                                                                  });
+
+    // External shutdown cancels the EarlyCancellationToken; the interceptor's registered StopRequest
+    // brings the counter from 1 back to 0, so the application must NOT stop while a request is still
+    // in-flight.
+    lifetime_.StopApplication();
+
+    Assert.That(exceptionManager.LateCancellationToken.IsCancellationRequested,
+                Is.False,
+                "Application stopped while a request was still in-flight");
+
+    // Draining the last request takes the counter from 0 to -1, triggering UnregisterAndStop, which
+    // stops the application and fires the late cancellation token.
+    release.SetResult();
+    await inFlight.ConfigureAwait(false);
+
+    try
+    {
+      await exceptionManager.LateCancellationToken.AsTask()
+                            .ConfigureAwait(false);
+    }
+    catch (OperationCanceledException)
+    {
+      // Expected: AsTask completes as cancelled once the late token fires.
+    }
+
+    Assert.That(exceptionManager.LateCancellationToken.IsCancellationRequested,
+                Is.True);
+  }
+
+  [Test]
+  [Timeout(60000)]
+  public async Task ConcurrentRequestsKeepCounterBalanced()
+  {
+    using var exceptionManager = BuildExceptionManager(int.MaxValue / 2,
+                                                       TimeSpan.FromMinutes(10));
+    var interceptor = new ExceptionInterceptor(exceptionManager,
+                                               NullLogger<ExceptionInterceptor>.Instance);
+
+    // Probabilistic regression guard for the StartRequest CAS loop. Each request increments then
+    // decrements the in-flight counter, so it must return to exactly 0 after every round. A lost
+    // increment under contention (the pre-fix `while (counter == previousCounter)` bug) desyncs the
+    // counter, drives it negative, and trips a spurious shutdown that this test detects.
+    const int rounds      = 100;
+    const int concurrency = 128;
+
+    for (var round = 0; round < rounds; round++)
+    {
+      // Task.Run pushes the calls onto the thread pool so StartRequest is invoked concurrently.
+      var calls = Enumerable.Range(0,
+                                   concurrency)
+                            .Select(_ => Task.Run(() => interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                                                       TestServerCallContext.Create(),
+                                                                                                       (_,
+                                                                                                        _) => Task.FromResult(new object()))));
+      await Task.WhenAll(calls)
+                .ConfigureAwait(false);
+    }
+
+    // No spurious shutdown happened: the control plane is still up and still accepts requests.
+    Assert.That(exceptionManager.EarlyCancellationToken.IsCancellationRequested,
+                Is.False,
+                "Concurrent requests triggered a spurious shutdown (the in-flight counter desynced)");
+
+    Assert.DoesNotThrowAsync(async () => await interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                                              TestServerCallContext.Create(),
+                                                                                              (_,
+                                                                                               _) => Task.FromResult(new object()))
+                                                          .ConfigureAwait(false));
+
+    // The counter is balanced at 0, so the single sentinel decrement at shutdown reaches -1 at once
+    // and stops the application immediately, without waiting out the 10-minute grace delay.
+    lifetime_.StopApplication();
+
+    try
+    {
+      await exceptionManager.LateCancellationToken.AsTask()
+                            .ConfigureAwait(false);
+    }
+    catch (OperationCanceledException)
+    {
+      // Expected: AsTask completes as cancelled once the late token fires.
+    }
+
+    Assert.That(exceptionManager.LateCancellationToken.IsCancellationRequested,
+                Is.True);
+  }
+
+  [Test]
+  public void GraceDelayDefaultsToFifteenSeconds()
+    => Assert.That(new Injection.Options.Submitter().GraceDelay,
+                   Is.EqualTo(TimeSpan.FromSeconds(15)));
 }

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -105,9 +105,12 @@ public static class Program
              .AddInitializedOption<InitServices>(builder.Configuration,
                                                  InitServices.SettingSection)
              .AddSingleton<InitDatabase>()
-             .AddExceptionManager(sp => new ExceptionManager.Options(TimeSpan.Zero,
-                                                                     sp.GetRequiredService<Common.Injection.Options.Submitter>()
-                                                                       .MaxErrorAllowed))
+             .AddExceptionManager(sp =>
+                                  {
+                                    var options = sp.GetRequiredService<Common.Injection.Options.Submitter>();
+                                    return new ExceptionManager.Options(options.GraceDelay,
+                                                                        options.MaxErrorAllowed);
+                                  })
              .AddGrpcReflection()
              .AddSingleton<MeterHolder>()
              .AddSingleton<AgentIdentifier>()
@@ -130,7 +133,7 @@ public static class Program
         ActivitySource.AddActivityListener(new ActivityListener
                                            {
                                              ShouldListenTo = _ => true,
-                                             //Sample         = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                                             // Sample         = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
                                              ActivityStopped = activity =>
                                                                {
                                                                  foreach (var (key, value) in activity.Baggage)


### PR DESCRIPTION
# Motivation

When the Submitter control plane shuts down (SIGTERM, or after too many errors trip the `ExceptionManager`), in-flight gRPC calls were aborted abruptly. Clients saw hard transport failures instead of a clean, retryable signal, and there was no window for ongoing RPCs to finish. This change lets the control plane drain gracefully: stop accepting new work, let in-flight RPCs complete within a bounded delay, then stop.

# Description

`ExceptionInterceptor` now participates in graceful shutdown in addition to its existing exception-to-`RpcException` mapping and health reporting:

- Tracks the number of in-flight RPCs in a per-singleton counter, incremented at the top of every handler (unary/client-stream/server-stream/duplex) and decremented via a `Deferrer` when the handler returns.
- While the control plane is shutting down (the `ExceptionManager`'s `EarlyCancellationToken` is cancelled, or the counter has already gone negative), new RPCs are rejected up front with `StatusCode.Unavailable` ("Control plane is shutting down") so clients get a clean, retryable status.
- The interceptor `Register()`s with the `ExceptionManager` and registers its `StopRequest` on the `EarlyCancellationToken`; that single extra decrement at shutdown drives the counter below zero once all in-flight RPCs drain, which calls `UnregisterAndStop` and stops the application immediately instead of waiting out the full grace delay.
- New `Submitter.GraceDelay` option (default 15s), wired into `ExceptionManager.Options` in `Control/Submitter/src/Program.cs` (previously hardcoded to `TimeSpan.Zero`).

During review, an inverted compare-and-swap loop-exit condition in `StartRequest` was found and fixed (`while (counter == previousCounter)` -> `!=`): under contention it dropped increments, which desynced the counter and could trigger spurious shutdowns under normal concurrent load. The CAS loop and the shutdown sentinel are now documented inline.

Files changed:
- `Common/src/gRPC/ExceptionInterceptor.cs` - in-flight counter, shutdown gate, drain-to-stop signalling, CAS fix + comments.
- `Common/src/Injection/Options/Submitter.cs` - `GraceDelay` option.
- `Control/Submitter/src/Program.cs` - wire `GraceDelay` into the `ExceptionManager`.
- `Common/tests/Submitter/ExceptionInterceptorTests.cs` - tests (separate commit).

# Testing

Added unit tests in `ExceptionInterceptorTests` (separate commit), invoking the handlers directly:

- `RequestDuringShutdownIsRejected` - after shutdown, a handler throws `RpcException(Unavailable)`.
- `DrainingLastInFlightRequestStopsApplication` - an in-flight request held open keeps the app up; once it drains, the counter reaches -1, `UnregisterAndStop` fires and the late cancellation token triggers.
- `ConcurrentRequestsKeepCounterBalanced` - concurrency regression guard for the CAS fix: a storm of concurrent calls must leave the counter balanced (no spurious shutdown, a follow-up request still succeeds, and shutdown then fires the late token immediately). Verified to fail against the pre-fix `==` condition.
- `GraceDelayDefaultsToFifteenSeconds` - pins the option default.

The three existing `[Obsolete] TooManyException*ShouldBeUnhealthy` tests were updated: their post-threshold calls now assert the request is rejected with `Unavailable` (the new shutdown-gate behavior) instead of returning a reply. All 22 tests in the fixture pass locally; the concurrency/streaming tests were run repeatedly to confirm they are not flaky.

# Impact

- Behavior change: once the Submitter begins shutting down (including after `MaxErrorAllowed` is exceeded), new RPCs are rejected with `Unavailable` rather than processed or hard-aborted. Clients should treat `Unavailable` as retryable.
- New `Submitter.GraceDelay` configuration option (default 15s); previously the Submitter had no grace delay (`TimeSpan.Zero`).
- No new dependencies. No public adapter interface changes.

# Additional Information

The updated `TooManyException*` tests remain marked `[Obsolete]`; the attribute was left in place since its removal is a separate decision.