### PR TITLE
perf(postgres): run List* count and page queries in parallel

### DIFF
--- a/Adaptors/PostgresSQL/src/Common/PagedQuery.cs
+++ b/Adaptors/PostgresSQL/src/Common/PagedQuery.cs
@@ -26,13 +26,12 @@ using Npgsql;
 namespace ArmoniK.Core.Adapters.PostgresSQL.Common;
 
 /// <summary>
-///   The page half of a paginated query: its SQL, which must end with <c>LIMIT @limit OFFSET @offset</c>,
-///   and the parameters its WHERE and ORDER BY clauses reference.
+///   A query and the parameters it references.
 /// </summary>
-/// <param name="Sql">The page query</param>
-/// <param name="Parameters">Parameters referenced by <paramref name="Sql" />, excluding limit and offset</param>
-public readonly record struct PageQuery(string                      Sql,
-                                        Dictionary<string, object?> Parameters);
+/// <param name="Sql">The query</param>
+/// <param name="Parameters">Parameters referenced by <paramref name="Sql" /></param>
+public readonly record struct Query(string                      Sql,
+                                    Dictionary<string, object?> Parameters);
 
 /// <summary>
 ///   Runs the two queries behind a paginated list: the total number of matches, and one page of rows.
@@ -47,7 +46,7 @@ public static class PagedQuery
   /// </summary>
   /// <remarks>
   ///   Queries that don't have that shape - one counting distinct combinations of columns, say, or one
-  ///   ordering on several fields - build their own SQL and call the overload taking it directly.
+  ///   ordering on several fields - build their own and call the overload taking them directly.
   /// </remarks>
   /// <typeparam name="TEntity">Entity type the filter and order field apply to</typeparam>
   /// <typeparam name="TRow">Type each row maps to</typeparam>
@@ -79,9 +78,13 @@ public static class PagedQuery
   {
     var (whereSql, parameters)     = ExpressionToSql<TEntity>.Translate(filter);
     var (orderColumn, orderParams) = ExpressionToSql<TEntity>.TranslateOrderBy(orderField);
-    foreach (var (key, value) in orderParams)
+
+    // Only the page references the ORDER BY parameters, so they are kept out of the count's set rather
+    // than merged into it. The two namespaces are disjoint - filters are named @p<n> and order keys
+    // @orderkey<n> - so nothing is overwritten either way round.
+    foreach (var (key, value) in parameters)
     {
-      parameters[key] = value;
+      orderParams[key] = value;
     }
 
     var orderDir = ascOrder
@@ -89,12 +92,12 @@ public static class PagedQuery
                      : "DESC";
 
     return await ExecuteAsync(connectionProvider,
-                              $"SELECT COUNT(*) FROM {table} WHERE {whereSql}",
-                              parameters,
+                              new Query($"SELECT COUNT(*) FROM {table} WHERE {whereSql}",
+                                        parameters),
+                              new Query($"SELECT {selectList} FROM {table} WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset",
+                                        orderParams),
                               page,
                               pageSize,
-                              () => new PageQuery($"SELECT {selectList} FROM {table} WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset",
-                                                  parameters),
                               mapRow,
                               cancellationToken)
              .ConfigureAwait(false);
@@ -111,42 +114,57 @@ public static class PagedQuery
   /// </remarks>
   /// <typeparam name="TRow">Type each row maps to</typeparam>
   /// <param name="connectionProvider">Provider of pooled connections</param>
-  /// <param name="countSql">Query returning the total number of matches as a single scalar</param>
-  /// <param name="countParameters">Parameters referenced by <paramref name="countSql" /></param>
+  /// <param name="countQuery">Query returning the total number of matches as a single scalar</param>
+  /// <param name="pageQuery">
+  ///   Query returning one page of rows; its SQL must end with <c>LIMIT @limit OFFSET @offset</c>, whose
+  ///   values are supplied from <paramref name="page" /> and <paramref name="pageSize" />
+  /// </param>
   /// <param name="page">Zero-based index of the page to read</param>
   /// <param name="pageSize">Rows per page; when not positive no page is read and no rows are returned</param>
-  /// <param name="pageQuery">
-  ///   Builds the page query. Only called when <paramref name="pageSize" /> is positive, so any cost of
-  ///   assembling it (translating ORDER BY fields, say) is skipped when only the count was asked for.
-  /// </param>
   /// <param name="mapRow">Maps the reader's current row to <typeparamref name="TRow" /></param>
   /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
   /// <returns>The page's rows, and the total number of matches irrespective of paging</returns>
   public static async Task<(List<TRow> items, long totalCount)> ExecuteAsync<TRow>(NpgsqlConnectionProvider     connectionProvider,
-                                                                                   string                       countSql,
-                                                                                   Dictionary<string, object?>  countParameters,
+                                                                                   Query                        countQuery,
+                                                                                   Query                        pageQuery,
                                                                                    int                          page,
                                                                                    int                          pageSize,
-                                                                                   Func<PageQuery>              pageQuery,
                                                                                    Func<NpgsqlDataReader, TRow> mapRow,
                                                                                    CancellationToken            cancellationToken)
   {
-    var countTask = CountAsync(connectionProvider,
-                               countSql,
-                               countParameters,
-                               cancellationToken);
+    var countTask = RunAsync(connectionProvider,
+                             countQuery,
+                             async cmd => Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken)
+                                                                   .ConfigureAwait(false)),
+                             cancellationToken);
 
     if (pageSize <= 0)
     {
       return (new List<TRow>(), await countTask.ConfigureAwait(false));
     }
 
