### PR TITLE
perf(postgres): batch dependency removal into a single round trip

### DIFF
--- a/Adaptors/PostgresSQL/src/TaskTable.cs
+++ b/Adaptors/PostgresSQL/src/TaskTable.cs
@@ -645,8 +645,11 @@ LIMIT @limit OFFSET @offset";
   {
     await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
                                                           .ConfigureAwait(false);
-    await using var transaction = await connection.BeginTransactionAsync(cancellationToken)
-                                                  .ConfigureAwait(false);
+
+    // A single NpgsqlBatch is atomic (its commands run in the implicit transaction bounded by the
+    // batch's Sync message), so no explicit transaction is needed and the whole operation costs
+    // one round trip.
+    await using var batch = new NpgsqlBatch(connection);
 
     // Acquire row-level locks on the affected tasks in a deterministic order (ORDER BY task_id)
     // BEFORE deleting their remaining dependencies. Without this lock, two concurrent transactions
@@ -656,14 +659,17 @@ LIMIT @limit OFFSET @offset";
     // both commits the task has no remaining deps — permanently stranding it in Pending status.
     // Locking first serialises the two transactions: the second waits until the first commits,
     // then sees all previously deleted rows as gone and correctly identifies the task as ready.
-    await using var lockCmd = connection.CreateCommand();
-    lockCmd.Transaction = transaction;
-    lockCmd.CommandText = @"
+    //
+    // The three commands must stay separate statements. Each takes its own snapshot when it
+    // executes, so the readiness check runs on a snapshot taken after this lock was granted, and
+    // sees both the blocking transaction's commit and this transaction's own DELETE. Merging them
+    // into one statement leaves a single snapshot predating that commit and reinstates the race.
+    var lockCmd = new NpgsqlBatchCommand(@"
 SELECT task_id FROM tasks
 WHERE task_id = ANY(@task_ids)
   AND status IN (@status_creating, @status_pending)
 ORDER BY task_id
-FOR UPDATE";
+FOR UPDATE");
     lockCmd.Parameters.AddWithValue("task_ids",
                                     NpgsqlDbType.Array | NpgsqlDbType.Text,
                                     taskIds.ToArray());
@@ -671,37 +677,24 @@ FOR UPDATE";
                                     (int)TaskStatus.Creating);
     lockCmd.Parameters.AddWithValue("status_pending",
                                     (int)TaskStatus.Pending);
-    await using (var lockReader = await lockCmd.ExecuteReaderAsync(cancellationToken)
-                                               .ConfigureAwait(false))
-    {
-      while (await lockReader.ReadAsync(cancellationToken)
-                             .ConfigureAwait(false))
-      {
-      }
-    }
+    batch.BatchCommands.Add(lockCmd);
 
-    await using var deleteCmd = connection.CreateCommand();
-    deleteCmd.Transaction = transaction;
-    deleteCmd.CommandText = "DELETE FROM task_remaining_dependencies WHERE task_id = ANY(@task_ids) AND result_id = ANY(@dep_ids)";
+    var deleteCmd = new NpgsqlBatchCommand("DELETE FROM task_remaining_dependencies WHERE task_id = ANY(@task_ids) AND result_id = ANY(@dep_ids)");
     deleteCmd.Parameters.AddWithValue("task_ids",
                                       NpgsqlDbType.Array | NpgsqlDbType.Text,
                                       taskIds.ToArray());
     deleteCmd.Parameters.AddWithValue("dep_ids",
                                       NpgsqlDbType.Array | NpgsqlDbType.Text,
                                       dependenciesToRemove.ToArray());
+    batch.BatchCommands.Add(deleteCmd);
 
-    await deleteCmd.ExecuteNonQueryAsync(cancellationToken)
-                   .ConfigureAwait(false);
-
-    await using var readyCmd = connection.CreateCommand();
-    readyCmd.Transaction = transaction;
-    readyCmd.CommandText = @"
+    var readyCmd = new NpgsqlBatchCommand(@"
 SELECT t.* FROM tasks t
 WHERE t.task_id = ANY(@ready_task_ids)
   AND t.status IN (@status_creating, @status_pending)
   AND NOT EXISTS (
     SELECT 1 FROM task_remaining_dependencies d WHERE d.task_id = t.task_id
-  )";
+  )");
     readyCmd.Parameters.AddWithValue("ready_task_ids",
                                      NpgsqlDbType.Array | NpgsqlDbType.Text,
                                      taskIds.ToArray());
@@ -709,20 +702,28 @@ WHERE t.task_id = ANY(@ready_task_ids)
                                      (int)TaskStatus.Creating);
     readyCmd.Parameters.AddWithValue("status_pending",
                                      (int)TaskStatus.Pending);
+    batch.BatchCommands.Add(readyCmd);
 
     var result = new List<TaskData>();
-    await using (var reader = await readyCmd.ExecuteReaderAsync(cancellationToken)
-                                            .ConfigureAwait(false))
+    await using (var reader = await batch.ExecuteReaderAsync(cancellationToken)
+                                         .ConfigureAwait(false))
     {
+      // Two result sets, not three: the DELETE returns no rows so it contributes none. Drain the
+      // lock command's rows, then advance to the ready tasks.
+      while (await reader.ReadAsync(cancellationToken)
+                         .ConfigureAwait(false))
+      {
+      }
+
+      await reader.NextResultAsync(cancellationToken)
+                  .ConfigureAwait(false);
+
       while (await reader.ReadAsync(cancellationToken)
                          .ConfigureAwait(false))
       {
         result.Add(RowMapper.MapToTaskData(reader));
       }
     }
