### PR TITLE
fix: Remove the 'a' prefix from the pubsub topic name if prefix is configured

### DIFF
--- a/Adaptors/PubSub/src/PubSubExt.cs
+++ b/Adaptors/PubSub/src/PubSubExt.cs
@@ -1,0 +1,119 @@
+// This file is part of the ArmoniK project
+// 
+// Copyright (C) ANEO, 2021-2026. All rights reserved.
+// 
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published
+// by the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+// 
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY, without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+// 
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+using System.Threading.Tasks;
+
+using Google.Cloud.PubSub.V1;
+using Google.Protobuf.WellKnownTypes;
+
+using Grpc.Core;
+
+namespace ArmoniK.Core.Adapters.PubSub;
+
+internal static class PubSubExt
+{
+  private static string GetTopicNameInternal(this PubSub options,
+                                             string      partition)
+  {
+    var prefix = options.Prefix;
+    if (string.IsNullOrWhiteSpace(prefix))
+    {
+      prefix = "a";
+    }
+
+    return $"{prefix}-{partition}";
+  }
+
+  /// <summary>
+  ///   Get the <see cref="TopicName" /> for the given <paramref name="partition" />.
+  /// </summary>
+  /// <param name="options">PubSub options to configure the topic</param>
+  /// <param name="partition">Partition the topic refers to</param>
+  /// <returns>The topic name in a format understood by GCP</returns>
+  public static TopicName GetTopicName(this PubSub options,
+                                       string      partition)
+    => TopicName.FromProjectTopic(options.ProjectId,
+                                  options.GetTopicNameInternal(partition));
+
+  /// <summary>
+  ///   Get the <see cref="SubscriptionName" /> for the given <paramref name="partition" />.
+  /// </summary>
+  /// <param name="options">PubSub options to configure the subscription</param>
+  /// <param name="partition">Partition the subscription refers to</param>
+  /// <returns>The subscription name in a format understood by GCP</returns>
+  internal static SubscriptionName GetSubscriptionName(this PubSub options,
+                                                       string      partition)
+    => SubscriptionName.FromProjectSubscription(options.ProjectId,
+                                                $"{options.GetTopicNameInternal(partition)}-ak-sub");
+
+  /// <summary>
+  ///   Try to create the topic for the <paramref name="partition" /> if it does not already exist.
+  /// </summary>
+  /// <param name="publisher">The publisher client</param>
+  /// <param name="options">PubSub options to configure the topic</param>
+  /// <param name="partition">Partition the topic refers to</param>
+  public static async ValueTask EnsureTopicIsCreatedAsync(this PublisherServiceApiClient publisher,
+                                                          PubSub                         options,
+                                                          string                         partition)
+  {
+    var topicName = options.GetTopicName(partition);
+    try
+    {
+      await publisher.CreateTopicAsync(new Topic
+                                       {
+                                         MessageRetentionDuration = Duration.FromTimeSpan(options.MessageRetention),
+                                         TopicName                = topicName,
+                                         KmsKeyName               = options.KmsKeyName,
+                                       })
+                     .ConfigureAwait(false);
+    }
+    catch (RpcException ex) when (ex.StatusCode == StatusCode.AlreadyExists)
+    {
+    }
+  }
+
+  /// <summary>
+  ///   Try to create the subscription for the <paramref name="partition" /> if it does not already exist.
+  /// </summary>
+  /// <param name="subscriber">The subscriber client</param>
+  /// <param name="options">PubSub options to configure the subscription</param>
+  /// <param name="partition">Partition the subscription refers to</param>
+  public static async ValueTask EnsureSubscriptionIsCreatedAsync(this SubscriberServiceApiClient subscriber,
+                                                                 PubSub                          options,
+                                                                 string                          partition)
+  {
+    var topicName        = options.GetTopicName(partition);
+    var subscriptionName = options.GetSubscriptionName(partition);
+
+    var subscriptionRequest = new Subscription
+                              {
+                                SubscriptionName          = subscriptionName,
+                                TopicAsTopicName          = topicName,
+                                EnableExactlyOnceDelivery = options.ExactlyOnceDelivery,
+                                EnableMessageOrdering     = options.MessageOrdering,
+                                AckDeadlineSeconds        = options.AckDeadlinePeriod,
+                              };
+    try
+    {
+      await subscriber.CreateSubscriptionAsync(subscriptionRequest)
+                      .ConfigureAwait(false);
+    }
+    catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
+    {
+    }
+  }
+}

