### PR TITLE
fix(submitter): shut down gracefully on too many errors and expose readiness probe

### DIFF
--- a/Common/src/Injection/Options/Submitter.cs
+++ b/Common/src/Injection/Options/Submitter.cs
@@ -65,7 +65,13 @@ public class Submitter
   public int PreferredMessageSize { get; set; } = 2 * 1024 * 1024;
 
   /// <summary>
-  ///   Grace delay before the control plane aborts all on-going RPCs when shutting down
+  ///   Grace delay before the control plane aborts all on-going RPCs when shutting down.
   /// </summary>
   public TimeSpan GraceDelay { get; set; } = TimeSpan.FromSeconds(15);
+
+  /// <summary>
+  ///   Time to wait, after the maximum number of errors has been recorded, before the control plane triggers its own
+  ///   shutdown. Acts as a backstop in case the orchestrator does not initiate the shutdown first.
+  /// </summary>
+  public TimeSpan SelfTerminationDelay { get; set; } = TimeSpan.FromSeconds(10);
 }

--- a/Common/src/Utils/ExceptionManager.cs
+++ b/Common/src/Utils/ExceptionManager.cs
@@ -239,13 +239,13 @@ public class ExceptionManager : IDisposable, IHostApplicationLifetime, IHostLife
     {
       if (selfTerminationDelay_ > TimeSpan.Zero)
       {
-        logger_?.LogCritical("Wait {SelfTerminationDelay} seconds, and stop Application after too many errors",
-                             selfTerminationDelay_.TotalSeconds);
+        logger?.LogCritical("Wait {SelfTerminationDelay} seconds, and stop Application after too many errors",
+                            selfTerminationDelay_.TotalSeconds);
         earlyCts_.CancelAfter(selfTerminationDelay_);
       }
       else
       {
-        logger_?.LogCritical("Stop Application after too many errors");
+        logger?.LogCritical("Stop Application after too many errors");
         earlyCts_.Cancel();
       }
     }

--- a/Common/src/Utils/ExceptionManager.cs
+++ b/Common/src/Utils/ExceptionManager.cs
@@ -21,6 +21,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Threading;
 using System.Threading.Tasks;
 
+using ArmoniK.Core.Common.Injection.Options;
+
 using JetBrains.Annotations;
 
 using Microsoft.Extensions.Hosting;
@@ -52,6 +54,7 @@ public class ExceptionManager : IDisposable, IHostApplicationLifetime, IHostLife
 
   private readonly ILogger? logger_;
   private readonly int      maxError_;
+  private readonly TimeSpan selfTerminationDelay_;
   private          int      nbError_;
   private          int      registeredApplications_;
 