-
-    await transaction.CommitAsync(cancellationToken)
-                     .ConfigureAwait(false);
 
     return result;
   }


### PR DESCRIPTION
# Motivation

`TaskTable.FetchReadyTasksAfterDependencyRemoval` backs `RemoveRemainingDataDependenciesAsync`, which sits on a hot path: `TaskLifeCycleHelper.ResolveDependencies` calls it every time results complete, and the submission path calls it again for newly created tasks.

It performed five sequential server interactions — `BEGIN`, the `FOR UPDATE` lock, the `DELETE`, the ready-tasks `SELECT`, then `COMMIT`. Two costs follow from that:

- Four avoidable network round trips per invocation.
- More importantly, the row-level lock on the affected tasks was held across three client round trips. Client-side latency, a GC pause, or a thread-pool stall inside that window blocked every other transaction queued on the same task. That window is exactly where contention concentrates: a fan-in/aggregation task receives many concurrent dependency removals.

# Description

Replaced the explicit transaction plus three sequentially executed commands with a **single `NpgsqlBatch` holding the same three commands**. A batch is already atomic — its commands run inside the implicit transaction bounded by the batch's `Sync` message — so `BeginTransactionAsync`/`CommitAsync` are no longer needed. This matches the existing pattern in `BulkUpdateTasks`/`BulkUpdateResults`.

**The three SQL statements are unchanged byte-for-byte.** Only the execution shape changed; the diff is 30 insertions / 29 deletions.

Two points a reviewer may want to poke at, both documented in-code:

1. **The commands are deliberately kept as three separate statements.** This is load-bearing, not an oversight. Each statement takes its own snapshot when it executes, so the readiness check runs on a snapshot taken *after* the lock was granted and therefore sees both the blocking transaction's commit and this transaction's own `DELETE`. Merging them into one statement collapses that to a single snapshot predating the commit and reinstates the stranded-task race the lock exists to prevent.

2. **The reader advances through two result sets, not three.** The `DELETE` returns no rows, so it contributes no result set.

I did evaluate folding the `DELETE` into the `SELECT` as a data-modifying CTE (a two-command batch). It was rejected on measurements — see Impact.

# Testing

- Full PostgreSQL adapter suite: **421/421 passing**. No test changes were needed, since behaviour is unchanged.
- Because the change touches a concurrency-correctness invariant that the unit tests do not directly exercise, I verified it separately against PostgreSQL 18.4 in Docker:
  - **Per-command snapshot freshness** — confirmed a batch's second command gets a snapshot taken after the first command finished blocking on a row lock (it observes the concurrent commit). This is the property the whole design rests on.
  - **The stranded-task race** — two workers concurrently removing different dependencies of the same task; exactly one must report it ready. 0 incorrect over 30 rounds.
  - **Negative control** — the same harness with the lock command removed reproduces the bug at 25/40 rounds, confirming the test genuinely exercises the race rather than passing vacuously.

# Impact

No changes to public interfaces, schema, configuration, or dependencies. Behaviour is identical; this is purely an execution-shape change.

Measured against PostgreSQL 18.4, medians over repeated trials, comparing the previous shape (`tx+3cmd`), the rejected CTE variant (`batch+cte`), and this change (`batch+3cmd`):

| Scenario | before | CTE variant | **this PR** |
|---|---|---|---|
| Hot path — 1 task, 1 dependency | 2804 us | 1749 us | **1749 us** |
| Contention — 16 workers, 128 deps, one task | 320 ms | 207 ms | **187 ms** |
| Bulk — M=500 id supersets | 10.9 ms | 29.7 ms | **8.7 ms** |
| Bulk — M=2000, 8 deps | 24.2 ms | 25.5 ms | **23.1 ms** |
| Bulk — M=2000, 16 deps | 25.1 ms | 26.6 ms | 27.9 ms |

Roughly 38% off the hot path and 42% off the contention scenario. The gain comes entirely from collapsing round trips and from the shortened lock-hold window, not from any query change.

**Caveat on these figures:** they were taken over WSL2-to-Docker loopback, where RTT is unusually high (~1.6 ms). The percentages therefore overstate what to expect with PostgreSQL on the same host and understate a cross-AZ deployment. The direction is robust — it is round-trip count — but the magnitudes should not be quoted as production numbers.

Why the CTE variant was rejected: it matched this PR on the hot path but ran up to 3.4x slower on bulk calls (29.7 vs 8.7 ms at M=500). With the `DELETE` inside a CTE, the readiness check can no longer scan `task_remaining_dependencies` directly — a CTE shares the statement's single snapshot, so rows being deleted are still visible — and must anti-join against the CTE's `RETURNING` output. The planner then flips between hashing that CTE and rescanning it per row, and chooses badly in the mid-size range. That regime is real traffic: both callers in `TaskLifeCycleHelper` intentionally pass id supersets ("*This will try to remove more results than strictly necessary... should be optimized by the DB*").

# Additional Information

Only the `NOT EXISTS` readiness check, the `DELETE`, and the `FOR UPDATE` lock are involved; the lock's `ORDER BY task_id` (deterministic ordering for deadlock avoidance) and the original explanatory comment about the stranding race are preserved.