### PR TITLE
ci: pin the git-version tool version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,7 @@ jobs:
       id: genver
       uses: codacy/git-version@e81d6fdad74f9e114420d69ca8b47658f1182afb # 2.8.7
       with:
+        tool-version: "2.8.7"
         minor-identifier: "feat:"
         release-branch: release
         dev-branch: main

--- a/.github/workflows/make-release.yml
+++ b/.github/workflows/make-release.yml
@@ -35,6 +35,7 @@ jobs:
       id: snapshot
       uses: codacy/git-version@e81d6fdad74f9e114420d69ca8b47658f1182afb # 2.8.7
       with:
+        tool-version: "2.8.7"
         minor-identifier: "feat:"
         release-branch: ${{ github.ref_name }}-pre
         dev-branch: ${{ steps.rev.outputs.current-branch }}
@@ -43,6 +44,7 @@ jobs:
       id: release
       uses: codacy/git-version@e81d6fdad74f9e114420d69ca8b47658f1182afb # 2.8.7
       with:
+        tool-version: "2.8.7"
         minor-identifier: "feat:"
         release-branch: ${{ steps.rev.outputs.current-branch }}
         dev-branch: main


### PR DESCRIPTION
# Motivation

The `Versionning` job fails intermittently, and because every build and test job declares
`needs: versionning`, one failure skips the entire pipeline. A recent run on an unrelated PR went red
with 25 passed / 2 failed / **14 skipped** from exactly this, six seconds in, before any code was
compiled:

```
Run set -eo pipefail
  download_url="$(curl -Ls https://api.github.com/repos/codacy/git-version/releases/latest | jq -r .assets[0].browser_download_url)"
  ...
##[error]Process completed with exit code 6.
```

`curl` exit 6 is *couldn't resolve host*. Under `set -eo pipefail` that propagates from the pipeline
above — a DNS lookup for `api.github.com`.

# Description

`codacy/git-version` defaults its `tool-version` input to `latest`, and its download step branches on
that value ([`action.yml` at the pinned SHA](https://github.com/codacy/git-version/blob/e81d6fdad74f9e114420d69ca8b47658f1182afb/action.yml)):

```bash
if [ "${{ inputs.tool-version }}" = "latest" ]; then
  download_url="$(curl -Ls https://api.github.com/repos/codacy/git-version/releases/latest | jq -r .assets[0].browser_download_url)"
else
  download_url="https://github.com/codacy/git-version/releases/download/${{ inputs.tool-version }}/git-version"
fi
curl -Ls "$download_url" > /usr/local/bin/git-version
```

So the default costs an extra round trip to a rate-limited API purely to discover a URL. Setting
`tool-version: "2.8.7"` takes the `else` branch and constructs the URL directly, removing that call.

Applied at all three call sites:

- `.github/workflows/build.yml` — the `Versionning` job
- `.github/workflows/make-release.yml` — the `snapshot` and `release` steps

The value matches the action SHA, which was already pinned with a `# 2.8.7` comment, so the tool and
the action no longer drift apart: previously the action was pinned but the binary it fetched was
whatever `latest` happened to be that day.

# Testing

No tests — this is workflow configuration, only observable by running CI. The `Versionning` job on this
PR exercises the changed step in `build.yml` directly; a green run means the pinned URL resolves and
`git-version` still produces a version.

The `make-release.yml` change is **not** exercised by PR CI, since that workflow runs on release. It is
the same one-line addition to the same action at the same pinned SHA, so the risk is that `2.8.7` is
not a downloadable release tag — which the `build.yml` half proves either way.

# Impact

CI only; no product code, no dependencies. Two effects:

- **Reliability.** Removes one of the two network calls in that step, and specifically the one that has
  been failing. Honest scope: the second `curl` to `github.com` for the binary itself remains, so this
  reduces exposure rather than eliminating it. A DNS failure on that one would still break the job.
- **Reproducibility.** The version-computing tool is now deterministic instead of tracking upstream
  `latest`. Worth having on its own: an unpinned tool silently changing behaviour would move computed
  version numbers, which are what CI tags images with.

# Additional Information

Renovate keeps the action SHA current; if it bumps `codacy/git-version` past 2.8.7, this input needs
bumping in step with it, or the action and its tool will disagree. That is the cost of pinning, and it
is preferable to the version moving without anyone noticing.