-    var pageTask = PageAsync(connectionProvider,
-                             pageQuery.Invoke(),
-                             page,
-                             pageSize,
-                             mapRow,
-                             cancellationToken);
+    var pageTask = RunAsync(connectionProvider,
+                            pageQuery,
+                            async cmd =>
+                            {
+                              cmd.Parameters.AddWithValue("limit",
+                                                          pageSize);
+                              cmd.Parameters.AddWithValue("offset",
+                                                          (long)page * pageSize);
+
+                              await using var reader = await cmd.ExecuteReaderAsync(cancellationToken)
+                                                                .ConfigureAwait(false);
+
+                              var items = new List<TRow>();
+                              while (await reader.ReadAsync(cancellationToken)
+                                                 .ConfigureAwait(false))
+                              {
+                                items.Add(mapRow.Invoke(reader));
+                              }
+
+                              return items;
+                            },
+                            cancellationToken);
 
     // WhenAll rather than awaiting in sequence, so a failure of either still observes both.
     await Task.WhenAll(countTask,
@@ -156,50 +174,27 @@ public static class PagedQuery
     return (await pageTask.ConfigureAwait(false), await countTask.ConfigureAwait(false));
   }
 
-  private static async Task<long> CountAsync(NpgsqlConnectionProvider    connectionProvider,
-                                             string                      countSql,
-                                             Dictionary<string, object?> countParameters,
-                                             CancellationToken           cancellationToken)
+  /// <summary>
+  ///   Run <paramref name="query" /> on its own connection and return whatever
+  ///   <paramref name="execute" /> makes of the resulting command.
+  /// </summary>
+  /// <remarks>
+  ///   The connection has to be held open for as long as the command runs, so the caller passes what to
+  ///   do with the command rather than receiving it.
+  /// </remarks>
+  private static async Task<T> RunAsync<T>(NpgsqlConnectionProvider     connectionProvider,
+                                           Query                        query,
+                                           Func<NpgsqlCommand, Task<T>> execute,
+                                           CancellationToken            cancellationToken)
   {
     await using var connection = await connectionProvider.GetConnectionAsync(cancellationToken)
                                                          .ConfigureAwait(false);
     await using var cmd = connection.CreateCommand();
-    cmd.CommandText = countSql;
+    cmd.CommandText = query.Sql;
     SqlHelper.AddExpressionParameters(cmd,
-                                      countParameters);
+                                      query.Parameters);
 
-    return Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken)
-                                    .ConfigureAwait(false));
-  }
-
-  private static async Task<List<TRow>> PageAsync<TRow>(NpgsqlConnectionProvider     connectionProvider,
-                                                        PageQuery                    pageQuery,
-                                                        int                          page,
-                                                        int                          pageSize,
-                                                        Func<NpgsqlDataReader, TRow> mapRow,
-                                                        CancellationToken            cancellationToken)
-  {
-    await using var connection = await connectionProvider.GetConnectionAsync(cancellationToken)
-                                                         .ConfigureAwait(false);
-    await using var cmd = connection.CreateCommand();
-    cmd.CommandText = pageQuery.Sql;
-    SqlHelper.AddExpressionParameters(cmd,
-                                      pageQuery.Parameters);
-    cmd.Parameters.AddWithValue("limit",
-                                pageSize);
-    cmd.Parameters.AddWithValue("offset",
-                                (long)page * pageSize);
-
-    await using var reader = await cmd.ExecuteReaderAsync(cancellationToken)
-                                      .ConfigureAwait(false);
-
-    var items = new List<TRow>();
-    while (await reader.ReadAsync(cancellationToken)
-                       .ConfigureAwait(false))
-    {
-      items.Add(mapRow.Invoke(reader));
-    }
-
-    return items;
+    return await execute.Invoke(cmd)
+                        .ConfigureAwait(false);
   }
 }

