### PR TITLE
fix: pageSize<=0 crash in MongoDB ListApplicationsAsync, dedup in Memory AddTaskDependencies

### DIFF
--- a/Adaptors/Memory/src/ResultTable.cs
+++ b/Adaptors/Memory/src/ResultTable.cs
@@ -231,7 +231,8 @@ public class ResultTable : IResultTable
         throw new ResultNotFoundException($"Key '{resultId}' not found");
       }
 
-      result.DependentTasks.AddRange(taskIds);
+      var newTaskIds = taskIds.Except(result.DependentTasks);
+      result.DependentTasks.AddRange(newTaskIds);
     }
 
     return Task.CompletedTask;

--- a/Adaptors/MongoDB/src/TaskTable.cs
+++ b/Adaptors/MongoDB/src/TaskTable.cs
@@ -365,12 +365,19 @@ public class TaskTable : BaseTable<TaskData, TaskDataModelMapping>, ITaskTable
                                                               ascOrder)
                                       : queryable;
 
-    var taskResult = paged.Skip(page * pageSize)
-                          .Take(pageSize)
-                          .ToListAsync(cancellationToken);
+    var totalCount = paged.CountAsync(cancellationToken);
 
-    return (await taskResult.ConfigureAwait(false), await paged.CountAsync(cancellationToken)
-                                                               .ConfigureAwait(false));
+    if (pageSize <= 0)
+    {
+      return (Enumerable.Empty<Application>(), await totalCount.ConfigureAwait(false));
+    }
+
+    var taskResult = await paged.Skip(page * pageSize)
+                                .Take(pageSize)
+                                .ToListAsync(cancellationToken)
+                                .ConfigureAwait(false);
+
+    return (taskResult, await totalCount.ConfigureAwait(false));
   }
 
   /// <inheritdoc />

--- a/Common/tests/TestBase/ResultTableTestBase.cs
+++ b/Common/tests/TestBase/ResultTableTestBase.cs
@@ -732,6 +732,72 @@ public class ResultTableTestBase
   }
 
   [Test]
+  public async Task AddTaskDependenciesTwiceShouldNotDuplicate()
+  {
+    if (RunTests)
+    {
+      const string resultId  = "ResultForDedupTest";
+      const string sessionId = "SessionId";
+
+      await ResultTable!.Create(new[]
+                                {
+                                  new Result(sessionId,
+                                             resultId,
+                                             "",
+                                             "CreatedBy",
+                                             "CompletedBy",
+                                             "OwnerId",
+                                             ResultStatus.Created,
+                                             new List<string>(),
+                                             DateTime.UtcNow,
+                                             null,
+                                             0,
+                                             Array.Empty<byte>(),
+                                             false),
+                                })
+                        .ConfigureAwait(false);
+
+      await ResultTable.AddTaskDependencies(new Dictionary<string, ICollection<string>>
+                                            {
+                                              {
+                                                resultId, new[]
+                                                          {
+                                                            "Task1",
+                                                            "Task2",
+                                                          }
+                                              },
+                                            })
+                       .ConfigureAwait(false);
+
+      // Task2 overlaps with the first call; the second call should dedup it.
+      await ResultTable.AddTaskDependencies(new Dictionary<string, ICollection<string>>
+                                            {
+                                              {
+                                                resultId, new[]
+                                                          {
+                                                            "Task2",
+                                                            "Task3",
+                                                          }
+                                              },
+                                            })
+                       .ConfigureAwait(false);
+
+      var dependents = await ResultTable.GetDependents(sessionId,
+                                                       resultId)
+                                        .ToListAsync()
+                                        .ConfigureAwait(false);
+
+      Assert.That(dependents,
+                  Is.EquivalentTo(new List<string>
+                                  {
+                                    "Task1",
+                                    "Task2",
+                                    "Task3",
+                                  }));
+    }
+  }
+
+  [Test]
   public void AddDependentNotExistingResultShouldThrow()
   {
     if (RunTests)

--- a/Common/tests/TestBase/TaskTableTestBase.cs
+++ b/Common/tests/TestBase/TaskTableTestBase.cs
@@ -2613,4 +2613,22 @@ public class TaskTableTestBase
                   Is.Not.Empty);
     }
   }
+
+  [Test]
+  public async Task ListApplicationsAsyncShouldReturnEmptyForNegativePageSize()
+  {
+    if (RunTests)
+    {
+      var (applications, _) = await TaskTable!.ListApplicationsAsync(_ => true,
+                                                                     new List<Expression<Func<Application, object?>>>(),
+                                                                     false,
+                                                                     0,
+                                                                     -1,
+                                                                     CancellationToken.None)
+                                              .ConfigureAwait(false);
+
+      Assert.That(applications,
+                  Is.Empty);
+    }
+  }
 }


### PR DESCRIPTION
# Motivation

While working on the Postgres adapter, two regression tests already existed for Postgres-specific fixes: a guard against negative `pageSize` in `ListApplicationsAsync`, and deduplication in `AddTaskDependencies`. Checking whether Memory and MongoDB satisfied the same behavioral contracts revealed that neither did — each had its own latent bug.

# Description

- **MongoDB `TaskTable.ListApplicationsAsync`**: a negative or zero `pageSize` was passed straight into `.Take(pageSize)`, which the MongoDB LINQ provider translates into a `$limit` pipeline stage. That stage's constructor rejects non-positive values and throws `ArgumentOutOfRangeException` instead of returning an empty result, unlike Postgres which already guards this case. Added the same `pageSize <= 0` guard, returning `(Enumerable.Empty<Application>(), totalCount)` without building the paginated query.
- **Memory `ResultTable.AddTaskDependencies`**: appended incoming task ids to `DependentTasks` unconditionally via `List<string>.AddRange`, so calling it twice with an overlapping task id produced a duplicate entry. MongoDB already dedups this via `$addToSet`. Fixed by excluding task ids already present in `DependentTasks` before appending (`taskIds.Except(result.DependentTasks)`).
- Promoted the two regression tests (`ListApplicationsAsyncShouldReturnEmptyForNegativePageSize`, `AddTaskDependenciesTwiceShouldNotDuplicate`) from the Postgres-specific test files into the shared `TaskTableTestBase`/`ResultTableTestBase`, so all three adapters (Memory, MongoDB, Postgres) are held to the same contracts going forward.

# Testing

- `dotnet test Adaptors/Memory/tests/` — 205/205 passed
- `dotnet test Adaptors/MongoDB/tests/` — 310/310 passed
- Both new shared tests verified to pass on Memory, MongoDB, and Postgres.

# Impact

- Behavioral fix only for two edge cases (negative `pageSize`, repeated `AddTaskDependencies` calls with overlapping ids); no change to normal usage paths.
- No new dependencies, no configuration or documentation changes.

# Additional Information

Extracted from work on the `jg/postgressql` branch, where Postgres already handled both cases correctly — this PR brings Memory and MongoDB in line with the same contracts.