### PR TITLE
chore: unpin version of extraction tool so the latest is used

### DIFF
--- a/tools/generate-envvars-doc.sh
+++ b/tools/generate-envvars-doc.sh
@@ -5,7 +5,7 @@ set -e
 SOLUTION_FILE=$(realpath "ArmoniK.Core.sln")
 OUTPUT_DIR=.docs/content/envars/
 
-dotnet tool install -g ArmoniK.Utils.DocExtractor --version 0.7.3
+dotnet tool install -g ArmoniK.Utils.DocExtractor
 
 cd $OUTPUT_DIR
 armonik.utils.docextractor -s $SOLUTION_FILE


### PR DESCRIPTION
# Motivation

`tools/generate-envvars-doc.sh` installed `ArmoniK.Utils.DocExtractor` pinned to version `0.7.3`, so newer versions of the tool (with bug fixes or new extraction features) were never picked up unless someone remembered to bump the pin manually.

# Description

Removed the `--version 0.7.3` pin from the `dotnet tool install -g ArmoniK.Utils.DocExtractor` call in `tools/generate-envvars-doc.sh`, so the script always installs the latest published version of the tool.

# Testing

Ran `tools/generate-envvars-doc.sh` to confirm the tool installs successfully without the version pin and generates the environment-variable documentation as before.

# Impact

- No runtime/behavioral changes to ArmoniK.Core itself; affects only the documentation-generation tooling.
- Future runs of the doc-generation script will pick up whatever is the latest `ArmoniK.Utils.DocExtractor` release rather than a pinned version, so generated docs may shift silently when the tool is updated upstream.

# Additional Information

None.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.