--- a/Adaptors/PostgresSQL/src/Common/PagedQuery.cs
+++ b/Adaptors/PostgresSQL/src/Common/PagedQuery.cs
@@ -1,0 +1,205 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Npgsql;
+
+namespace ArmoniK.Core.Adapters.PostgresSQL.Common;
+
+/// <summary>
+///   The page half of a paginated query: its SQL, which must end with <c>LIMIT @limit OFFSET @offset</c>,
+///   and the parameters its WHERE and ORDER BY clauses reference.
+/// </summary>
+/// <param name="Sql">The page query</param>
+/// <param name="Parameters">Parameters referenced by <paramref name="Sql" />, excluding limit and offset</param>
+public readonly record struct PageQuery(string                      Sql,
+                                        Dictionary<string, object?> Parameters);
+
+/// <summary>
+///   Runs the two queries behind a paginated list: the total number of matches, and one page of rows.
+/// </summary>
+public static class PagedQuery
+{
+  /// <summary>
+  ///   Count the matches and read the requested page of a single table, deriving both queries from
+  ///   <paramref name="filter" /> and <paramref name="orderField" />:
+  ///   <c>SELECT COUNT(*)</c> for the count and, for the page, <paramref name="selectList" /> ordered on
+  ///   one column.
+  /// </summary>
+  /// <remarks>
+  ///   Queries that don't have that shape - one counting distinct combinations of columns, say, or one
+  ///   ordering on several fields - build their own SQL and call the overload taking it directly.
+  /// </remarks>
+  /// <typeparam name="TEntity">Entity type the filter and order field apply to</typeparam>
+  /// <typeparam name="TRow">Type each row maps to</typeparam>
+  /// <param name="connectionProvider">Provider of pooled connections</param>
+  /// <param name="table">Table to select from</param>
+  /// <param name="filter">Filter both queries apply</param>
+  /// <param name="orderField">Field the page is ordered on</param>
+  /// <param name="ascOrder">Whether the page is ordered ascending</param>
+  /// <param name="page">Zero-based index of the page to read</param>
+  /// <param name="pageSize">Rows per page; when not positive no page is read and no rows are returned</param>
+  /// <param name="mapRow">Maps the reader's current row to <typeparamref name="TRow" /></param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <param name="selectList">
+  ///   Columns the page selects, <c>*</c> for every one. Pass <see cref="RowMapper.SelectList" /> to read
+  ///   only what a projection needs, keeping it in step with the mapper handed to
+  ///   <paramref name="mapRow" />.
+  /// </param>
+  /// <returns>The page's rows, and the total number of matches irrespective of paging</returns>
+  public static async Task<(List<TRow> items, long totalCount)> ExecuteAsync<TEntity, TRow>(NpgsqlConnectionProvider           connectionProvider,
+                                                                                            string                             table,
+                                                                                            Expression<Func<TEntity, bool>>    filter,
+                                                                                            Expression<Func<TEntity, object?>> orderField,
+                                                                                            bool                               ascOrder,
+                                                                                            int                                page,
+                                                                                            int                                pageSize,
+                                                                                            Func<NpgsqlDataReader, TRow>       mapRow,
+                                                                                            CancellationToken                  cancellationToken,
+                                                                                            string                             selectList = "*")
+  {
+    var (whereSql, parameters)     = ExpressionToSql<TEntity>.Translate(filter);
+    var (orderColumn, orderParams) = ExpressionToSql<TEntity>.TranslateOrderBy(orderField);
+    foreach (var (key, value) in orderParams)
+    {
+      parameters[key] = value;
+    }
+
+    var orderDir = ascOrder
+                     ? "ASC"
+                     : "DESC";
+
+    return await ExecuteAsync(connectionProvider,
+                              $"SELECT COUNT(*) FROM {table} WHERE {whereSql}",
+                              parameters,
+                              page,
+                              pageSize,
+                              () => new PageQuery($"SELECT {selectList} FROM {table} WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset",
+                                                  parameters),
+                              mapRow,
+                              cancellationToken)
+             .ConfigureAwait(false);
+  }
+
+  /// <summary>
+  ///   Count the matches and read the requested page, using the given queries.
+  /// </summary>
+  /// <remarks>
+  ///   The two queries are independent, so they run concurrently, each on its own pooled connection - a
+  ///   single <see cref="NpgsqlConnection" /> can only run one command at a time. They are not in a shared
+  ///   transaction and so see independent snapshots, exactly as they did when run sequentially on one
+  ///   connection: under READ COMMITTED every statement takes its own snapshot either way.
+  /// </remarks>
+  /// <typeparam name="TRow">Type each row maps to</typeparam>
+  /// <param name="connectionProvider">Provider of pooled connections</param>
+  /// <param name="countSql">Query returning the total number of matches as a single scalar</param>
+  /// <param name="countParameters">Parameters referenced by <paramref name="countSql" /></param>
+  /// <param name="page">Zero-based index of the page to read</param>
+  /// <param name="pageSize">Rows per page; when not positive no page is read and no rows are returned</param>
+  /// <param name="pageQuery">
+  ///   Builds the page query. Only called when <paramref name="pageSize" /> is positive, so any cost of
+  ///   assembling it (translating ORDER BY fields, say) is skipped when only the count was asked for.
+  /// </param>
+  /// <param name="mapRow">Maps the reader's current row to <typeparamref name="TRow" /></param>
+  /// <param name="cancellationToken">Token used to cancel the execution of the method</param>
+  /// <returns>The page's rows, and the total number of matches irrespective of paging</returns>
+  public static async Task<(List<TRow> items, long totalCount)> ExecuteAsync<TRow>(NpgsqlConnectionProvider     connectionProvider,
+                                                                                   string                       countSql,
+                                                                                   Dictionary<string, object?>  countParameters,
+                                                                                   int                          page,
+                                                                                   int                          pageSize,
+                                                                                   Func<PageQuery>              pageQuery,
+                                                                                   Func<NpgsqlDataReader, TRow> mapRow,
+                                                                                   CancellationToken            cancellationToken)
+  {
+    var countTask = CountAsync(connectionProvider,
+                               countSql,
+                               countParameters,
+                               cancellationToken);
+
+    if (pageSize <= 0)
+    {
+      return (new List<TRow>(), await countTask.ConfigureAwait(false));
+    }
+
+    var pageTask = PageAsync(connectionProvider,
+                             pageQuery.Invoke(),
+                             page,
+                             pageSize,
+                             mapRow,
+                             cancellationToken);
+
+    // WhenAll rather than awaiting in sequence, so a failure of either still observes both.
+    await Task.WhenAll(countTask,
+                       pageTask)
+              .ConfigureAwait(false);
+
+    return (await pageTask.ConfigureAwait(false), await countTask.ConfigureAwait(false));
+  }
+
+  private static async Task<long> CountAsync(NpgsqlConnectionProvider    connectionProvider,
+                                             string                      countSql,
+                                             Dictionary<string, object?> countParameters,
+                                             CancellationToken           cancellationToken)
+  {
+    await using var connection = await connectionProvider.GetConnectionAsync(cancellationToken)
+                                                         .ConfigureAwait(false);
+    await using var cmd = connection.CreateCommand();
+    cmd.CommandText = countSql;
+    SqlHelper.AddExpressionParameters(cmd,
+                                      countParameters);
+
+    return Convert.ToInt64(await cmd.ExecuteScalarAsync(cancellationToken)
+                                    .ConfigureAwait(false));
+  }
+
+  private static async Task<List<TRow>> PageAsync<TRow>(NpgsqlConnectionProvider     connectionProvider,
+                                                        PageQuery                    pageQuery,
+                                                        int                          page,
+                                                        int                          pageSize,
+                                                        Func<NpgsqlDataReader, TRow> mapRow,
+                                                        CancellationToken            cancellationToken)
+  {
+    await using var connection = await connectionProvider.GetConnectionAsync(cancellationToken)
+                                                         .ConfigureAwait(false);
+    await using var cmd = connection.CreateCommand();
+    cmd.CommandText = pageQuery.Sql;
+    SqlHelper.AddExpressionParameters(cmd,
+                                      pageQuery.Parameters);
+    cmd.Parameters.AddWithValue("limit",
+                                pageSize);
+    cmd.Parameters.AddWithValue("offset",
+                                (long)page * pageSize);
+
+    await using var reader = await cmd.ExecuteReaderAsync(cancellationToken)
+                                      .ConfigureAwait(false);
+
+    var items = new List<TRow>();
+    while (await reader.ReadAsync(cancellationToken)
+                       .ConfigureAwait(false))
+    {
+      items.Add(mapRow.Invoke(reader));
+    }
+
+    return items;
+  }
+}

