### PR TITLE
fix: list applications empty sort

### DIFF
--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -262,11 +262,13 @@ public class TaskTable : ITaskTable
                                                                      data.Options.ApplicationService))
                                     .Select(group => group.Key);
 
-    var ordered = queryable.OrderByList(orderFields,
-                                        ascOrder);
+    IQueryable<Application> paged = orderFields.Count > 0
+                                       ? queryable.OrderByList(orderFields,
+                                                               ascOrder)
+                                       : queryable;
 
-    return Task.FromResult<(IEnumerable<Application> tasks, int totalCount)>((ordered.Skip(page * pageSize)
-                                                                                     .Take(pageSize), ordered.Count()));
+    return Task.FromResult<(IEnumerable<Application> tasks, int totalCount)>((paged.Skip(page * pageSize)
+                                                                                   .Take(pageSize), paged.Count()));
   }
 
   public IAsyncEnumerable<T> RemoveRemainingDataDependenciesAsync<T>(ICollection<string>           taskIds,

--- a/Adaptors/Memory/src/TaskTable.cs
+++ b/Adaptors/Memory/src/TaskTable.cs
@@ -263,9 +263,9 @@ public class TaskTable : ITaskTable
                                     .Select(group => group.Key);
 
     IQueryable<Application> paged = orderFields.Count > 0
-                                       ? queryable.OrderByList(orderFields,
-                                                               ascOrder)
-                                       : queryable;
+                                      ? queryable.OrderByList(orderFields,
+                                                              ascOrder)
+                                      : queryable;
 
     return Task.FromResult<(IEnumerable<Application> tasks, int totalCount)>((paged.Skip(page * pageSize)
                                                                                    .Take(pageSize), paged.Count()));

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -360,15 +360,17 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                                                    data.Options.ApplicationService))
                                   .Select(group => group.Key);
 
-    var ordered = queryable.OrderByList(orderFields,
-                                        ascOrder);
+    IQueryable<Application> paged = orderFields.Count > 0
+                                       ? queryable.OrderByList(orderFields,
+                                                               ascOrder)
+                                       : queryable;
 
-    var taskResult = ordered.Skip(page * pageSize)
-                            .Take(pageSize)
-                            .ToListAsync(cancellationToken);
+    var taskResult = paged.Skip(page * pageSize)
+                          .Take(pageSize)
+                          .ToListAsync(cancellationToken);
 
-    return (await taskResult.ConfigureAwait(false), await ordered.CountAsync(cancellationToken)
-                                                                 .ConfigureAwait(false));
+    return (await taskResult.ConfigureAwait(false), await paged.CountAsync(cancellationToken)
+                                                               .ConfigureAwait(false));
   }
 
   /// <inheritdoc />

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -361,9 +361,9 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                   .Select(group => group.Key);
 
     IQueryable<Application> paged = orderFields.Count > 0
-                                       ? queryable.OrderByList(orderFields,
-                                                               ascOrder)
-                                       : queryable;
+                                      ? queryable.OrderByList(orderFields,
+                                                              ascOrder)
+                                      : queryable;
 
     var taskResult = paged.Skip(page * pageSize)
                           .Take(pageSize)

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -22,6 +22,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
@@ -2259,6 +2260,27 @@ public class TaskTableTestBase
                         Assert.That(taskData.DataDependencies,
                                     Is.Empty);
                       });
+    }
+  }
+
+  [Test]
+  public async Task ListApplicationFromTasksNoSortShouldSucceed()
+  {
+    if (RunTests)
+    {
+      // ListApplicationsAsync with an empty sort field list called OrderByList, which
+      // unconditionally called .First() on the field collection and threw
+      // InvalidOperationException instead of leaving results in natural order.
+      var (applications, _) = await TaskTable!.ListApplicationsAsync(_ => true,
+                                                                     Array.Empty<Expression<Func<Application, object?>>>(),
+                                                                     false,
+                                                                     0,
+                                                                     10,
+                                                                     CancellationToken.None)
+                                              .ConfigureAwait(false);
+
+      Assert.That(applications,
+                  Is.Not.Empty);
     }
   }
 }


### PR DESCRIPTION
# Motivation

  While adding regression tests for a set of PostgreSQL adaptor fixes (on `jg/postgressql`), a new test
  that calls `ListApplicationsAsync` with an empty sort field list uncovered that the same bug —
  originally identified and fixed in PostgreSQL — also exists in the MongoDB and Memory adaptors. Since
  `TaskTableTestBase` is shared across all `ITaskTable` implementations, this one test case exposed the
  issue in all three backends at once.

  # Description

  `ListApplicationsAsync` builds an ordered queryable by calling `OrderByList(orderFields, ascOrder)`
  unconditionally. `OrderByList` calls `.First()` on the field collection with no guard, so passing an
  empty sort field list throws `InvalidOperationException` instead of falling back to the backend's
  natural ordering.

  This PR fixes it in the two affected adaptors:
  - `Adaptors/MongoDB/src/TaskTable.cs`: skip `OrderByList` when `orderFields.Count == 0`, leaving
  MongoDB free to return results in its natural order.
  - `Adaptors/Memory/src/TaskTable.cs`: same guard, in-memory implementation.

  (The PostgreSQL adaptor already carries the equivalent fix in a separate branch/PR.)

  # Testing

  Added `ListApplicationFromTasksNoSortShouldSucceed` to `Common/tests/TestBase/TaskTableTestBase.cs`,
  which calls `ListApplicationsAsync` with `Array.Empty<Expression<Func<Application, object?>>>()` as the
  sort field list. Since this test lives in the shared base class, it runs against every `ITaskTable`
  implementation (Memory, MongoDB, PostgreSQL).

  Verified locally:
  dotnet test Adaptors/Memory/tests/  --filter "ListApplicationFromTasksNoSortShouldSucceed"   # passed
  dotnet test Adaptors/MongoDB/tests/ --filter "ListApplicationFromTasksNoSortShouldSucceed"   # passed

  # Impact

  Bug fix only — no behavior change for callers that already pass a non-empty sort field list. Callers
  passing an empty list now get results in natural order instead of an exception. No new dependencies, no
  configuration or documentation changes.

  # Additional Information

  Split out of `jg/postgressql`, which bundles a larger set of PostgreSQL-specific fixes. These two fixes
  and the regression test are backend-agnostic (they touch Memory and MongoDB, not PostgreSQL) so
  they're proposed here as a standalone, smaller PR.

  # Checklist

  - [x] My code adheres to the coding and style guidelines of the project.
  - [x] I have performed a self-review of my code.
  - [ ] I have commented my code, particularly in hard-to-understand areas.
  - [ ] I have made corresponding changes to the documentation.
  - [x] I have thoroughly tested my modifications and added tests when necessary.
  - [x] Tests pass locally and in the CI.
  - [ ] I have assessed the performance impact of my modifications.
