### PR TITLE
fix(mongodb): prevent duplicate task dispatch on concurrent dependency removal

### DIFF
--- a/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
+++ b/Adaptors/MongoDB/src/ArmoniK.Core.Adapters.MongoDB.csproj
@@ -32,6 +32,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="ArmoniK.Utils.DocAttribute" Version="0.7.3" />
+    <PackageReference Include="ArmoniK.Utils" Version="0.7.3">
+      <ExcludeAssets>runtime</ExcludeAssets>
+    </PackageReference>
     <PackageReference Include="MongoDB.Driver" Version="3.8.1" />
     <PackageReference Include="MongoDB.Driver.Core.Extensions.DiagnosticSources" Version="3.0.0" />
     <PackageReference Include="AWSSDK.Core" Version="3.7.500.80" />

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -403,28 +403,19 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                     dependenciesToRemove,
                     taskIds);
 
-    var readyTasks = await sessionHandle.WithTransactionAsync(async (session,
-                                                                     ct) =>
-                                                              {
-                                                                await taskCollection.UpdateManyAsync(session,
-                                                                                                     data => taskIds.Contains(data.TaskId),
-                                                                                                     update,
-                                                                                                     cancellationToken: ct)
-                                                                                    .ConfigureAwait(false);
+    await taskCollection.UpdateManyAsync(sessionHandle,
+                                         data => taskIds.Contains(data.TaskId),
+                                         update,
+                                         cancellationToken: cancellationToken)
+                        .ConfigureAwait(false);
 
-                                                                return taskCollection.Find(session,
-                                                                                           data => taskIds.Contains(data.TaskId) &&
-                                                                                                   (data.Status == TaskStatus.Creating ||
-                                                                                                    data.Status == TaskStatus.Pending) &&
-                                                                                                   data.RemainingDataDependencies == new Dictionary<string, bool>())
-                                                                                     .Project(selector)
-                                                                                     .ToAsyncEnumerable(ct);
-                                                              },
-                                                              cancellationToken: cancellationToken)
-                                        .ConfigureAwait(false);
+    var readyTasks = taskCollection.Find(sessionHandle,
+                                         data => taskIds.Contains(data.TaskId) && (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
+                                                 data.RemainingDataDependencies == new Dictionary<string, bool>())
+                                   .Project(selector)
+                                   .ToAsyncEnumerable(cancellationToken);
 
-    await foreach (var task in readyTasks.WithCancellation(cancellationToken)
-                                         .ConfigureAwait(false))
+    await foreach (var task in readyTasks.ConfigureAwait(false))
     {
       yield return task;
     }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -403,19 +403,28 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                     dependenciesToRemove,
                     taskIds);
 
-    await taskCollection.UpdateManyAsync(sessionHandle,
-                                         data => taskIds.Contains(data.TaskId),
-                                         update,
-                                         cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
+    var readyTasks = await sessionHandle.WithTransactionAsync(async (session,
+                                                                     ct) =>
+                                                              {
+                                                                await taskCollection.UpdateManyAsync(session,
+                                                                                                     data => taskIds.Contains(data.TaskId),
+                                                                                                     update,
+                                                                                                     cancellationToken: ct)
+                                                                                    .ConfigureAwait(false);
 
-    var readyTasks = taskCollection.Find(sessionHandle,
-                                         data => taskIds.Contains(data.TaskId) && (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
-                                                 data.RemainingDataDependencies == new Dictionary<string, bool>())
-                                   .Project(selector)
-                                   .ToAsyncEnumerable(cancellationToken);
+                                                                return taskCollection.Find(session,
+                                                                                           data => taskIds.Contains(data.TaskId) &&
+                                                                                                   (data.Status == TaskStatus.Creating ||
+                                                                                                    data.Status == TaskStatus.Pending) &&
+                                                                                                   data.RemainingDataDependencies == new Dictionary<string, bool>())
+                                                                                     .Project(selector)
+                                                                                     .ToAsyncEnumerable(ct);
+                                                              },
+                                                              cancellationToken: cancellationToken)
+                                        .ConfigureAwait(false);
 
-    await foreach (var task in readyTasks.ConfigureAwait(false))
+    await foreach (var task in readyTasks.WithCancellation(cancellationToken)
+                                         .ConfigureAwait(false))
     {
       yield return task;
     }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -412,19 +412,19 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                                                                                      cancellationToken: ct)
                                                                                     .ConfigureAwait(false);
 
-                                                                return await taskCollection.Find(session,
-                                                                                                 data => taskIds.Contains(data.TaskId) &&
-                                                                                                         (data.Status == TaskStatus.Creating ||
-                                                                                                          data.Status == TaskStatus.Pending) &&
-                                                                                                         data.RemainingDataDependencies == new Dictionary<string, bool>())
-                                                                                           .Project(selector)
-                                                                                           .ToListAsync(ct)
-                                                                                           .ConfigureAwait(false);
+                                                                return taskCollection.Find(session,
+                                                                                           data => taskIds.Contains(data.TaskId) &&
+                                                                                                   (data.Status == TaskStatus.Creating ||
+                                                                                                    data.Status == TaskStatus.Pending) &&
+                                                                                                   data.RemainingDataDependencies == new Dictionary<string, bool>())
+                                                                                     .Project(selector)
+                                                                                     .ToAsyncEnumerable(ct);
                                                               },
                                                               cancellationToken: cancellationToken)
                                         .ConfigureAwait(false);
 