--- a/Adaptors/PostgresSQL/src/PartitionTable.cs
+++ b/Adaptors/PostgresSQL/src/PartitionTable.cs
@@ -170,54 +170,18 @@ INSERT INTO partitions (
                                                                                                  int                                      pageSize,
                                                                                                  CancellationToken                        cancellationToken = default)
   {
-    var (whereSql, whereParams)    = ExpressionToSql<PartitionData>.Translate(filter);
-    var (orderColumn, orderParams) = ExpressionToSql<PartitionData>.TranslateOrderBy(orderField);
-    foreach (var (key, value) in orderParams)
-    {
-      whereParams[key] = value;
-    }
+    var (partitions, totalCount) = await PagedQuery.ExecuteAsync(connectionProvider_,
+                                                                 "partitions",
+                                                                 filter,
+                                                                 orderField,
+                                                                 ascOrder,
+                                                                 page,
+                                                                 pageSize,
+                                                                 RowMapper.MapToPartitionData,
+                                                                 cancellationToken)
+                                                   .ConfigureAwait(false);
 
-    var orderDir = ascOrder
-                     ? "ASC"
-                     : "DESC";
-
-    await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
-                                                          .ConfigureAwait(false);
-
-    // Count query
-    await using var countCmd = connection.CreateCommand();
-    countCmd.CommandText = $"SELECT COUNT(*) FROM partitions WHERE {whereSql}";
-    SqlHelper.AddExpressionParameters(countCmd,
-                                      whereParams);
-    var totalCount = Convert.ToInt32(await countCmd.ExecuteScalarAsync(cancellationToken)
-                                                   .ConfigureAwait(false));
-
-    if (pageSize <= 0)
-    {
-      return (Enumerable.Empty<PartitionData>(), totalCount);
-    }
-
-    // Data query
-    await using var dataCmd = connection.CreateCommand();
-    dataCmd.CommandText = $"SELECT * FROM partitions WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset";
-    SqlHelper.AddExpressionParameters(dataCmd,
-                                      whereParams);
-    dataCmd.Parameters.AddWithValue("limit",
-                                    pageSize);
-    dataCmd.Parameters.AddWithValue("offset",
-                                    (long)page * pageSize);
-
-    await using var reader = await dataCmd.ExecuteReaderAsync(cancellationToken)
-                                          .ConfigureAwait(false);
-
-    var results = new List<PartitionData>();
-    while (await reader.ReadAsync(cancellationToken)
-                       .ConfigureAwait(false))
-    {
-      results.Add(RowMapper.MapToPartitionData(reader));
-    }
-
-    return (results, totalCount);
+    return (partitions, Convert.ToInt32(totalCount));
   }
 
   /// <inheritdoc />

--- a/Adaptors/PostgresSQL/src/ResultTable.cs
+++ b/Adaptors/PostgresSQL/src/ResultTable.cs
@@ -346,57 +346,18 @@ WHERE result_id = ANY(@keys) AND owner_task_id = @old_task_id";
                                                                                     int                               pageSize,
                                                                                     CancellationToken                 cancellationToken = default)
   {
-    var (whereSql, whereParams)    = ExpressionToSql<Result>.Translate(filter);
-    var (orderColumn, orderParams) = ExpressionToSql<Result>.TranslateOrderBy(orderField);
-    foreach (var (key, value) in orderParams)
-    {
-      whereParams[key] = value;
-    }
+    var (results, totalCount) = await PagedQuery.ExecuteAsync(connectionProvider_,
+                                                              "results",
+                                                              filter,
+                                                              orderField,
+                                                              ascOrder,
+                                                              page,
+                                                              pageSize,
+                                                              RowMapper.FullRow.MapToResult,
+                                                              cancellationToken)
+                                                .ConfigureAwait(false);
 
-    var orderDir = ascOrder
-                     ? "ASC"
-                     : "DESC";
-
-    await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
-                                                          .ConfigureAwait(false);
-
-    // Count query
-    await using var countCmd = connection.CreateCommand();
-    countCmd.CommandText = $"SELECT COUNT(*) FROM results WHERE {whereSql}";
-    SqlHelper.AddExpressionParameters(countCmd,
-                                      whereParams);
-    var totalCount = Convert.ToInt32(await countCmd.ExecuteScalarAsync(cancellationToken)
-                                                   .ConfigureAwait(false));
-
-    if (pageSize <= 0)
-    {
-      return (Enumerable.Empty<Result>(), totalCount);
-    }
-
-    // Data query
-    await using var dataCmd = connection.CreateCommand();
-    dataCmd.CommandText = $"SELECT * FROM results WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset";
-    SqlHelper.AddExpressionParameters(dataCmd,
-                                      whereParams);
-    dataCmd.Parameters.AddWithValue("limit",
-                                    pageSize);
-    dataCmd.Parameters.AddWithValue("offset",
-                                    (long)page * pageSize);
-
-    await using var reader = await dataCmd.ExecuteReaderAsync(cancellationToken)
-                                          .ConfigureAwait(false);
-
-    var results = new List<Result>();
-    while (await reader.ReadAsync(cancellationToken)
-                       .ConfigureAwait(false))
-    {
-      results.Add(RowMapper.FullRow.MapToResult(reader));
-    }
-
-    await reader.CloseAsync()
-                .ConfigureAwait(false);
-
-    return (results, totalCount);
+    return (results, Convert.ToInt32(totalCount));
   }
 
   /// <inheritdoc />

