### PR TITLE
docs(readme): add CI status and SonarCloud badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@
 | [![Docker image latest version](https://img.shields.io/docker/v/dockerhubaneo/armonik_control_metrics?color=fe5001&label=armonik_control_metrics&sort=semver)](https://hub.docker.com/r/dockerhubaneo/armonik_control_metrics)                               | [![Docker image latest version](https://img.shields.io/docker/v/dockerhubaneo/armonik_control_metrics?color=fe5001&label=armonik_control_metrics&sort=date)](https://hub.docker.com/r/dockerhubaneo/armonik_control_metrics)                               |
 | [![Docker image latest version](https://img.shields.io/docker/v/dockerhubaneo/armonik_control?color=fe5001&label=armonik_control&sort=semver)](https://hub.docker.com/r/dockerhubaneo/armonik_control)                                                       | [![Docker image latest version](https://img.shields.io/docker/v/dockerhubaneo/armonik_control?color=fe5001&label=armonik_control&sort=date)](https://hub.docker.com/r/dockerhubaneo/armonik_control)                                                       |
 
+## Status
+
+The badges below reflect the latest run on the `main` branch: the GitHub Actions *Build and Test* workflow, plus the SonarCloud quality gate and code coverage.
+
+[![Build and Test](https://github.com/aneoconsulting/ArmoniK.Core/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/aneoconsulting/ArmoniK.Core/actions/workflows/build.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aneoconsulting_ArmoniK.Core&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aneoconsulting_ArmoniK.Core)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aneoconsulting_ArmoniK.Core&metric=coverage)](https://sonarcloud.io/summary/new_code?id=aneoconsulting_ArmoniK.Core)
+[![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=aneoconsulting_ArmoniK.Core&metric=reliability_rating)](https://sonarcloud.io/summary/new_code?id=aneoconsulting_ArmoniK.Core)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=aneoconsulting_ArmoniK.Core&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=aneoconsulting_ArmoniK.Core)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=aneoconsulting_ArmoniK.Core&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=aneoconsulting_ArmoniK.Core)
+
 
  ## What is ArmoniK.Core?
 


### PR DESCRIPTION
# Motivation

The README lacked visibility into the project's health at a glance. Contributors and users visiting the repository had no quick way to see whether the build is passing, what the test coverage looks like, or how the project rates on code quality metrics.

# Description

Adds a new **Status** section to `README.md` containing the following badges, all scoped to the `main` branch:

- **Build and Test** — GitHub Actions workflow status
- **Quality Gate Status** — SonarCloud overall quality gate
- **Coverage** — SonarCloud code coverage
- **Reliability Rating** — SonarCloud reliability score
- **Security Rating** — SonarCloud security score
- **Maintainability Rating** — SonarCloud maintainability (SQALE) score

# Testing

Documentation-only change; no code was modified. Badges are rendered by GitHub and SonarCloud's badge API and can be verified visually on the repository's main page.

# Impact

No functional impact. The README gains a concise status overview that makes CI health and code quality immediately visible to anyone visiting the repository.

# Additional Information

Badge URLs reference the `aneoconsulting_ArmoniK.Core` SonarCloud project key, which is already in use by the existing CI pipeline.