-    foreach (var task in readyTasks)
+    await foreach (var task in readyTasks.WithCancellation(cancellationToken)
+                                         .ConfigureAwait(false))
     {
       yield return task;
     }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -412,19 +412,19 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                                                                                      cancellationToken: ct)
                                                                                     .ConfigureAwait(false);
 
-                                                                return taskCollection.Find(session,
-                                                                                           data => taskIds.Contains(data.TaskId) &&
-                                                                                                   (data.Status == TaskStatus.Creating ||
-                                                                                                    data.Status == TaskStatus.Pending) &&
-                                                                                                   data.RemainingDataDependencies == new Dictionary<string, bool>())
-                                                                                     .Project(selector)
-                                                                                     .ToAsyncEnumerable(ct);
+                                                                return await taskCollection.Find(session,
+                                                                                                 data => taskIds.Contains(data.TaskId) &&
+                                                                                                         (data.Status == TaskStatus.Creating ||
+                                                                                                          data.Status == TaskStatus.Pending) &&
+                                                                                                         data.RemainingDataDependencies == new Dictionary<string, bool>())
+                                                                                           .Project(selector)
+                                                                                           .ToListAsync(ct)
+                                                                                           .ConfigureAwait(false);
                                                               },
                                                               cancellationToken: cancellationToken)
                                         .ConfigureAwait(false);
 
-    await foreach (var task in readyTasks.WithCancellation(cancellationToken)
-                                         .ConfigureAwait(false))
+    foreach (var task in readyTasks)
     {
       yield return task;
     }

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -377,7 +377,6 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                                                      CancellationToken              cancellationToken = default)
   {
     using var activity       = StartActivity();
-    var       sessionHandle  = GetSession();
     var       taskCollection = GetCollection();
 
     // MongoDB driver does not support to unset a list, so Unset should be called multiple times.
@@ -411,14 +410,18 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
     // FindOneAndUpdateAsync ties the readiness check to this call's own position in MongoDB's
     // per-document write order, so only the removal that happens to run last observes the fully
     // cleared state.
-    return taskIds.ParallelSelect(async taskId => await taskCollection.FindOneAndUpdateAsync<TaskData>(sessionHandle,
-                                                                                                        data => data.TaskId == taskId,
-                                                                                                        update,
-                                                                                                        new FindOneAndUpdateOptions<TaskData, TaskData>
-                                                                                                        {
-                                                                                                          ReturnDocument = ReturnDocument.After,
-                                                                                                        },
-                                                                                                        cancellationToken)
+    // The shared session from GetSession() must not be used here: it is a single IClientSessionHandle
+    // reused by every concurrent operation in the process, and it cannot support more than one
+    // in-flight retryable write at a time ("a newer retryable write ... has already started on this
+    // session"). Each of these fanned-out FindOneAndUpdateAsync calls instead gets its own implicit,
+    // independent session, matching UpdateOneTask above.
+    return taskIds.ParallelSelect(async taskId => await taskCollection.FindOneAndUpdateAsync(data => data.TaskId == taskId,
+                                                                                              update,
+                                                                                              new FindOneAndUpdateOptions<TaskData>
+                                                                                              {
+                                                                                                ReturnDocument = ReturnDocument.After,
+                                                                                              },
+                                                                                              cancellationToken)
                                                                        .ConfigureAwait(false))
                   .Where(task => task is not null && (task.Status == TaskStatus.Creating || task.Status == TaskStatus.Pending) &&
                                  task.RemainingDataDependencies.Count == 0)

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -20,7 +20,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -372,10 +371,10 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
   }
 
   /// <inheritdoc />
-  public async IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>                        taskIds,
-                                                                           ICollection<string>                        dependenciesToRemove,
-                                                                           Expression<Func<TaskData, T>>              selector,
-                                                                           [EnumeratorCancellation] CancellationToken cancellationToken = default)
+  public IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>           taskIds,
+                                                                     ICollection<string>           dependenciesToRemove,
+                                                                     Expression<Func<TaskData, T>> selector,
+                                                                     CancellationToken              cancellationToken = default)
   {
     using var activity       = StartActivity();
     var       sessionHandle  = GetSession();
@@ -387,7 +386,7 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
     using var deps = dependenciesToRemove.GetEnumerator();
     if (!deps.MoveNext())
     {
-      yield break;
+      return AsyncEnumerable.Empty<T>();
     }
 
 
@@ -403,22 +402,27 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                     dependenciesToRemove,
                     taskIds);
 