--- a/Adaptors/PostgresSQL/src/SessionTable.cs
+++ b/Adaptors/PostgresSQL/src/SessionTable.cs
@@ -178,56 +178,16 @@ INSERT INTO sessions (
                                                                                             int                                    page,
                                                                                             int                                    pageSize,
                                                                                             CancellationToken                      cancellationToken = default)
-  {
-    var (whereSql, whereParams)    = ExpressionToSql<SessionData>.Translate(filter);
-    var (orderColumn, orderParams) = ExpressionToSql<SessionData>.TranslateOrderBy(orderField);
-    foreach (var (key, value) in orderParams)
-    {
-      whereParams[key] = value;
-    }
-
-    var orderDir = ascOrder
-                     ? "ASC"
-                     : "DESC";
-
-    await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
-                                                          .ConfigureAwait(false);
-
-    // Count query
-    await using var countCmd = connection.CreateCommand();
-    countCmd.CommandText = $"SELECT COUNT(*) FROM sessions WHERE {whereSql}";
-    SqlHelper.AddExpressionParameters(countCmd,
-                                      whereParams);
-    var totalCount = Convert.ToInt64(await countCmd.ExecuteScalarAsync(cancellationToken)
-                                                   .ConfigureAwait(false));
-
-    if (pageSize <= 0)
-    {
-      return (Enumerable.Empty<SessionData>(), totalCount);
-    }
-
-    // Data query
-    await using var dataCmd = connection.CreateCommand();
-    dataCmd.CommandText = $"SELECT * FROM sessions WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset";
-    SqlHelper.AddExpressionParameters(dataCmd,
-                                      whereParams);
-    dataCmd.Parameters.AddWithValue("limit",
-                                    pageSize);
-    dataCmd.Parameters.AddWithValue("offset",
-                                    (long)page * pageSize);
-
-    await using var reader = await dataCmd.ExecuteReaderAsync(cancellationToken)
-                                          .ConfigureAwait(false);
-
-    var results = new List<SessionData>();
-    while (await reader.ReadAsync(cancellationToken)
-                       .ConfigureAwait(false))
-    {
-      results.Add(RowMapper.MapToSessionData(reader));
-    }
-
-    return (results, totalCount);
-  }
+    => await PagedQuery.ExecuteAsync(connectionProvider_,
+                                     "sessions",
+                                     filter,
+                                     orderField,
+                                     ascOrder,
+                                     page,
+                                     pageSize,
+                                     RowMapper.MapToSessionData,
+                                     cancellationToken)
+                       .ConfigureAwait(false);
 
   /// <inheritdoc />
   public async Task<SessionData?> UpdateOneSessionAsync(string                               sessionId,

--- a/Adaptors/PostgresSQL/src/TaskTable.cs
+++ b/Adaptors/PostgresSQL/src/TaskTable.cs
@@ -316,61 +316,29 @@ SELECT @dep_task_id, unnest(@dep_ids)");
                                                                                int                                 pageSize,
                                                                                CancellationToken                   cancellationToken = default)
   {
-    var (whereSql, whereParams)    = ExpressionToSql<TaskData>.Translate(filter);
-    var (orderColumn, orderParams) = ExpressionToSql<TaskData>.TranslateOrderBy(orderField);
-    foreach (var (key, value) in orderParams)
-    {
-      whereParams[key] = value;
-    }
-
-    var orderDir = ascOrder
-                     ? "ASC"
-                     : "DESC";
-
-    await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
-                                                          .ConfigureAwait(false);
-
-    // Count query
-    await using var countCmd = connection.CreateCommand();
-    countCmd.CommandText = $"SELECT COUNT(*) FROM tasks WHERE {whereSql}";
-    SqlHelper.AddExpressionParameters(countCmd,
-                                      whereParams);
-    var totalCount = Convert.ToInt64(await countCmd.ExecuteScalarAsync(cancellationToken)
-                                                   .ConfigureAwait(false));
-
-    if (pageSize <= 0)
-    {
-      return (Enumerable.Empty<T>(), totalCount);
-    }
-
-    // Data query: project only the columns the selector needs, when we can determine them,
-    // instead of always fetching the whole row.
+    // Project only the columns the selector needs, when we can determine them, instead of
+    // always fetching the whole row.
     var mapper = RowMapper.For(selector);
 
-    await using var dataCmd = connection.CreateCommand();
-    dataCmd.CommandText = $"SELECT {mapper.SelectList} FROM tasks WHERE {whereSql} ORDER BY {orderColumn} {orderDir} LIMIT @limit OFFSET @offset";
-    SqlHelper.AddExpressionParameters(dataCmd,
-                                      whereParams);
-    dataCmd.Parameters.AddWithValue("limit",
-                                    pageSize);
-    dataCmd.Parameters.AddWithValue("offset",
-                                    (long)page * pageSize);
+    var (rawTasks, totalCount) = await PagedQuery.ExecuteAsync(connectionProvider_,
+                                                               "tasks",
+                                                               filter,
+                                                               orderField,
+                                                               ascOrder,
+                                                               page,
+                                                               pageSize,
+                                                               mapper.MapToTaskData,
+                                                               cancellationToken,
+                                                               mapper.SelectList)
+                                                 .ConfigureAwait(false);
 
-    var rawTasks = new List<TaskData>();
-    await using (var reader = await dataCmd.ExecuteReaderAsync(cancellationToken)
-                                           .ConfigureAwait(false))
-    {
-      while (await reader.ReadAsync(cancellationToken)
-                         .ConfigureAwait(false))
-      {
-        rawTasks.Add(mapper.MapToTaskData(reader));
-      }
-    }
-
-    // RemainingDataDependencies lives in a separate join table; only load it when the
-    // selector explicitly reads it.
+    // RemainingDataDependencies lives in a separate join table; only load it when the selector
+    // explicitly reads it. PagedQuery owns the connections it queries on, so this takes its own.
     if (mapper.NeedsSeparatelyStoredData)
     {
+      await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
+                                                            .ConfigureAwait(false);
+
       var depsByTaskId = await LoadRemainingDependenciesBatch(connection,
                                                               rawTasks,
                                                               cancellationToken)
@@ -386,9 +354,8 @@ SELECT @dep_task_id, unnest(@dep_ids)");
     }
 
     var compiled = selector.Compile();
-    var results  = rawTasks.Select(taskData => compiled.Invoke(taskData));
 
-    return (results, totalCount);
+    return (rawTasks.Select(taskData => compiled.Invoke(taskData)), totalCount);
   }
 
   /// <inheritdoc />