@@ -71,11 +74,12 @@ public class ExceptionManager : IDisposable, IHostApplicationLifetime, IHostLife
                           ILogger<ExceptionManager>?       logger  = null,
                           Options?                         options = null)
   {
-    options              ??= new Options();
-    applicationLifetime_ =   applicationLifetime;
-    disposables_         =   new List<IDisposable>();
-    earlyCts_            =   new CancellationTokenSource();
-    lateCts_             =   earlyCts_;
+    options               ??= new Options();
+    applicationLifetime_  =   applicationLifetime;
+    disposables_          =   new List<IDisposable>();
+    earlyCts_             =   new CancellationTokenSource();
+    lateCts_              =   earlyCts_;
+    selfTerminationDelay_ =   options.SelfTerminationDelay;
 
     disposables_.Add(applicationLifetime.ApplicationStopping.Register(() =>
                                                                       {
@@ -233,8 +237,17 @@ public class ExceptionManager : IDisposable, IHostApplicationLifetime, IHostLife
 
     if (nbError == maxError_ + 1)
     {
-      logger_?.LogCritical("Stop Application after too many errors");
-      earlyCts_.Cancel();
+      if (selfTerminationDelay_ > TimeSpan.Zero)
+      {
+        logger_?.LogCritical("Wait {SelfTerminationDelay} seconds, and stop Application after too many errors",
+                             selfTerminationDelay_.TotalSeconds);
+        earlyCts_.CancelAfter(selfTerminationDelay_);
+      }
+      else
+      {
+        logger_?.LogCritical("Stop Application after too many errors");
+        earlyCts_.Cancel();
+      }
     }
 
     if (nbError >= maxError_ + 1)
@@ -390,7 +403,31 @@ public class ExceptionManager : IDisposable, IHostApplicationLifetime, IHostLife
   ///   Delay between the <see cref="ExceptionManager.EarlyCancellationToken" /> and the
   ///   <see cref="ExceptionManager.LateCancellationToken" />
   /// </param>
+  /// <param name="SelfTerminationDelay">
+  ///   Delay between the maximum errors recording and the
+  ///   <see cref="ExceptionManager.EarlyCancellationToken" /> trigger.
+  /// </param>
   /// <param name="MaxError">Maximum number of allowed errors</param>
-  public record Options(TimeSpan GraceDelay = default,
-                        int?     MaxError   = null);
+  public record Options(TimeSpan GraceDelay           = default,
+                        TimeSpan SelfTerminationDelay = default,
+                        int?     MaxError             = null)
+  {
+    /// <summary>
+    ///   Convert <see cref="Injection.Options.Submitter" /> to <see cref="ExceptionManager.Options" />
+    /// </summary>
+    /// <param name="submitterOptions">Options to convert</param>
+    public static Options FromSubmitterOptions(Submitter submitterOptions)
+      => new(submitterOptions.GraceDelay,
+             submitterOptions.SelfTerminationDelay,
+             submitterOptions.MaxErrorAllowed);
+
+    /// <summary>
+    ///   Convert <see cref="Injection.Options.Pollster" /> to <see cref="ExceptionManager.Options" />
+    /// </summary>
+    /// <param name="pollsterOptions">Options to convert</param>
+    public static Options FromPollsterOptions(Injection.Options.Pollster pollsterOptions)
+      => new(pollsterOptions.GraceDelay,
+             TimeSpan.Zero,
+             pollsterOptions.MaxErrorAllowed);
+  }
 }

--- a/Common/src/gRPC/ExceptionInterceptor.cs
+++ b/Common/src/gRPC/ExceptionInterceptor.cs
@@ -67,13 +67,9 @@ public class ExceptionInterceptor : Interceptor, IHealthCheckProvider
 
   /// <inheritdoc />
   public Task<HealthCheckResult> Check(HealthCheckTag tag)
-    => Task.FromResult((tag, exceptionManager_.Failed) switch
-                       {
-                         // If there is too many errors, the pod is marked as not ready to avoid Kubernetes sending new requests to the controller.
-                         // Liveness Unhealthy is not needed as the pod is killing itself, without the intervention of Kubernetes.
-                         (HealthCheckTag.Readiness, true) => HealthCheckResult.Unhealthy("Too many errors recorded, application is shutting down"),
-                         _                                => HealthCheckResult.Healthy(),
-                       });
+    => Task.FromResult(exceptionManager_.Failed
+                         ? HealthCheckResult.Unhealthy("Too many errors recorded, application is shutting down")
+                         : HealthCheckResult.Healthy());
 
   /// <inheritdoc />
   public override async Task<TResponse> UnaryServerHandler<TRequest, TResponse>(TRequest                               request,

--- a/Common/tests/ExceptionManagerTests.cs
+++ b/Common/tests/ExceptionManagerTests.cs
@@ -66,6 +66,7 @@ public class ExceptionManagerTests
                                         new OptionsWrapper<HostOptions>(new HostOptions()),
                                         loggerFactory_.CreateLogger<ExceptionManager>(),
                                         new ExceptionManager.Options(TimeSpan.Zero,
+                                                                     TimeSpan.Zero,
                                                                      0));
 
     Assert.That(em.EarlyCancellationToken,
@@ -90,6 +91,7 @@ public class ExceptionManagerTests
                                         new OptionsWrapper<HostOptions>(new HostOptions()),
                                         loggerFactory_.CreateLogger<ExceptionManager>(),
                                         new ExceptionManager.Options(TimeSpan.FromSeconds(5),
+                                                                     TimeSpan.Zero,
                                                                      maxError));
 
     Assert.That(em.EarlyCancellationToken,
@@ -165,6 +167,7 @@ public class ExceptionManagerTests
                                         new OptionsWrapper<HostOptions>(new HostOptions()),
                                         loggerFactory_.CreateLogger<ExceptionManager>(),
                                         new ExceptionManager.Options(TimeSpan.FromSeconds(1),
+                                                                     TimeSpan.Zero,
                                                                      maxError));
 
     Assert.That(em.EarlyCancellationToken,
@@ -236,6 +239,7 @@ public class ExceptionManagerTests
                                         new OptionsWrapper<HostOptions>(new HostOptions()),
                                         loggerFactory_.CreateLogger<ExceptionManager>(),
                                         new ExceptionManager.Options(TimeSpan.FromSeconds(1),
+                                                                     TimeSpan.Zero,
                                                                      maxError));
 
     Assert.That(em.EarlyCancellationToken,

--- a/Common/tests/ExceptionManagerTests.cs
+++ b/Common/tests/ExceptionManagerTests.cs
@@ -288,6 +288,123 @@ public class ExceptionManagerTests
 
   [Test]
   [Timeout(10000)]
+  [Retry(2)] // Sometimes on Windows, the delay is not respected
+  public async Task SelfTerminationDelayStop([Values(0,
+                                                     5)]
+                                             int maxError)
+  {
+    var logger = loggerFactory_.CreateLogger(nameof(SelfTerminationDelayStop));
+    var events = new ConcurrentQueue<int>();
+    using var em = new ExceptionManager(lifetime_,
+                                        new OptionsWrapper<ConsoleLifetimeOptions>(new ConsoleLifetimeOptions()),
+                                        new HostingEnvironment(),
+                                        new OptionsWrapper<HostOptions>(new HostOptions()),
+                                        loggerFactory_.CreateLogger<ExceptionManager>(),
+                                        new ExceptionManager.Options(TimeSpan.FromSeconds(1),
+                                                                     TimeSpan.FromSeconds(1),
+                                                                     maxError));
+
+    Assert.That(em.EarlyCancellationToken,
+                Is.Not.EqualTo(em.LateCancellationToken));
+
+    await using var d0 = lifetime_.ApplicationStarted.Register(() => events.Enqueue(0));
+    await using var d1 = em.EarlyCancellationToken.Register(() => events.Enqueue(1));
+    await using var d2 = em.LateCancellationToken.Register(() => events.Enqueue(2));
+    await using var d3 = lifetime_.ApplicationStopping.Register(() => events.Enqueue(3));
+    await using var d4 = lifetime_.ApplicationStopped.Register(() => events.Enqueue(4));
+
+    lifetime_.NotifyStarted();
+
+    await Task.Delay(10)
+              .ConfigureAwait(false);
+
+    for (var i = 0; i < maxError + 1; i++)
+    {
+      em.RecordError(logger,
+                     new ApplicationException($"Error {i}"),
+                     nameof(SelfTerminationDelayStop));
+    }
+
+    // Failed is set as soon as the threshold is crossed, but the EarlyCancellationToken is only
+    // triggered after the SelfTerminationDelay has elapsed.
+    Assert.That(em.Failed,
+                Is.True);
+    Assert.That(em.EarlyCancellationToken.IsCancellationRequested,
+                Is.False);
+
+    var sw = Stopwatch.StartNew();
+
+    try
+    {
+      await em.EarlyCancellationToken.AsTask()
+              .ConfigureAwait(false);
+    }
+    catch (OperationCanceledException)
+    {
+      // ignore
+    }
+
+    var elapsed = sw.Elapsed.TotalSeconds;
+    Assert.That(elapsed,
+                Is.GreaterThanOrEqualTo(0.5));
+
+    // Once the early token fired, the existing grace delay chain still drives the application all the
+    // way down to ApplicationStopping.
+    try
+    {
+      await lifetime_.ApplicationStopping.AsTask()
+                     .ConfigureAwait(false);
+    }
+    catch (OperationCanceledException)
+    {
+      // ignore
+    }
+
+    Assert.That(em.Failed,
+                Is.True);
+
+    lifetime_.NotifyStopped();
+
+    Assert.That(events,
+                Is.EqualTo(Enumerable.Range(0,
+                                            5)));
+  }
+
+  [Test]
+  [Timeout(1000)]
+  public void SelfTerminationDelayDefersCancellation([Values(0,
+                                                             5)]
+                                                     int maxError)
+  {
+    var logger = loggerFactory_.CreateLogger(nameof(SelfTerminationDelayDefersCancellation));
+    using var em = new ExceptionManager(lifetime_,
+                                        new OptionsWrapper<ConsoleLifetimeOptions>(new ConsoleLifetimeOptions()),
+                                        new HostingEnvironment(),
+                                        new OptionsWrapper<HostOptions>(new HostOptions()),
+                                        loggerFactory_.CreateLogger<ExceptionManager>(),
+                                        new ExceptionManager.Options(TimeSpan.Zero,
+                                                                     TimeSpan.FromMinutes(10),
+                                                                     maxError));
+
+    lifetime_.NotifyStarted();
+
+    for (var i = 0; i < maxError + 1; i++)
+    {
+      em.RecordError(logger,
+                     new ApplicationException($"Error {i}"),
+                     nameof(SelfTerminationDelayDefersCancellation));
+    }
+
+    // The threshold is crossed: Failed is set immediately, but the long SelfTerminationDelay keeps the
+    // EarlyCancellationToken uncancelled for the duration of the test.
+    Assert.That(em.Failed,
+                Is.True);
+    Assert.That(em.EarlyCancellationToken.IsCancellationRequested,
+                Is.False);
+  }
+
+  [Test]
+  [Timeout(10000)]
   public async Task FatalStop([Values(1,
                                       2)]
                               int nbFatal)

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -209,10 +209,7 @@ public class TestPollsterProvider : IDisposable
            .AddInitializedOption<InitServices>(builder.Configuration,
                                                InitServices.SettingSection)
            .AddSingleton<InitDatabase>()
-           .AddExceptionManager(sp => new ExceptionManager.Options(sp.GetRequiredService<Injection.Options.Pollster>()
-                                                                     .GraceDelay,
-                                                                   sp.GetRequiredService<Injection.Options.Pollster>()
-                                                                     .MaxErrorAllowed))
+           .AddExceptionManager(sp => ExceptionManager.Options.FromPollsterOptions(sp.GetRequiredService<Injection.Options.Pollster>()))
            .AddSingleton<MeterHolder>()
            .AddSingleton<AgentIdentifier>()
            .AddScoped(typeof(FunctionExecutionMetrics<>))

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -100,6 +100,7 @@ internal class ExceptionInterceptorTests
            new OptionsWrapper<HostOptions>(new HostOptions()),
            NullLogger<ExceptionManager>.Instance,
            new ExceptionManager.Options(graceDelay,
+                                        default,
                                         maxError));
 
   /// <summary>
@@ -108,12 +109,12 @@ internal class ExceptionInterceptorTests
   /// </summary>
   private static IEnumerable<Type> ArmoniKExceptionTypes
     => new[]
-      {
-        typeof(ArmoniKException).Assembly,     // ArmoniK.Core.Base
-        typeof(ExceptionInterceptor).Assembly, // ArmoniK.Core.Common
-      }.SelectMany(assembly => assembly.GetTypes())
-       .Where(type => typeof(ArmoniKException).IsAssignableFrom(type) && !type.IsAbstract)
-       .Distinct();
+       {
+         typeof(ArmoniKException).Assembly,     // ArmoniK.Core.Base
+         typeof(ExceptionInterceptor).Assembly, // ArmoniK.Core.Common
+       }.SelectMany(assembly => assembly.GetTypes())
+        .Where(type => typeof(ArmoniKException).IsAssignableFrom(type) && !type.IsAbstract)
+        .Distinct();
 
   /// <summary>
   ///   Exception types that are intentionally allowed to resolve to the generic <see cref="ArmoniKException" /> ->

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -116,12 +116,12 @@ internal class ExceptionInterceptorTests
   /// </summary>
   private static IEnumerable<Type> ArmoniKExceptionTypes
     => new[]
-       {
-         typeof(ArmoniKException).Assembly,     // ArmoniK.Core.Base
-         typeof(ExceptionInterceptor).Assembly, // ArmoniK.Core.Common
-       }.SelectMany(assembly => assembly.GetTypes())
-        .Where(type => typeof(ArmoniKException).IsAssignableFrom(type) && !type.IsAbstract)
-        .Distinct();
+      {
+        typeof(ArmoniKException).Assembly,     // ArmoniK.Core.Base
+        typeof(ExceptionInterceptor).Assembly, // ArmoniK.Core.Common
+      }.SelectMany(assembly => assembly.GetTypes())
+       .Where(type => typeof(ArmoniKException).IsAssignableFrom(type) && !type.IsAbstract)
+       .Distinct();
 
   /// <summary>
   ///   Exception types that are intentionally allowed to resolve to the generic <see cref="ArmoniKException" /> ->

--- a/Common/tests/Submitter/ExceptionInterceptorTests.cs
+++ b/Common/tests/Submitter/ExceptionInterceptorTests.cs
@@ -94,13 +94,20 @@ internal class ExceptionInterceptorTests
 
   private ExceptionManager BuildExceptionManager(int      maxError,
                                                  TimeSpan graceDelay)
+    => BuildExceptionManager(maxError,
+                             graceDelay,
+                             TimeSpan.Zero);
+
+  private ExceptionManager BuildExceptionManager(int      maxError,
+                                                 TimeSpan graceDelay,
+                                                 TimeSpan selfTerminationDelay)
     => new(lifetime_,
            new OptionsWrapper<ConsoleLifetimeOptions>(new ConsoleLifetimeOptions()),
            new HostingEnvironment(),
            new OptionsWrapper<HostOptions>(new HostOptions()),
            NullLogger<ExceptionManager>.Instance,
            new ExceptionManager.Options(graceDelay,
-                                        default,
+                                        selfTerminationDelay,
                                         maxError));
 
   /// <summary>
@@ -654,6 +661,52 @@ internal class ExceptionInterceptorTests
 
   [Test]
   [Timeout(10000)]
+  public async Task RequestDuringSelfTerminationDelayIsAccepted()
+  {
+    // Large delays: neither the grace timer nor the self-termination timer can fire during the test,
+    // so the EarlyCancellationToken stays uncancelled while the manager is already in the Failed state.
+    using var exceptionManager = BuildExceptionManager(0,
+                                                       TimeSpan.FromMinutes(10),
+                                                       TimeSpan.FromMinutes(10));
+    var interceptor = new ExceptionInterceptor(exceptionManager,
+                                               NullLogger<ExceptionInterceptor>.Instance);
+
+    // A single server error crosses the threshold (maxError == 0): this sets Failed and schedules the
+    // deferred self-termination, without cancelling the EarlyCancellationToken yet.
+    Assert.CatchAsync<RpcException>(async () => await interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                                                     TestServerCallContext.Create(),
+                                                                                                     (_,
+                                                                                                      _) => throw new ApplicationException("server error"))
+                                                                 .ConfigureAwait(false));
+
+    var readiness = await interceptor.Check(HealthCheckTag.Readiness)
+                                     .ConfigureAwait(false);
+    var liveness = await interceptor.Check(HealthCheckTag.Liveness)
+                                    .ConfigureAwait(false);
+
+    // The control plane advertises Unhealthy on every probe tag as soon as it has Failed, while the
+    // EarlyCancellationToken is still pending the self-termination delay.
+    Assert.Multiple(() =>
+                    {
+                      Assert.That(exceptionManager.EarlyCancellationToken.IsCancellationRequested,
+                                  Is.False);
+                      Assert.That(readiness.Status,
+                                  Is.EqualTo(HealthStatus.Unhealthy));
+                      Assert.That(liveness.Status,
+                                  Is.EqualTo(HealthStatus.Unhealthy));
+                    });
+
+    // During the self-termination window the interceptor still admits new requests: the gate only
+    // rejects once the EarlyCancellationToken is cancelled.
+    Assert.DoesNotThrowAsync(async () => await interceptor.UnaryServerHandler<object, object>(new object(),
+                                                                                              TestServerCallContext.Create(),
+                                                                                              (_,
+                                                                                               _) => Task.FromResult(new object()))
+                                                          .ConfigureAwait(false));
+  }
+
+  [Test]
+  [Timeout(10000)]
   public async Task DrainingLastInFlightRequestStopsApplication()
   {
     using var exceptionManager = BuildExceptionManager(int.MaxValue / 2,
@@ -765,4 +818,9 @@ internal class ExceptionInterceptorTests
   public void GraceDelayDefaultsToFifteenSeconds()
     => Assert.That(new Injection.Options.Submitter().GraceDelay,
                    Is.EqualTo(TimeSpan.FromSeconds(15)));
+
+  [Test]
+  public void SelfTerminationDelayDefaultsToTenSeconds()
+    => Assert.That(new Injection.Options.Submitter().SelfTerminationDelay,
+                   Is.EqualTo(TimeSpan.FromSeconds(10)));
 }

--- a/Compute/PollingAgent/src/Program.cs
+++ b/Compute/PollingAgent/src/Program.cs
@@ -117,8 +117,7 @@ public static class Program
              .AddSingleton<InitDatabase>()
              .AddSingleton(pollsterOptions)
              .AddSingleton<HealthCheckRecord>()
-             .AddExceptionManager(_ => new ExceptionManager.Options(pollsterOptions.GraceDelay,
-                                                                    pollsterOptions.MaxErrorAllowed))
+             .AddExceptionManager(sp => ExceptionManager.Options.FromPollsterOptions(sp.GetRequiredService<Pollster>()))
              .AddSingleton<IHealthCheckPublisher, HealthCheckRecord.Publisher>()
              .AddSingleton<IAgentHandler, AgentHandler>()
              .AddSingleton<DataPrefetcher>()
@@ -141,7 +140,7 @@ public static class Program
         ActivitySource.AddActivityListener(new ActivityListener
                                            {
                                              ShouldListenTo = _ => true,
-                                             //Sample         = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
+                                             // Sample         = (ref ActivityCreationOptions<ActivityContext> options) => ActivitySamplingResult.AllDataAndRecorded,
                                              ActivityStopped = activity =>
                                                                {
                                                                  foreach (var (key, value) in activity.Baggage)

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -234,6 +234,13 @@ public static class Program
                             Predicate = check => check.Tags.Contains(nameof(HealthCheckTag.Liveness)),
                           });
 
+      app.UseHealthChecks("/readiness",
+                          1081,
+                          new HealthCheckOptions
+                          {
+                            Predicate = check => check.Tags.Contains(nameof(HealthCheckTag.Readiness)),
+                          });
+
       if (app.Environment.IsDevelopment())
       {
         app.MapGrpcReflectionService();

--- a/Control/Submitter/src/Program.cs
+++ b/Control/Submitter/src/Program.cs
@@ -105,12 +105,7 @@ public static class Program
              .AddInitializedOption<InitServices>(builder.Configuration,
                                                  InitServices.SettingSection)
              .AddSingleton<InitDatabase>()
-             .AddExceptionManager(sp =>
-                                  {
-                                    var options = sp.GetRequiredService<Common.Injection.Options.Submitter>();
-                                    return new ExceptionManager.Options(options.GraceDelay,
-                                                                        options.MaxErrorAllowed);
-                                  })
+             .AddExceptionManager(sp => ExceptionManager.Options.FromSubmitterOptions(sp.GetRequiredService<Common.Injection.Options.Submitter>()))
              .AddGrpcReflection()
              .AddSingleton<MeterHolder>()
              .AddSingleton<AgentIdentifier>()


### PR DESCRIPTION
# Motivation

When the control plane (Submitter) recorded too many errors, `ExceptionManager` cancelled the `EarlyCancellationToken` immediately, aborting in-flight processing at once. Under Kubernetes that is too abrupt: the orchestrator had no window to observe the failure, deregister the pod from the load balancer, and drive an orderly `SIGTERM`-based shutdown, so requests could be cut off mid-flight.

On top of that, the Submitter never exposed an HTTP `/readiness` endpoint (unlike the PollingAgent, which has all three probes), so a readiness probe could not observe the Unhealthy state at all; it was only reachable through the gRPC health service.

This fixes both: the control plane now signals Unhealthy first and waits a short grace window before self-terminating, and the readiness state is exposed over HTTP so the orchestrator can react. Follows up on #1254 (graceful drain of in-flight RPCs).

# Description

- **Defer self-termination instead of aborting immediately.** The error-threshold path in `ExceptionManager` no longer cancels `EarlyCancellationToken` synchronously. It sets `Failed` right away (flipping the health checks to Unhealthy) and defers the cancellation by a configurable `SelfTerminationDelay` (`Common/Injection/Options/Submitter`, default `10s`) via `CancelAfter`. A delay of zero preserves the previous immediate-cancel behaviour.
- **Options plumbing**: `ExceptionManager.Options` gains a `SelfTerminationDelay` parameter plus `FromSubmitterOptions` / `FromPollsterOptions` factory methods; the Submitter and PollingAgent `Program.cs` and `TestPollsterProvider` build options through them. The PollingAgent passes `TimeSpan.Zero`, so this only changes the control plane; the agent is unaffected.
- **Report Unhealthy on every probe tag.** `ExceptionInterceptor.Check()` is now tag-agnostic: it reports Unhealthy on all tags (not only Readiness) once `Failed` is set. Liveness going Unhealthy is the intended trigger for Kubernetes to send `SIGTERM`, which `ExceptionManager` (acting as the `IHostLifetime`) catches and turns into the same graceful drain; `SelfTerminationDelay` is the backstop for when `SIGTERM` never arrives.
- **Expose the readiness probe.** The Submitter now maps an HTTP `/readiness` endpoint on port `1081` (filtered by the Readiness tag), mirroring its existing `/startup` and `/liveness` endpoints and matching the PollingAgent.

# Testing

- `ExceptionManagerTests`: `SelfTerminationDelayStop` (Failed set immediately, `EarlyCancellationToken` deferred by ~the delay, and the existing grace-delay -> late-token -> `ApplicationStopping` chain still composes) and `SelfTerminationDelayDefersCancellation` (deterministic, timing-free guard for the decoupling invariant).
- `ExceptionInterceptorTests`: `RequestDuringSelfTerminationDelayIsAccepted` (the control plane reports Unhealthy on both probe tags but still admits requests during the window) and `SelfTerminationDelayDefaultsToTenSeconds`, plus a 3-arg `BuildExceptionManager` helper overload.
- All `ExceptionManager` + `ExceptionInterceptor` tests pass locally (45/45). The timing-sensitive test was run repeatedly to confirm stability and carries `[Retry(2)]`, consistent with the existing `GraceDelayStop`.

# Impact

- **Behaviour change (Submitter only)**: after crossing the error threshold the control plane now stays alive (Unhealthy, still draining) for `SelfTerminationDelay` (default `10s`) before self-cancelling, instead of cancelling immediately. The PollingAgent is unaffected (delay `0`).
- **Liveness now reports Unhealthy on failure** (previously only Readiness did). This is intentional given the graceful `SIGTERM` handling; deployments should ensure `terminationGracePeriodSeconds` covers `SelfTerminationDelay + GraceDelay`.
- New `/readiness` HTTP endpoint on the Submitter management port (`1081`). No new dependencies.
- The actual readiness/liveness probe wiring lives in the deployment/infra, not in this repository; this PR only makes the endpoint and behaviour available.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
