### PR TITLE
test: set ReplicaSetSetupTimeout for every embedded MongoDB

### DIFF
--- a/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
+++ b/Adaptors/MongoDB/tests/MongoDatabaseProvider.cs
@@ -21,6 +21,7 @@ using System.Diagnostics;
 
 using ArmoniK.Core.Common.Injection.Options;
 using ArmoniK.Core.Common.Injection.Options.Database;
+using ArmoniK.Core.Common.Tests.Helpers;
 using ArmoniK.Core.Utils;
 
 using EphemeralMongo;
@@ -55,27 +56,10 @@ internal class MongoDatabaseProvider : IDisposable
     var logger = LoggerFactory.Create(builder => builder.AddSerilog(loggerSerilog))
                               .CreateLogger("root");
 
-    var options = new MongoRunnerOptions
-                  {
-                    UseSingleNodeReplicaSet = useSingleNodeReplicaSet,
-#pragma warning disable CA2254 // log inputs should be constant
-                    StandardOutputLogger = showMongoLogs
-                                             ? line => logger.LogInformation(line)
-                                             : null,
-                    StandardErrorLogger = showMongoLogs
-                                            ? line => logger.LogError(line)
-                                            : null,
-#pragma warning restore CA2254
-                    ReplicaSetSetupTimeout = TimeSpan.FromSeconds(30),
-                  };
-
-    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
-    if (!string.IsNullOrEmpty(binDir))
-    {
-      options.BinaryDirectory = binDir;
-    }
-
-    runner_ = MongoRunner.Run(options);
+    runner_ = MongoRunner.Run(MongoRunnerOptionsFactory.Create(useSingleNodeReplicaSet,
+                                                               showMongoLogs
+                                                                 ? logger
+                                                                 : null));
     var settings = MongoClientSettings.FromUrl(new MongoUrl(runner_.ConnectionString));
 
     settings.ClusterConfigurator = cb => cb.Subscribe<CommandStartedEvent>(e => logger.LogInformation("{CommandName} - {Command}",

--- a/Common/tests/Helpers/MongoRunnerOptionsFactory.cs
+++ b/Common/tests/Helpers/MongoRunnerOptionsFactory.cs
@@ -1,0 +1,75 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System;
+
+using EphemeralMongo;
+
+using Microsoft.Extensions.Logging;
+
+namespace ArmoniK.Core.Common.Tests.Helpers;
+
+/// <summary>
+///   Builds the <see cref="MongoRunnerOptions" /> every test provider runs its embedded MongoDB with.
+/// </summary>
+/// <remarks>
+///   These options used to be copied into each provider, which is how the replica-set timeout below
+///   ended up set in only one of them. Everything that should hold for every embedded MongoDB in the
+///   test suites belongs here.
+/// </remarks>
+public static class MongoRunnerOptionsFactory
+{
+  /// <summary>
+  ///   Create the options for an embedded MongoDB.
+  /// </summary>
+  /// <param name="useSingleNodeReplicaSet">
+  ///   Whether the instance is a single-node replica set, needed by tests that watch collections
+  /// </param>
+  /// <param name="logger">Logger the mongod output is forwarded to, or null to discard it</param>
+  /// <returns>Options to hand to <see cref="MongoRunner.Run" /></returns>
+  public static MongoRunnerOptions Create(bool     useSingleNodeReplicaSet = false,
+                                          ILogger? logger                  = null)
+  {
+    var options = new MongoRunnerOptions
+                  {
+                    UseSingleNodeReplicaSet = useSingleNodeReplicaSet,
+#pragma warning disable CA2254 // log inputs should be constant
+                    StandardOutputLogger = logger is null
+                                             ? null
+                                             : line => logger.LogInformation(line),
+                    StandardErrorLogger = logger is null
+                                            ? null
+                                            : line => logger.LogError(line),
+#pragma warning restore CA2254
+                    // Starting a single-node replica set means launching mongod, running rs.initiate
+                    // and waiting for the node to reach PRIMARY, which does not fit in EphemeralMongo's
+                    // 10s default on a loaded CI runner - the Windows runner installs no mongod, so it
+                    // also has to download and unpack one first. The same timeout additionally guards
+                    // EphemeralMongo's wait for the cluster to accept transactions.
+                    ReplicaSetSetupTimeout = TimeSpan.FromSeconds(30),
+                  };
+
+    // Lets CI point at a preinstalled mongod instead of downloading one.
+    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
+    if (!string.IsNullOrEmpty(binDir))
+    {
+      options.BinaryDirectory = binDir;
+    }
+
+    return options;
+  }
+}

--- a/Common/tests/Helpers/TestDatabaseProvider.cs
+++ b/Common/tests/Helpers/TestDatabaseProvider.cs
@@ -66,21 +66,7 @@ public class TestDatabaseProvider : IDisposable
                               bool                           validateGrpcRequests             = false,
                               bool                           useSingleNodeReplicaSet          = false)
   {
-    var logger = NullLogger.Instance;
-    var options = new MongoRunnerOptions
-                  {
-                    UseSingleNodeReplicaSet = useSingleNodeReplicaSet,
-#pragma warning disable CA2254 // log inputs should be constant
-                    StandardOutputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger  = line => logger.LogError(line),
-#pragma warning restore CA2254
-                  };
-
-    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
-    if (!string.IsNullOrEmpty(binDir))
-    {
-      options.BinaryDirectory = binDir;
-    }
+    var options = MongoRunnerOptionsFactory.Create(useSingleNodeReplicaSet);
 
     var loggerProvider = new ConsoleForwardingLoggerProvider();
     var loggerDb       = loggerProvider.CreateLogger("db commands");

--- a/Common/tests/Helpers/TestPollingAgentProvider.cs
+++ b/Common/tests/Helpers/TestPollingAgentProvider.cs
@@ -60,22 +60,8 @@ public class TestPollingAgentProvider : IDisposable
   public TestPollingAgentProvider(IWorkerStreamHandler workerStreamHandler)
   {
     var logger = NullLogger.Instance;
-    var options = new MongoRunnerOptions
-                  {
-                    UseSingleNodeReplicaSet = false,
-#pragma warning disable CA2254 // log inputs should be constant
-                    StandardOutputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger  = line => logger.LogError(line),
-#pragma warning restore CA2254
-                  };
 
-    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
-    if (!string.IsNullOrEmpty(binDir))
-    {
-      options.BinaryDirectory = binDir;
-    }
-
-    runner_ = MongoRunner.Run(options);
+    runner_ = MongoRunner.Run(MongoRunnerOptionsFactory.Create());
     IMongoClient client = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB

--- a/Common/tests/Helpers/TestPollsterProvider.cs
+++ b/Common/tests/Helpers/TestPollsterProvider.cs
@@ -89,23 +89,7 @@ public class TestPollsterProvider : IDisposable
                               IDictionary<string, string>? additionalConfig = null)
   {
     graceDelay_ = graceDelay;
-    var logger = NullLogger.Instance;
-    var options = new MongoRunnerOptions
-                  {
-                    UseSingleNodeReplicaSet = false,
-#pragma warning disable CA2254 // log inputs should be constant
-                    StandardOutputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger  = line => logger.LogError(line),
-#pragma warning restore CA2254
-                  };
-
-    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
-    if (!string.IsNullOrEmpty(binDir))
-    {
-      options.BinaryDirectory = binDir;
-    }
-
-    runner_ = MongoRunner.Run(options);
+    runner_     = MongoRunner.Run(MongoRunnerOptionsFactory.Create());
     var client = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB

--- a/Common/tests/Helpers/TestTaskHandlerProvider.cs
+++ b/Common/tests/Helpers/TestTaskHandlerProvider.cs
@@ -85,22 +85,7 @@ public class TestTaskHandlerProvider : IDisposable
   {
     var logger = NullLogger.Instance;
 
-    var options = new MongoRunnerOptions
-                  {
-                    UseSingleNodeReplicaSet = false,
-#pragma warning disable CA2254 // log inputs should be constant
-                    StandardOutputLogger = line => logger.LogInformation(line),
-                    StandardErrorLogger  = line => logger.LogError(line),
-#pragma warning restore CA2254
-                  };
-
-    var binDir = Environment.GetEnvironmentVariable("EphemeralMongo__BinaryDirectory");
-    if (!string.IsNullOrEmpty(binDir))
-    {
-      options.BinaryDirectory = binDir;
-    }
-
-    runner_ = MongoRunner.Run(options);
+    runner_ = MongoRunner.Run(MongoRunnerOptionsFactory.Create());
     var client = new MongoClient(runner_.ConnectionString);
 
     // Minimal set of configurations to operate on a toy DB


### PR DESCRIPTION
# Motivation

`testsWinOnly (Common/tests)` fails intermittently on the Windows runner, reddening unrelated PRs — it has hit `perf/pg-selector-projection` and several renovate branches. One of the two causes is `WatchToGrpcTests.UseMongoForResultsShouldSucceed`:

```
System.TimeoutException : Replica set initialization command took longer than the specified timeout
of 10 seconds. Consider increasing the value of 'ReplicaSetSetupTimeout'.
   at EphemeralMongo.MongodProcess.ConfigureAndWaitForReplicaSetReadinessAsync(...)
```

`ReplicaSetSetupTimeout` was unset in `Common/tests/Helpers/TestDatabaseProvider.cs`, so EphemeralMongo 3.2.0's **10 s default** applied. Bringing up a single-node replica set means launching mongod, running `rs.initiate` and waiting for the node to reach PRIMARY — and the Windows job installs no mongod, so EphemeralMongo downloads and unpacks one first. That does not reliably fit in 10 s on a loaded runner. Not a product bug.

**The fix already existed and had never propagated.** `Adaptors/MongoDB/tests/MongoDatabaseProvider.cs` has carried `ReplicaSetSetupTimeout = TimeSpan.FromSeconds(30)` since 2023 (commit `0ab246814`, immediately after one titled *"Increase ReplicaSetSetupTimeout"*), and its replica-set tests do not flake. This PR reuses that same 30 s — a value already proven in this CI rather than a guess.

The reason it never spread is the more interesting half: the `MongoRunnerOptions` block was duplicated byte-for-byte across **five** test providers, so a setting added to one was invisible to the other four. Fixing only `TestDatabaseProvider` would have left that trap in place for the next option.

# Description

Adds `Common/tests/Helpers/MongoRunnerOptionsFactory.Create(useSingleNodeReplicaSet, logger)`, which owns everything that should hold for every embedded MongoDB in the test suites:

- `UseSingleNodeReplicaSet` from the caller;
- the `StandardOutputLogger` / `StandardErrorLogger` delegates, left `null` when no logger is supplied;
- `ReplicaSetSetupTimeout = TimeSpan.FromSeconds(30)`, commented with why;
- the `EphemeralMongo__BinaryDirectory` override, the existing convention CI uses to point at a preinstalled mongod (`build.yml`).

All five providers now call it — the four in `Common/tests/Helpers/` plus `Adaptors/MongoDB/tests/MongoDatabaseProvider.cs`, whose project already references `Common/tests`. After the change there is exactly **one** `new MongoRunnerOptions` and **one** `EphemeralMongo__BinaryDirectory` read left in the repo, both inside the factory, so the class of bug that stranded the 2023 timeout is closed.

Net effect is a reduction: 102 insertions against 102 deletions, of which 75 insertions are the new shared file.

Two details worth a reviewer's eye:

**Logger handling is not uniform, deliberately.** The four `Common/tests` providers built their delegates over `NullLogger.Instance`, so they now pass no logger at all — behaviourally identical, since `NullLogger` discards everything. `MongoDatabaseProvider` builds a real Serilog console logger and forwards it only when `showMongoLogs` is set; it now passes `showMongoLogs ? logger : null`, preserving that exactly.

**The `logger` local survives in two providers only.** In `TestDatabaseProvider` and `TestPollsterProvider` it was used solely by the options block and is removed; in `TestTaskHandlerProvider` and `TestPollingAgentProvider` it is also passed to `AddMongoStorages(...)`, so it stays. The build reports no unused-variable warnings, which confirms the split.

**Behaviour change is limited to two tests.** Only four call sites request a replica set: `WatchToGrpcTests.cs:129` and `:176`, plus `ResultWatcherTests.cs:41` and `TaskWatcherTests.cs:41`. The latter two already had the 30 s timeout. The three providers that hardcode `UseSingleNodeReplicaSet = false` never initialise a replica set, so the timeout is inert for them.

# Testing

No new tests: this repairs existing ones and is otherwise behaviour-preserving.

| Suite | Result |
|---|---|
| `Common/tests --filter WatchToGrpcTests` | **5/5** — includes the two replica-set tests, one being the flake |
| `Adaptors/MongoDB/tests` | **329/329** — exercises a replica set through the refactored `MongoDatabaseProvider` |
| Full `Common/tests` | **7192 passed**, 2 failed |

The `Adaptors/MongoDB/tests` run is the meaningful check on the refactor: `MongoDatabaseProvider` was the one provider whose options block differed from the others, and its replica-set tests pass through the new factory unchanged.

The two failures in the full run are `Eviction` and `Eviction2` in an untracked local scratch file (`Common/tests/LolTests.cs`, unknown to git and therefore never compiled in CI). They fail in that file's own `DriveInfo`-based helper with `ArgumentException: Drive name must not be empty`, unrelated to MongoDB options. Everything tracked passes.

Honest limitation: **the flake does not reproduce on demand** — it needs a loaded Windows runner — so these local runs prove "still correct" rather than "fixed". The confidence that 30 s is sufficient comes from `Adaptors/MongoDB/tests` having used exactly that value in this CI since 2023 without flaking.

# Impact

Test-infrastructure only; no product code, no dependencies, no configuration. Nothing ships.

On the three providers with `UseSingleNodeReplicaSet = false` the new timeout is unreachable, so their startup cost is unchanged. On the two `WatchToGrpcTests` cases the timeout is a *ceiling*, not a delay: a replica set that comes up in 3 s still takes 3 s. The only change is that a slow start now succeeds instead of throwing.

# Additional Information

The second diagnosed cause of `testsWinOnly (Common/tests)` flaking is **not** addressed here and was deliberately left out of scope: `PollsterTest.RunThenCancelPollster` has a cancellation race — `TestPollsterProvider.StopApplicationAfter` delays on `ExceptionManager.EarlyCancellationToken`, and `Pollster.MainLoop`'s `finally` cancels that token via `UnregisterAndStop`, so a loop that ends before the 105 µs delay elapses faults the task. It passed in the run above, being load-dependent. Worth knowing that a green run here does not mean that job is now reliable.