@@ -567,74 +534,56 @@ SELECT @dep_task_id, unnest(@dep_ids)");
                      ? "ASC"
                      : "DESC";
 
-    await using var connection = await connectionProvider_.GetConnectionAsync(cancellationToken)
-                                                          .ConfigureAwait(false);
-
-    // Count distinct applications
-    await using var countCmd = connection.CreateCommand();
-    countCmd.CommandText = $@"
+    // The count gets its own copy of the parameters: building the page query below adds the ORDER BY
+    // parameters to whereParams, which would otherwise be mutated while the count reads it concurrently.
+    var (applications, totalCount) = await PagedQuery.ExecuteAsync(connectionProvider_,
+                                                                   $@"
 SELECT COUNT(*) FROM (
   SELECT DISTINCT options_app_name, options_app_namespace, options_app_version, options_app_service
   FROM tasks WHERE {whereSql}
-) sub";
-    SqlHelper.AddExpressionParameters(countCmd,
-                                      whereParams);
-    var totalCount = Convert.ToInt32(await countCmd.ExecuteScalarAsync(cancellationToken)
-                                                   .ConfigureAwait(false));
+) sub",
+                                                                   new Dictionary<string, object?>(whereParams),
+                                                                   page,
+                                                                   pageSize,
+                                                                   BuildPageQuery,
+                                                                   reader => new Application(reader.GetString(0),
+                                                                                             reader.GetString(1),
+                                                                                             reader.GetString(2),
+                                                                                             reader.GetString(3)),
+                                                                   cancellationToken)
+                                                     .ConfigureAwait(false);
 
-    if (pageSize <= 0)
-    {
-      return (Enumerable.Empty<Application>(), totalCount);
-    }
+    return (applications, Convert.ToInt32(totalCount));
 
-    // Get paginated applications
-    var orderClauses = new List<string>();
-    var orderIndex   = 0;
-    foreach (var f in orderFields)
+    PageQuery BuildPageQuery()
     {
-      var (orderColumn, orderParams) = ExpressionToSql<Application>.TranslateOrderBy(f,
-                                                                                     orderIndex++);
-      foreach (var (key, value) in orderParams)
+      var orderClauses = new List<string>();
+      var orderIndex   = 0;
+      foreach (var f in orderFields)
       {
-        whereParams[key] = value;
+        var (orderColumn, orderParams) = ExpressionToSql<Application>.TranslateOrderBy(f,
+                                                                                       orderIndex++);
+        foreach (var (key, value) in orderParams)
+        {
+          whereParams[key] = value;
+        }
+
+        orderClauses.Add($"{orderColumn} {orderDir}");
       }
 
-      orderClauses.Add($"{orderColumn} {orderDir}");
-    }
+      var orderBySql = string.Join(", ",
+                                   orderClauses);
+      var orderByClause = orderBySql.Length > 0
+                            ? $"ORDER BY {orderBySql}"
+                            : "";
 
-    var orderBySql = string.Join(", ",
-                                 orderClauses);
-    var orderByClause = orderBySql.Length > 0
-                          ? $"ORDER BY {orderBySql}"
-                          : "";
-
-    await using var dataCmd = connection.CreateCommand();
-    dataCmd.CommandText = $@"
+      return new PageQuery($@"
 SELECT DISTINCT options_app_name, options_app_namespace, options_app_version, options_app_service
 FROM tasks WHERE {whereSql}
 {orderByClause}
-LIMIT @limit OFFSET @offset";
-    SqlHelper.AddExpressionParameters(dataCmd,
-                                      whereParams);
-    dataCmd.Parameters.AddWithValue("limit",
-                                    pageSize);
-    dataCmd.Parameters.AddWithValue("offset",
-                                    (long)page * pageSize);
-
-    await using var reader = await dataCmd.ExecuteReaderAsync(cancellationToken)
-                                          .ConfigureAwait(false);
-
-    var results = new List<Application>();
-    while (await reader.ReadAsync(cancellationToken)
-                       .ConfigureAwait(false))
-    {
-      results.Add(new Application(reader.GetString(0),
-                                  reader.GetString(1),
-                                  reader.GetString(2),
-                                  reader.GetString(3)));
+LIMIT @limit OFFSET @offset",
+                           whereParams);
     }
-
-    return (results, totalCount);
   }
 
   /// <inheritdoc />

--- a/Adaptors/PostgresSQL/src/TaskTable.cs
+++ b/Adaptors/PostgresSQL/src/TaskTable.cs
@@ -534,18 +534,55 @@ SELECT @dep_task_id, unnest(@dep_ids)");
                      ? "ASC"
                      : "DESC";
 
