### PR TITLE
chore: annotate PostgreSQL adapter options for documentation extraction tool

### DIFF
--- a/Adaptors/PostgresSQL/src/Options/PostgreSQL.cs
+++ b/Adaptors/PostgresSQL/src/Options/PostgreSQL.cs
@@ -15,6 +15,8 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+using ArmoniK.Utils.DocAttribute;
+
 using JetBrains.Annotations;
 
 namespace ArmoniK.Core.Adapters.PostgresSQL.Options;
@@ -23,6 +25,7 @@ namespace ArmoniK.Core.Adapters.PostgresSQL.Options;
 ///   Represents the configuration settings for PostgreSQL connection.
 /// </summary>
 [PublicAPI]
+[ExtractDocumentation("Options for PostgreSQL")]
 public class PostgreSQL
 {
   /// <summary>


### PR DESCRIPTION
# Motivation

`ArmoniK.Utils.DocExtractor` generates the environment-variables reference (`.docs/content/envars/`) from `[ExtractDocumentation]` attributes on options classes. Every other adapter's options class already carries this attribute, but `Adaptors/PostgresSQL/src/Options/PostgreSQL` was missed.

# Description

Annotates `PostgreSQL` in `Adaptors/PostgresSQL/src/Options/PostgreSQL.cs`
with `[ExtractDocumentation("Options for PostgreSQL")]`, matching the
convention used by every other adapter's options class, plus the
corresponding `using ArmoniK.Utils.DocAttribute;` import.

# Testing

Ran the doc-extraction tool locally (`tools/generate-envvars-doc.sh`) and
confirmed a "Options for PostgreSQL" section is now produced in the generated
environment-variables reference, alongside the existing sections for the
other adapters.

# Impact

Documentation-only change: no runtime behavior, configuration, or public API
is affected. PostgreSQL connection options will now be included when the
environment-variables reference documentation is regenerated.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
