### PR TITLE
ci: start the Docker service on Windows runners when it fails to boot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -754,6 +754,34 @@ jobs:
           repository: ${{ env.REPOSITORY }}
           ref: ${{ env.REFERENCE }}
 
+      # Windows runners intermittently boot with the Docker Engine service stopped: on boot from the
+      # saved image, Docker tries to create its Hyper-V virtual switch and sometimes fails with
+      # "hnsCall failed in Win32: The system cannot find the file specified. (0x2)", after which the
+      # service stays Stopped. Waiting for the daemon does not help since nothing will restart it,
+      # but starting the service manually is a reliable fix.
+      # https://github.com/actions/runner-images/issues/13729
+      - name: Ensure the Docker daemon is running
+        run: |
+          Get-Service -Name "*docker*" |
+            Where-Object { $_.Status -ne "Running" } |
+            ForEach-Object {
+              Write-Host "Service '$($_.Name)' is $($_.Status), starting it"
+              Start-Service -Name $_.Name -ErrorAction SilentlyContinue
+            }
+
+          foreach ($attempt in 1..30) {
+            docker info *> $null
+            if ($LASTEXITCODE -eq 0) {
+              Write-Host "Docker daemon ready after $attempt attempt(s)"
+              exit 0
+            }
+            Start-Sleep -Seconds 2
+          }
+
+          Write-Host "::error::Docker daemon did not become available"
+          Get-Service -Name "*docker*" | Format-Table -AutoSize
+          exit 1
+
       - name: Docker networks
         run : docker network ls
 


### PR DESCRIPTION
# Motivation

The `Docker Windows` job fails intermittently on its very first Docker command, before anything is built:

```
docker network ls
failed to connect to the docker API at npipe:////./pipe/docker_engine; check if the path is
correct and if the daemon is running: open //./pipe/docker_engine: The system cannot find the
file specified.
```

This is a known, still-unfixed bug in the GitHub-hosted Windows runner images: [actions/runner-images#13729](https://github.com/actions/runner-images/issues/13729), open since 2026-02-24.

Per the runner-images maintainers' own investigation:

- The runner boots from a saved image. On that second boot, the Docker Engine service tries to create its Hyper-V virtual switch and intermittently fails with `hnsCall failed in Win32: The system cannot find the file specified. (0x2)`, and the service is left **Stopped**.
- It is specific to **Docker Engine v29+**, and the latest version they tested (29.4.3) is still affected.
- It does not depend on runner size or load — it is purely a boot-time race.
- **"Manual service restart solves problem in 100% cases (tested on 1000+ job reruns)."**

The underlying HNS failure is [docker/for-win#4354](https://github.com/docker/for-win/issues/4354). Windows Server 2025 was initially thought to be unaffected, but that has since been disproven in the thread — and our own failure was on the `windows-2025-vs2026` image, `20260714.173.1`.

# Description

Adds an `Ensure the Docker daemon is running` step to the `testWindowsDocker` job, immediately after `Checkout` and before the first Docker command. It:

1. Starts any `*docker*` service that is not `Running`.
2. Polls `docker info` until it succeeds, up to 30 attempts at 2s intervals (60s ceiling).
3. On timeout, emits a `::error::` annotation and dumps the service states, so a genuinely broken host fails fast with a clear diagnosis instead of erroring out at some arbitrary later Docker command.

Step 1 is the actual fix and matches the workaround recommended by the runner-images maintainers in the issue. Steps 2 and 3 are hardening, modelled on [spiffe/spire's `wait-for-docker-windows.ps1`](https://github.com/spiffe/spire/blob/main/.github/workflows/scripts/wait-for-docker-windows.ps1).

**Worth knowing for anyone tempted to simplify this:** a wait-only loop does *not* work. The service is dead, not slow, so nothing will bring it up on its own — a maintainer of testcontainers-dotnet reported exactly that failure mode in the thread, with `do { docker info } until ($LASTEXITCODE -eq 0)` timing out after 10 minutes. The `Start-Service` call is the part that matters; the polling only covers the ordinary case where the daemon is merely slow to accept connections.

No `shell:` is set, so the step runs under the Windows default (`pwsh`), consistent with the snippet in the issue.

Only `testWindowsDocker` is touched. The other `windows-latest` job, `testsWinOnly`, never invokes Docker and so needs nothing.

# Testing

The change is a CI workflow step and cannot be exercised locally — reproducing it would require a GitHub-hosted Windows runner that happens to lose the boot race, which is precisely the condition we cannot summon on demand.

What was verified:

- `build.yml` still parses, and the new step lands in the intended position (`Checkout` -> `Ensure the Docker daemon is running` -> `Docker networks` -> `Docker info`).
- The `Docker Windows` job on this PR exercises the happy path: the service is normally already running, so the loop should report readiness on its first attempt.

The failure path (service stopped) will only be exercised the next time a runner loses the race. Note the PowerShell was not run locally — no PowerShell available on the dev machine — so the `Docker Windows` job here is its first real execution.

# Impact

CI-only; no product code, configuration, or dependencies are affected.

On a healthy runner the step costs roughly one `docker info` invocation (about a second). Its value is removing a spurious red build whose only remedy today is noticing the failure and manually re-running the job. GitHub measures the failure rate at 1-in-30 to 1-in-50 in their environment, with several projects in the thread reporting substantially worse.

This is a workaround, not a fix. It should be removed once [actions/runner-images#13729](https://github.com/actions/runner-images/issues/13729) is resolved upstream.

# Additional Information

The existing `Docker networks` and `Docker info` diagnostic steps are left in place: they are cheap and still useful for debugging, and the new step's `docker info` output is suppressed.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.