### PR TITLE
perf(terraform): disable Redis RDB snapshots

### DIFF
--- a/terraform/modules/storage/object/redis/main.tf
+++ b/terraform/modules/storage/object/redis/main.tf
@@ -16,6 +16,8 @@ locals {
     tls-key-file /redis/certs/redis.key
     tls-ca-cert-file /redis/certs/ca.pem
     tls-auth-clients no
+    save ""
+    appendonly no
     EOT
 }
 resource "docker_container" "object" {


### PR DESCRIPTION
# Motivation

Redis is a volatile object store for ArmoniK, and the Terraform module mounts no volume, so `/data`
is container-local and dies with the container. The stock snapshot policy
(`save 3600 1 300 100 60 10000`) therefore forks and writes RDB dumps to a filesystem that is thrown
away on every `terraform apply`: cost with no benefit.

# Description

Add `save ""` (clears the snapshot schedule) and `appendonly no` (already the default, stated
explicitly) to `local.linux_redis_conf` in `terraform/modules/storage/object/redis/main.tf`. That
heredoc is uploaded to `/etc/redis/redis.conf`, which is the only config the container starts with
(`redis-server /etc/redis/redis.conf`).

# Testing

Deployed locally with `just object=redis build-deploy` (Redis 7.0.11 from `redis:bullseye`).

On the live server, `CONFIG GET save` returns empty and `CONFIG GET appendonly` returns `no`;
`INFO persistence` shows `aof_enabled:0` and `rdb_bgsave_in_progress:0`, and `/data` contains no
`dump.rdb` even after 1760 dirty keys accumulated. For comparison, the same image with these two
lines removed reports `save 3600 1 300 100 60 10000`.

No regression on the workloads:

- `just runHtcmock` (100 tasks, 4 levels): result matches expected, 139 tasks at 17.3 task/s.
- `just worker=bench build-deploy && just bench_payload_size=1000 bench_result_size=1000 runBench`:
  100/100 completed, 0 errors, 0 cancelled, object storage health `Healthy`.

# Impact

Less I/O and lower peak memory on the Redis container, and no fork pauses. Durability is unchanged
for the normal deploy path, since the container filesystem was already non-durable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.