-    // The count gets its own copy of the parameters: building the page query below adds the ORDER BY
-    // parameters to whereParams, which would otherwise be mutated while the count reads it concurrently.
-    var (applications, totalCount) = await PagedQuery.ExecuteAsync(connectionProvider_,
-                                                                   $@"
+    // Only the page references the ORDER BY parameters, so they are collected separately and the
+    // filter's own set is left as it is for the count. Nothing is mutated after either Query is built,
+    // which matters because the two run concurrently.
+    var countQuery = new Query($@"
 SELECT COUNT(*) FROM (
   SELECT DISTINCT options_app_name, options_app_namespace, options_app_version, options_app_service
   FROM tasks WHERE {whereSql}
 ) sub",
-                                                                   new Dictionary<string, object?>(whereParams),
+                               whereParams);
+
+    var pageParams   = new Dictionary<string, object?>();
+    var orderClauses = new List<string>();
+    var orderIndex   = 0;
+    foreach (var f in orderFields)
+    {
+      var (orderColumn, orderParams) = ExpressionToSql<Application>.TranslateOrderBy(f,
+                                                                                     orderIndex++);
+      foreach (var (key, value) in orderParams)
+      {
+        pageParams[key] = value;
+      }
+
+      orderClauses.Add($"{orderColumn} {orderDir}");
+    }
+
+    // The page filters as well as orders, so it needs both sets.
+    foreach (var (key, value) in whereParams)
+    {
+      pageParams[key] = value;
+    }
+
+    var orderBySql = string.Join(", ",
+                                 orderClauses);
+    var orderByClause = orderBySql.Length > 0
+                          ? $"ORDER BY {orderBySql}"
+                          : "";
+
+    var pageQuery = new Query($@"
+SELECT DISTINCT options_app_name, options_app_namespace, options_app_version, options_app_service
+FROM tasks WHERE {whereSql}
+{orderByClause}
+LIMIT @limit OFFSET @offset",
+                              pageParams);
+
+    var (applications, totalCount) = await PagedQuery.ExecuteAsync(connectionProvider_,
+                                                                   countQuery,
+                                                                   pageQuery,
                                                                    page,
                                                                    pageSize,
-                                                                   BuildPageQuery,
                                                                    reader => new Application(reader.GetString(0),
                                                                                              reader.GetString(1),
                                                                                              reader.GetString(2),
@@ -554,36 +591,6 @@ SELECT COUNT(*) FROM (
                                                      .ConfigureAwait(false);
 
     return (applications, Convert.ToInt32(totalCount));
-
-    PageQuery BuildPageQuery()
-    {
-      var orderClauses = new List<string>();
-      var orderIndex   = 0;
-      foreach (var f in orderFields)
-      {
-        var (orderColumn, orderParams) = ExpressionToSql<Application>.TranslateOrderBy(f,
-                                                                                       orderIndex++);
-        foreach (var (key, value) in orderParams)
-        {
-          whereParams[key] = value;
-        }
-
-        orderClauses.Add($"{orderColumn} {orderDir}");
-      }
-
-      var orderBySql = string.Join(", ",
-                                   orderClauses);
-      var orderByClause = orderBySql.Length > 0
-                            ? $"ORDER BY {orderBySql}"
-                            : "";
-
-      return new PageQuery($@"
-SELECT DISTINCT options_app_name, options_app_namespace, options_app_version, options_app_service
-FROM tasks WHERE {whereSql}
-{orderByClause}
-LIMIT @limit OFFSET @offset",
-                           whereParams);
-    }
   }
 
   /// <inheritdoc />

--- a/Common/tests/TestBase/SessionTableTestBase.cs
+++ b/Common/tests/TestBase/SessionTableTestBase.cs
@@ -845,4 +845,64 @@ public class SessionTableTestBase
                   Is.EqualTo("Filter_test"));
     }
   }
+
+  [Test]
+  public async Task ListSessionsAsyncOrderByTaskOptionShouldSucceed()
+  {
+    if (RunTests)
+    {
+      // Ordering on a task option, rather than on a column, is the only shape that makes the order-by
+      // contribute a parameter of its own. It is therefore the only way to notice a paginated read
+      // handing the wrong parameters to its count or to its page.
+      await SessionTable!.SetSessionDataAsync(new[]
+                                              {
+                                                "partition",
+                                              },
+                                              Options with
+                                              {
+                                                ApplicationName = "OrderByOption",
+                                                Options = new Dictionary<string, string>
+                                                          {
+                                                            {
+                                                              "sortkey", "b"
+                                                            },
+                                                          },
+                                              })
+                         .ConfigureAwait(false);
+
+      await SessionTable!.SetSessionDataAsync(new[]
+                                              {
+                                                "partition",
+                                              },
+                                              Options with
+                                              {
+                                                ApplicationName = "OrderByOption",
+                                                Options = new Dictionary<string, string>
+                                                          {
+                                                            {
+                                                              "sortkey", "a"
+                                                            },
+                                                          },
+                                              })
+                         .ConfigureAwait(false);
+
+      var (sessions, count) = await SessionTable!.ListSessionsAsync(data => data.Options.ApplicationName == "OrderByOption",
+                                                                    data => data.Options.Options["sortkey"],
+                                                                    true,
+                                                                    0,
+                                                                    10,
+                                                                    CancellationToken.None)
+                                                 .ConfigureAwait(false);
+
+      // The count must see the filter, and the page must see both the filter and the sort key.
+      Assert.That(count,
+                  Is.EqualTo(2));
+      Assert.That(sessions.Select(session => session.Options.Options["sortkey"]),
+                  Is.EqualTo(new[]
+                             {
+                               "a",
+                               "b",
+                             }));
+    }
+  }
 }


### PR DESCRIPTION
# Motivation

Every paginated `List*` method in the PostgreSQL adapter issues two independent queries — a `COUNT(*)` over the filter, and a `LIMIT`/`OFFSET` page — and ran them one after the other on a single connection. Since neither depends on the other, the caller was paying `count + page` when it only needs to pay `max(count, page)`.

The `COUNT(*)` is usually the more expensive of the two: it has to visit every row matching the filter, whereas the page query is bounded by `pageSize`. So the wasted time is roughly the whole duration of the page query, on every list call, on paths that back the public gRPC list endpoints.