-    await taskCollection.UpdateManyAsync(sessionHandle,
-                                         data => taskIds.Contains(data.TaskId),
-                                         update,
-                                         cancellationToken: cancellationToken)
-                        .ConfigureAwait(false);
+    var compiledSelector = selector.Compile();
 
-    var readyTasks = taskCollection.Find(sessionHandle,
-                                         data => taskIds.Contains(data.TaskId) && (data.Status == TaskStatus.Creating || data.Status == TaskStatus.Pending) &&
-                                                 data.RemainingDataDependencies == new Dictionary<string, bool>())
-                                   .Project(selector)
-                                   .ToAsyncEnumerable(cancellationToken);
-
-    await foreach (var task in readyTasks.ConfigureAwait(false))
-    {
-      yield return task;
-    }
+    // Removing the dependency and reading the resulting state must be a single atomic operation per
+    // task: doing them as a separate UpdateManyAsync followed by a Find let two concurrent removals
+    // (each clearing a different dependency of the same task) both read after the other's write had
+    // landed, so both would see an empty RemainingDataDependencies and both would enqueue the task.
+    // FindOneAndUpdateAsync ties the readiness check to this call's own position in MongoDB's
+    // per-document write order, so only the removal that happens to run last observes the fully
+    // cleared state.
+    return taskIds.ParallelSelect(async taskId => await taskCollection.FindOneAndUpdateAsync<TaskData>(sessionHandle,
+                                                                                                        data => data.TaskId == taskId,
+                                                                                                        update,
+                                                                                                        new FindOneAndUpdateOptions<TaskData, TaskData>
+                                                                                                        {
+                                                                                                          ReturnDocument = ReturnDocument.After,
+                                                                                                        },
+                                                                                                        cancellationToken)
+                                                                       .ConfigureAwait(false))
+                  .Where(task => task is not null && (task.Status == TaskStatus.Creating || task.Status == TaskStatus.Pending) &&
+                                 task.RemainingDataDependencies.Count == 0)
+                  .Select(compiledSelector);
   }
 
   /// <inheritdoc />


### PR DESCRIPTION
# Motivation

When multiple results that a task depends on complete around the same time, `RemoveRemainingDataDependenciesAsync` can be called concurrently for the same task from different dependency-completion paths. The previous implementation could let more than one of these concurrent calls observe the task as newly-ready, each enqueuing a duplicate task message.

This isn't benign: the existing dequeue-time deduplication only discards the duplicate after it has already consumed an AMQP prefetch credit. Under load, enough duplicate ready-detections exhaust the consumer's credits and stall processing.

# Description

`RemoveRemainingDataDependenciesAsync` previously did a separate `UpdateManyAsync` followed by a `Find` to check readiness. Because the read was decoupled from the write, two concurrent calls — each clearing a different dependency of the same task — could both run their `Find` after both writes had landed, so both would see an empty `RemainingDataDependencies` and both would enqueue the task.

A multi-document transaction was tried first but isn't viable here: `SessionProvider` hands out a single `IClientSessionHandle` shared by every concurrent operation in the whole process. Starting a transaction on it while other calls use the same session concurrently collides on the session's transaction number (`"Only servers in a sharded cluster can start a new transaction at the active transaction number"`), and even a plain concurrent retryable write on that shared session fails the same way (`"a newer retryable write ... has already started on this session"`).

The fix instead replaces the update+find pair with a single atomic `FindOneAndUpdateAsync` per task, fanned out concurrently with `ArmoniK.Utils`'s `ParallelSelect` (the same idiom already used in the S3 and Redis adapters), each using its own independent implicit session rather than the shared one — matching the existing per-document update pattern already used by `UpdateOneTask` in the same file. Tying the readiness check to each call's own atomic write means only the removal that happens to run last against a given document ever observes the fully-cleared dependency set, eliminating the duplicate ready-detection.

# Testing

- `dotnet build` on the MongoDB adapter project: 0 errors.
- `dotnet test Adaptors/MongoDB/tests/ --filter "FullyQualifiedName~RemoveRemainingDataDependencies"`: existing coverage (2/2) passes.

# Impact

- No public interface changes.
- New package reference: `ArmoniK.Utils` (already used elsewhere in the codebase at the same pinned version, e.g. S3/Redis adapters).
- Behavioural fix only for the MongoDB adapter; no changes to Postgres or Memory adapters.

# Additional Information

None.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.