--- a/Adaptors/PubSub/src/PullQueueStorage.cs
+++ b/Adaptors/PubSub/src/PullQueueStorage.cs
@@ -25,7 +25,6 @@ using ArmoniK.Core.Base;
 using ArmoniK.Core.Base.DataStructures;
 
 using Google.Cloud.PubSub.V1;
-using Google.Protobuf.WellKnownTypes;
 
 using Grpc.Core;
 
@@ -36,16 +35,8 @@ namespace ArmoniK.Core.Adapters.PubSub;
 
 internal class PullQueueStorage : IPullQueueStorage
 {
-  private readonly int     ackDeadlinePeriod_;
-  private readonly int     ackExtendDeadlineStep_;
-  private readonly bool    exactlyOnceDelivery_;
-  private readonly string  kmsKeyName_;
-  private readonly ILogger logger_;
-  private readonly bool    messageOrdering_;
-
-  private readonly TimeSpan                   messageRetention_;
-  private readonly string                     prefix_;
-  private readonly string                     project_;
+  private readonly ILogger                    logger_;
+  private readonly PubSub                     options_;
   private readonly PublisherServiceApiClient  publisher_;
   private readonly SubscriberServiceApiClient subscriber_;
   private          bool                       isInitialized_;
@@ -55,17 +46,10 @@ internal class PullQueueStorage : IPullQueueStorage
                           PubSub                     options,
                           ILogger<PullQueueStorage>  logger)
   {
-    messageRetention_      = options.MessageRetention;
-    ackDeadlinePeriod_     = options.AckDeadlinePeriod;
-    ackExtendDeadlineStep_ = options.AckExtendDeadlineStep;
-    exactlyOnceDelivery_   = options.ExactlyOnceDelivery;
-    kmsKeyName_            = options.KmsKeyName;
-    messageOrdering_       = options.MessageOrdering;
-    subscriber_            = subscriber;
-    publisher_             = publisher;
-    prefix_                = options.Prefix;
-    project_               = options.ProjectId;
-    logger_                = logger;
+    options_    = options;
+    subscriber_ = subscriber;
+    publisher_  = publisher;
+    logger_     = logger;
   }
 
   public async IAsyncEnumerable<IQueueMessageHandler> PullMessagesAsync(string                                     partitionId,
@@ -77,13 +61,8 @@ internal class PullQueueStorage : IPullQueueStorage
       throw new InvalidOperationException($"{nameof(PullQueueStorage)} should be initialized before calling this method.");
     }
 
-    var topic = $"a{prefix_}-{partitionId}";
-    var sub   = $"a{prefix_}-{partitionId}-ak-sub";
-
-    var topicName = TopicName.FromProjectTopic(project_,
-                                               topic);
-    var subscriptionName = SubscriptionName.FromProjectSubscription(project_,
-                                                                    sub);
+    var          topicName        = options_.GetTopicName(partitionId);
+    var          subscriptionName = options_.GetSubscriptionName(partitionId);
     PullResponse messages;
     try
     {
@@ -94,36 +73,12 @@ internal class PullQueueStorage : IPullQueueStorage
     }
     catch (RpcException ex) when (ex.StatusCode == StatusCode.NotFound)
     {
-      try
-      {
-        await publisher_.CreateTopicAsync(new Topic
-                                          {
-                                            MessageRetentionDuration = Duration.FromTimeSpan(messageRetention_),
-                                            TopicName                = topicName,
-                                            KmsKeyName               = kmsKeyName_,
-                                          })
-                        .ConfigureAwait(false);
-      }
-      catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
-      {
-      }
-
-      var subscriptionRequest = new Subscription
-                                {
-                                  SubscriptionName          = subscriptionName,
-                                  TopicAsTopicName          = topicName,
-                                  EnableExactlyOnceDelivery = exactlyOnceDelivery_,
-                                  EnableMessageOrdering     = messageOrdering_,
-                                  AckDeadlineSeconds        = ackDeadlinePeriod_,
-                                };
-      try
-      {
-        await subscriber_.CreateSubscriptionAsync(subscriptionRequest)
-                         .ConfigureAwait(false);
-      }
-      catch (RpcException e) when (e.StatusCode == StatusCode.AlreadyExists)
-      {
-      }
+      await publisher_.EnsureTopicIsCreatedAsync(options_,
+                                                 partitionId)
+                      .ConfigureAwait(false);
+      await subscriber_.EnsureSubscriptionIsCreatedAsync(options_,
+                                                         partitionId)
+                       .ConfigureAwait(false);
 
       messages = await subscriber_.PullAsync(subscriptionName,
                                              nbMessages,
@@ -137,8 +92,8 @@ internal class PullQueueStorage : IPullQueueStorage
       yield return new QueueMessageHandler(message,
                                            subscriber_,
                                            subscriptionName,
-                                           ackDeadlinePeriod_,
-                                           ackExtendDeadlineStep_,
+                                           options_.AckDeadlinePeriod,
+                                           options_.AckExtendDeadlineStep,
                                            logger_);
     }
   }