Those five methods were also near-identical copies of one another, so the parallelisation is factored into one shared helper rather than pasted five times.

# Description

New `Common/PagedQuery.cs` owns both the concurrency and the query generation, and exposes two entry points:

| Overload | Used by | Generates |
|---|---|---|
| `ExecuteAsync<TEntity, TRow>` | the four regular list methods | the filter/order translation, `SELECT COUNT(*) FROM {table} WHERE …`, and `SELECT {selectList} FROM {table} WHERE … ORDER BY … LIMIT @limit OFFSET @offset` |
| `ExecuteAsync<TRow>` | `ListApplicationsAsync` | nothing — the caller supplies both queries as `Query` values |

Affected methods: `ListSessionsAsync`, `ListResultsAsync`, `ListPartitionsAsync`, `ListTasksAsync<T>`, `ListApplicationsAsync`.

Six things that were duplicated across the four regular callers now live in one place: the count SQL, the page SQL, `ExpressionToSql.Translate`, `TranslateOrderBy`, the order-parameter merge, and the `ascOrder ? "ASC" : "DESC"` ternary. `ListSessionsAsync` is a single statement. The SQL produced is unchanged.

Points worth a reviewer's attention:

**Each query takes its own pooled connection.** A single `NpgsqlConnection` can only run one command at a time. `NpgsqlConnectionProvider.GetConnectionAsync` delegates to `NpgsqlDataSource.OpenConnectionAsync`, which hands out a distinct pooled connection per call.

**Snapshot consistency is unchanged.** The two queries now run on separate connections rather than sequentially on one, but they were never in a shared transaction — under `READ COMMITTED` each statement already took its own snapshot. A count that disagrees slightly with the page was possible before and remains possible now.

**`pageSize <= 0` still short-circuits.** The count is launched first; when the page would be empty the helper returns without launching the page query.

**`Task.WhenAll` rather than two sequential awaits**, so if one query faults the other is still observed instead of surfacing later as an unobserved task exception.

**The two queries do not share a parameter dictionary.** Only the page references the `ORDER BY` parameters, so the count is given the filter's set alone. Reversing that merge is safe because the namespaces are disjoint — `ExpressionToSql.Translate` names filter parameters `@p<n>`, `TranslateOrderBy` names order keys `@orderkey<n>`.

`ListApplicationsAsync` collects its order parameters into their own dictionary rather than adding them to the filter's. That removes the defensive copy the count previously needed: nothing is mutated after either `Query` is built, so there is no dictionary being written to while the other query reads it — a structural guarantee rather than a guarded one.

The helper returns `long` for the count; the three methods whose interfaces return `int` convert with `Convert.ToInt32`, preserving the existing overflow-throwing behaviour rather than silently wrapping.

# Testing

| Suite | Result |
|---|---|
| `Adaptors/PostgresSQL/tests` | **441/441** |
| `Adaptors/MongoDB/tests` | **330/330** |
| `Adaptors/Memory/tests` | **225/225** |

Adds one test: **`ListSessionsAsyncOrderByTaskOptionShouldSucceed`**, in the shared `SessionTableTestBase`. It orders on a task option (`data.Options.Options["sortkey"]`) rather than on a column, asserting both the count and the resulting order.

That shape matters. `TranslateOrderBy` only produces a parameter of its own for the dictionary-indexer form; for an ordinary column it returns an empty dictionary. So ordering by a task option is the only way a test can notice a paginated read handing the wrong parameters to its count or to its page — and before this, the only such coverage anywhere was one `ListTasksAsync` test for quoted keys. The count/page split described above was otherwise unverified, and the old code worked because the surplus parameters were harmless rather than because they were right.

It lives in the shared base deliberately, so it holds for Memory and MongoDB too; all three adapters gained exactly one test, which confirms it ran on each rather than being skipped.

# Impact

No API, schema, configuration, or dependency changes. Behaviour is intended to be identical; only the execution shape changes.

Single-call latency, medians against PostgreSQL 18.4, filter matching about one sixth of the table:

| Table rows | pageSize | sequential | parallel | |
|---|---|---|---|---|
| 50 000 | 20 | 7.49 ms | 4.05 ms | 45.9% faster |
| 50 000 | 500 | 8.21 ms | 5.16 ms | 37.1% faster |
| 400 000 | 20 | 54.98 ms | 35.74 ms | 35.0% faster |
| 400 000 | 500 | 55.45 ms | 36.47 ms | 34.2% faster |

The trade-off is that a list call holds two pooled connections instead of one for its duration, so it was worth checking under pool pressure: **64 concurrent list calls** — 128 connections wanted against the default `MaxPoolSize` of 100 — went from **1192.9 ms to 1073.0 ms**, still around 10% faster, with no connection timeouts.

Deadlock is not possible: the count never waits on the page, so even a fully saturated pool always drains. The run above exercised exactly that oversubscribed case.

Caveat on the figures: measured over WSL2-to-Docker loopback, so absolute numbers are not production figures. The effect comes from overlapping two server-side queries rather than from network latency, so the direction holds, but the percentages will vary with the relative cost of the count and page for a given filter.

# Additional Information

Rebased onto `main` after #1273 merged. That rebase surfaced one thing git could not: `RowMapper.MapToResult` became an instance method in #1273, and this branch passed it as a static method group in `ListResultsAsync` — a compile error rather than a conflict, so `git merge-tree` reported a clean automatic merge for that file. It now uses `RowMapper.FullRow.MapToResult`.

`ListTasksAsync<T>` carries both features: `RowMapper.For(selector)` supplies the projected column list and mapper from #1273, while the count and page run concurrently. Its dependency batch-load opens its own connection, since `PagedQuery` owns the ones it queries on.

Formatting was applied from the `Code Formatting` job's patch artifact rather than run locally.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.