--- a/Adaptors/PubSub/src/PushQueueStorage.cs
+++ b/Adaptors/PubSub/src/PushQueueStorage.cs
@@ -26,7 +26,6 @@ using ArmoniK.Core.Base.DataStructures;
 
 using Google.Cloud.PubSub.V1;
 using Google.Protobuf;
-using Google.Protobuf.WellKnownTypes;
 
 using Grpc.Core;
 
@@ -58,12 +57,9 @@ internal class PushQueueStorage : IPushQueueStorage
       throw new InvalidOperationException($"{nameof(PushQueueStorage)} should be initialized before calling this method.");
     }
 
-    var topic = $"a{options_.Prefix}-{partitionId}";
-    var topicName = TopicName.FromProjectTopic(options_.ProjectId,
-                                               topic);
     foreach (var chunks in messages.Chunk(500))
     {
-      await Publish(topicName,
+      await Publish(partitionId,
                     chunks)
         .ConfigureAwait(false);
     }
@@ -88,9 +84,10 @@ internal class PushQueueStorage : IPushQueueStorage
     => int.MaxValue;
 
 
-  private async Task Publish(TopicName                topicName,
+  private async Task Publish(string                   partitionId,
                              ICollection<MessageData> messages)
   {
+    var topicName = options_.GetTopicName(partitionId);
     try
     {
       await publisher_.PublishAsync(topicName,
@@ -102,19 +99,9 @@ internal class PushQueueStorage : IPushQueueStorage
     }
     catch (RpcException e) when (e.StatusCode == StatusCode.NotFound)
     {
-      try
-      {
-        await publisher_.CreateTopicAsync(new Topic
-                                          {
-                                            MessageRetentionDuration = Duration.FromTimeSpan(options_.MessageRetention),
-                                            TopicName                = topicName,
-                                            KmsKeyName               = options_.KmsKeyName,
-                                          })
-                        .ConfigureAwait(false);
-      }
-      catch (RpcException ex) when (ex.StatusCode == StatusCode.AlreadyExists)
-      {
-      }
+      await publisher_.EnsureTopicIsCreatedAsync(options_,
+                                                 partitionId)
+                      .ConfigureAwait(false);
 
       await publisher_.PublishAsync(topicName,
                                     messages.Select(msg => new PubsubMessage


### PR DESCRIPTION
# Motivation

Some customers have constraints on the naming convention for topics and subscriptions, and the added `a` at the beginning of the topic/subscription name breaks.

# Description

Avoid adding an `a` at the beginning of the name if prefix is not empty.
Add a helper class to avoid duplicating the prefix and topic creation logic.

# Testing

CI is green.

# Impact

If prefix is not set, the computed names do not change, and so there is no impact in that case.
If prefix is set, the topic and subscription names change (`a` is removed) and so prefix must be reconfigured to explicitly include the `a`. If the prefix is not reconfigured, new topics and subscriptions will be created, and the tasks queued in the old subscriptions won't be dequeued.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
